### PR TITLE
Implement differential DAT fetching

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/util/DataUsageTracker.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/util/DataUsageTracker.kt
@@ -1,0 +1,11 @@
+package com.websarva.wings.android.bbsviewer.data.util
+
+object DataUsageTracker {
+    @Volatile
+    var datBytes: Long = 0
+        private set
+
+    fun addBytes(size: Long) {
+        datBytes += size
+    }
+}


### PR DESCRIPTION
## Summary
- add `DataUsageTracker` to measure downloaded dat bytes
- support Range requests and conditional headers in `DatRemoteDataSourceImpl`

## Testing
- `./gradlew resolveAllDependencies`
- `./gradlew test` *(fails: `Execution failed for task ':app:compileReleaseKotlin'`)*

------
https://chatgpt.com/codex/tasks/task_e_6843aa70de008332891ee4abc893be99