### PR TITLE
feat: レス内のリンクをアプリ内WebViewで表示

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/common/InAppWebView.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/common/InAppWebView.kt
@@ -1,0 +1,83 @@
+package com.websarva.wings.android.bbsviewer.ui.common
+
+import android.graphics.Bitmap
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack // Use auto-mirrored icon
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.viewinterop.AndroidView
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun InAppWebViewScreen(
+    url: String,
+    onDismiss: () -> Unit
+) {
+    var webViewTitle by remember { mutableStateOf("Loading...") }
+    val context = LocalContext.current
+    // var webView: WebView? = null // Not strictly needed to be stored if only used in factory
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(webViewTitle, maxLines = 1) },
+                navigationIcon = {
+                    IconButton(onClick = onDismiss) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        }
+    ) { paddingValues ->
+        Column(modifier = Modifier.padding(paddingValues)) {
+            AndroidView(
+                modifier = Modifier.fillMaxSize(),
+                factory = {
+                    WebView(context).apply {
+                        webViewClient = object : WebViewClient() {
+                            override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
+                                super.onPageStarted(view, url, favicon)
+                                webViewTitle = "Loading..."
+                            }
+
+                            override fun onPageFinished(view: WebView?, url: String?) {
+                                super.onPageFinished(view, url)
+                                webViewTitle = view?.title ?: "Web Page"
+                            }
+
+                            // It's good practice to override shouldOverrideUrlLoading for security and control
+                            override fun shouldOverrideUrlLoading(view: WebView?, url: String?): Boolean {
+                                url?.let { view?.loadUrl(it) }
+                                return true // Indicates that the WebView handles the URL loading
+                            }
+                        }
+                        settings.javaScriptEnabled = true
+                        // Add other settings as needed, e.g.:
+                        // settings.domStorageEnabled = true
+                        // settings.useWideViewPort = true
+                        // settings.loadWithOverviewMode = true
+                        // settings.setSupportZoom(true)
+                        // settings.builtInZoomControls = true
+                        // settings.displayZoomControls = false
+                        loadUrl(url)
+                        // webView = this // Assign if needed for external control via update block
+                    }
+                },
+                update = { webView ->
+                    // This block is called when the composable is recomposed.
+                    // If the URL could change dynamically AND you want to reload,
+                    // you might need to do: if (webView.url != url) webView.loadUrl(url)
+                    // However, for this specific use case where InAppWebViewScreen is recreated
+                    // or url is a stable input for its lifetime, direct load in factory is often enough.
+                }
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/ThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/ThreadScreen.kt
@@ -3,6 +3,7 @@ package com.websarva.wings.android.bbsviewer.ui.thread
 import android.webkit.WebView
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -27,7 +28,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -39,32 +40,60 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.window.Dialog
 import com.websarva.wings.android.bbsviewer.R
 import com.websarva.wings.android.bbsviewer.data.model.ThreadInfo
+import androidx.compose.foundation.text.ClickableText
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextDecoration
+import java.util.regex.Pattern
+import androidx.compose.ui.graphics.Color
+import com.websarva.wings.android.bbsviewer.ui.common.InAppWebViewScreen // Import the InAppWebViewScreen
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.collectAsState
 
 @Composable
 fun ThreadScreen(
     modifier: Modifier = Modifier,
-    posts: List<ReplyInfo>,
-    listState: LazyListState = rememberLazyListState()
+    // posts: List<ReplyInfo>, // This will come from uiState
+    listState: LazyListState = rememberLazyListState(),
+    viewModel: ThreadViewModel = hiltViewModel()
 ) {
-    LazyColumn(
-        modifier = modifier
-            .fillMaxSize(),
-        state = listState,
-    ) {
-        // リスト全体の先頭に区切り線を追加
-        if (posts.isNotEmpty()) { // リストが空でない場合のみ線を表示
-            item {
+    val uiState by viewModel.uiState.collectAsState()
+    // Remove local state:
+    // var showInAppWebView by remember { mutableStateOf(false) }
+    // var webViewUrl by remember { mutableStateOf<String?>(null) }
+
+    Box(modifier = modifier.fillMaxSize()) {
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            state = listState,
+        ) {
+            // リスト全体の先頭に区切り線を追加
+            if (uiState.posts?.isNotEmpty() == true) { // Use uiState.posts
+                item {
+                    HorizontalDivider()
+                }
+            }
+
+            itemsIndexed(uiState.posts ?: emptyList()) { index, post -> // Use uiState.posts
+                PostItem(
+                    post = post,
+                    postNum = index + 1,
+                    onUrlClick = { url ->
+                        viewModel.openInAppWebView(url) // Call ViewModel function
+                    }
+                )
+                // 各アイテムの下に区切り線を表示
                 HorizontalDivider()
             }
         }
 
-        itemsIndexed(posts) { index, post ->
-            PostItem(
-                post = post,
-                postNum = index + 1
+        if (uiState.showInAppWebView && uiState.webViewUrl != null) {
+            InAppWebViewScreen(
+                url = uiState.webViewUrl!!,
+                onDismiss = { viewModel.closeInAppWebView() } // Call ViewModel function
             )
-            // 各アイテムの下に区切り線を表示
-            HorizontalDivider()
         }
     }
 }
@@ -73,12 +102,14 @@ fun ThreadScreen(
 fun PostItem(
     modifier: Modifier = Modifier,
     post: ReplyInfo,
-    postNum: Int
+    postNum: Int,
+    onUrlClick: (String) -> Unit // Callback to handle URL click
 ) {
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .clickable(onClick = { /* クリック処理が必要な場合はここに実装 */ })
+            // Consider removing this top-level clickable if it interferes with ClickableText
+            // .clickable(onClick = { /* クリック処理が必要な場合はここに実装 */ })
             .padding(horizontal = 16.dp, vertical = 8.dp),
     ) {
         Row {
@@ -95,8 +126,47 @@ fun PostItem(
             )
         }
 
-        Text(
-            text = post.content,
+        val annotatedString = buildAnnotatedString {
+            append(post.content)
+            // Regex to find URLs
+            val urlPattern = Pattern.compile(
+                "(?:^|[\\W])((ht|f)tp(s?):\\/\\/|www\\.)"
+                        + "(([\\w\\-]+\\.){1,}?([\\w\\-.~]+\\/?)*"
+                        + "[\\p{Alnum}.,%_=?&#\\-+()\\[\\]\\*$~@!:/{};']*)",
+                Pattern.CASE_INSENSITIVE or Pattern.MULTILINE or Pattern.DOTALL
+            )
+            val matcher = urlPattern.matcher(post.content)
+            while (matcher.find()) {
+                val start = matcher.start(1)
+                val end = matcher.end()
+                val url = post.content.substring(start, end)
+                addStyle(
+                    style = SpanStyle(
+                        color = Color.Blue, // Or MaterialTheme.colorScheme.primary
+                        textDecoration = TextDecoration.Underline
+                    ),
+                    start = start,
+                    end = end
+                )
+                addStringAnnotation(
+                    tag = "URL",
+                    annotation = url,
+                    start = start,
+                    end = end
+                )
+            }
+        }
+
+        // val uriHandler = LocalUriHandler.current // Not needed here anymore
+        ClickableText(
+            text = annotatedString,
+            style = MaterialTheme.typography.bodyMedium.copy(color = MaterialTheme.colorScheme.onSurface),
+            onClick = { offset ->
+                annotatedString.getStringAnnotations(tag = "URL", start = offset, end = offset)
+                    .firstOrNull()?.let { annotation ->
+                        onUrlClick(annotation.item) // Call the callback
+                    }
+            }
         )
     }
 
@@ -318,9 +388,10 @@ fun ReplyCardPreview() {
             email = "sage",
             date = "1/21(月) 15:43:45.34",
             id = "testnanjj",
-            content = "ガチで終わった模様"
+            content = "ガチで終わった模様 http://example.com" // Added a URL for preview
         ),
-        postNum = 1
+        postNum = 1,
+        onUrlClick = {} // Dummy lambda for preview
     )
 }
 

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/ThreadUiState.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/ThreadUiState.kt
@@ -23,7 +23,11 @@ data class ThreadUiState(
     val showThreadGroupSelector: Boolean = false,
     val showAddGroupDialog: Boolean = false,
     val enteredNewGroupName: String = "",
-    val selectedColorForNewGroup: String? = "#FF0000" // デフォルト色など適当に設定
+    val selectedColorForNewGroup: String? = "#FF0000", // デフォルト色など適当に設定
+
+    // WebView State
+    val webViewUrl: String? = null,
+    val showInAppWebView: Boolean = false
 )
 
 data class ReplyInfo(

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/ThreadViewModel.kt
@@ -325,4 +325,16 @@ class ThreadViewModel @Inject constructor(
             _uiState.update { it.copy(isLoading = false) }
         }
     }
+
+    fun openInAppWebView(url: String) {
+        _uiState.update {
+            it.copy(webViewUrl = url, showInAppWebView = true)
+        }
+    }
+
+    fun closeInAppWebView() {
+        _uiState.update {
+            it.copy(showInAppWebView = false, webViewUrl = null) // Clear URL on close
+        }
+    }
 }


### PR DESCRIPTION
レス本文に含まれるURLをタップすることで、そのリンク先をアプリ内WebViewで開く機能を追加しました。

主な変更点:
- TextViewの代わりにClickableTextを使用してURLを検出し、タップ可能にしました。
- URLタップ時に表示されるアプリ内WebView用のComposable関数 (InAppWebViewScreen) を作成しました。
- WebViewの状態 (表示/非表示、表示するURL) はThreadViewModelとThreadUiStateで管理するようにリファクタリングしました。