### PR TITLE
Add tabs screen and navigation

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/bottombar/BottomBarScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/bottombar/BottomBarScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.OpenInBrowser
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -51,6 +52,12 @@ fun HomeBottomNavigationBar(
             name = stringResource(R.string.boardList),
             icon = Icons.AutoMirrored.Filled.List,
             parentRoute = AppRoute.BbsServiceGroup
+        ),
+        TopLevelRoute(
+            route = AppRoute.Tabs,
+            name = stringResource(R.string.tabs),
+            icon = Icons.Default.Menu,
+            parentRoute = AppRoute.Tabs
         ),
         TopLevelRoute(
             route = AppRoute.Settings,

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/AppNavGraph.kt
@@ -59,6 +59,11 @@ fun AppNavGraph(
             tabsViewModel = tabsViewModel,
             openDrawer = openDrawer,
         )
+        //タブ画面
+        addTabsRoute(
+            navController = navController,
+            tabsViewModel = tabsViewModel
+        )
         //設定画面
         addSettingsRoute(
             viewModel = settingsViewModel,
@@ -104,6 +109,9 @@ sealed class AppRoute {
     @Serializable
     data object Settings : AppRoute()
 
+    @Serializable
+    data object Tabs : AppRoute()
+
     data object RouteName {
         const val BOOKMARK = "Bookmark"
         const val BBS_SERVICE_GROUP = "BbsServiceGroup"
@@ -113,5 +121,6 @@ sealed class AppRoute {
         const val BOARD = "Board"
         const val THREAD = "Thread"
         const val SETTINGS = "Settings"
+        const val TABS = "Tabs"
     }
 }

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/TabsRoute.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/TabsRoute.kt
@@ -1,0 +1,19 @@
+package com.websarva.wings.android.bbsviewer.ui.navigation
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import com.websarva.wings.android.bbsviewer.ui.drawer.TabsViewModel
+import com.websarva.wings.android.bbsviewer.ui.tabs.TabsScreen
+
+fun NavGraphBuilder.addTabsRoute(
+    navController: NavHostController,
+    tabsViewModel: TabsViewModel
+) {
+    composable<AppRoute.Tabs> {
+        TabsScreen(
+            tabsViewModel = tabsViewModel,
+            navController = navController
+        )
+    }
+}

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/tabs/TabsScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/tabs/TabsScreen.kt
@@ -1,0 +1,39 @@
+package com.websarva.wings.android.bbsviewer.ui.tabs
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.navigation.NavHostController
+import com.websarva.wings.android.bbsviewer.R
+import com.websarva.wings.android.bbsviewer.ui.drawer.OpenThreadsList
+import com.websarva.wings.android.bbsviewer.ui.drawer.TabsViewModel
+import com.websarva.wings.android.bbsviewer.ui.topbar.HomeTopAppBarScreen
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TabsScreen(
+    modifier: Modifier = Modifier,
+    tabsViewModel: TabsViewModel,
+    navController: NavHostController
+) {
+    val openTabs by tabsViewModel.openTabs.collectAsState()
+
+    Scaffold(
+        topBar = {
+            HomeTopAppBarScreen(
+                title = stringResource(R.string.tabs)
+            )
+        }
+    ) { innerPadding ->
+        OpenThreadsList(
+            openTabs = openTabs,
+            tabsViewModel = tabsViewModel,
+            navController = navController,
+            closeDrawer = {},
+        )
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,6 +14,7 @@
     <string name="e_mail">E-mail</string>
     <string name="post_message">本文</string>
     <string name="open_tablist">タブ一覧を開く</string>
+    <string name="tabs">タブ</string>
     <string name="edit">編集</string>
     <string name="cancel">キャンセル</string>
     <string name="complete">完了</string>


### PR DESCRIPTION
## Summary
- add `TabsScreen` to show open threads
- create `TabsRoute` and integrate into navigation graph
- add tab item to bottom navigation
- add translations for tab label

## Testing
- `./gradlew test --daemon`

------
https://chatgpt.com/codex/tasks/task_e_6842f6bee324833299f7d05f897d8886