### PR TITLE
Enable external URL opening

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/ThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/ThreadScreen.kt
@@ -28,6 +28,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.foundation.text.ClickableText
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -39,6 +41,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.window.Dialog
 import com.websarva.wings.android.bbsviewer.R
 import com.websarva.wings.android.bbsviewer.data.model.ThreadInfo
+import com.websarva.wings.android.bbsviewer.ui.util.buildUrlAnnotatedString
 
 @Composable
 fun ThreadScreen(
@@ -95,8 +98,17 @@ fun PostItem(
             )
         }
 
-        Text(
-            text = post.content,
+        val uriHandler = LocalUriHandler.current
+        val annotatedText = buildUrlAnnotatedString(post.content)
+        ClickableText(
+            text = annotatedText,
+            style = MaterialTheme.typography.bodyMedium,
+            onClick = { offset ->
+                annotatedText.getStringAnnotations("URL", offset, offset)
+                    .firstOrNull()?.let { annotation ->
+                        uriHandler.openUri(annotation.item)
+                    }
+            }
         )
     }
 

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/util/LinkUtils.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/util/LinkUtils.kt
@@ -1,0 +1,36 @@
+package com.websarva.wings.android.bbsviewer.ui.util
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextDecoration
+import java.util.regex.Pattern
+
+private val urlRegex: Pattern = Pattern.compile("(https?://[\\w\\-._~:/?#[\\]@!$&'()*+,;=%]+)")
+
+/**
+ * 入力されたテキストから URL を検出し、クリック可能な AnnotatedString を生成します。
+ */
+fun buildUrlAnnotatedString(text: String): AnnotatedString {
+    val builder = AnnotatedString.Builder()
+    var lastIndex = 0
+    val matcher = urlRegex.matcher(text)
+    while (matcher.find()) {
+        val start = matcher.start()
+        val end = matcher.end()
+        val url = matcher.group()
+        if (start > lastIndex) {
+            builder.append(text.substring(lastIndex, start))
+        }
+        builder.pushStringAnnotation(tag = "URL", annotation = url)
+        builder.pushStyle(SpanStyle(textDecoration = TextDecoration.Underline))
+        builder.append(url)
+        builder.pop() // style
+        builder.pop() // annotation
+        lastIndex = end
+    }
+    if (lastIndex < text.length) {
+        builder.append(text.substring(lastIndex))
+    }
+    return builder.toAnnotatedString()
+}


### PR DESCRIPTION
## Summary
- detect URLs in post messages and convert them to clickable links
- allow clicking these links to open in an external application

## Testing
- `sh gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6841c401e1f08332b934bf593b984f3a