### PR TITLE
お気に入り選択時のタブ切り替え無効化

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/bookmark/BookmarkScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/bookmark/BookmarkScreen.kt
@@ -70,8 +70,11 @@ fun BookmarkScreen(
                     Tab(
                         text = { Text(text) },
                         selected = pagerState.currentPage == index,
+                        enabled = !selectMode,
                         onClick = {
-                            scope.launch { pagerState.animateScrollToPage(index) }
+                            if (!selectMode) {
+                                scope.launch { pagerState.animateScrollToPage(index) }
+                            }
                         }
                     )
                 }
@@ -80,7 +83,8 @@ fun BookmarkScreen(
         // ページ本体
         HorizontalPager(
             state = pagerState,
-            modifier = Modifier.weight(1f)
+            modifier = Modifier.weight(1f),
+            userScrollEnabled = !selectMode
         ) { page ->
             val screenModifier = Modifier
                 .fillMaxSize()


### PR DESCRIPTION
## Summary
- お気に入り画面の選択モード時にタブのクリックを無効化
- HorizontalPagerのスワイプ操作も無効化

## Testing
- `sh gradlew test --console=plain` *(失敗: 環境依存のためビルドエラー)*

------
https://chatgpt.com/codex/tasks/task_e_684453d23cd483328bd9f27f2dbbaeff