### PR TITLE
Show board name and res count in tabs

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/AppScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/AppScaffold.kt
@@ -81,7 +81,6 @@ fun AppScaffold(
         AppNavGraph(
             navController = navController,
             scrollBehavior = scrollBehavior,
-            bookmarkViewModel = bookmarkViewModel,
             settingsViewModel = settingsViewModel,
             openDrawer = openDrawer,
             tabsViewModel = tabsViewModel

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/AppNavGraph.kt
@@ -105,7 +105,8 @@ sealed class AppRoute {
         val boardUrl: String,      // 必須：板URL（datUrl導出、投稿情報のため）
         val boardName: String,     // 推奨：表示用
         val boardId: Long,         // 推奨：将来的な機能（板情報連携）のため
-        val threadTitle: String    // 推奨：UX向上（即時タイトル表示）のため
+        val threadTitle: String,   // 推奨：UX向上（即時タイトル表示）のため
+        val resCount: Int = 0      // 表示用: レス数
     ) : AppRoute()
 
     @Serializable

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/BoardRoute.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/BoardRoute.kt
@@ -118,7 +118,8 @@ fun NavGraphBuilder.addBoardRoute(
                             boardName = board.boardName,
                             boardUrl = board.boardUrl,
                             boardId = board.boardId,
-                            threadTitle = threadInfo.title
+                            threadTitle = threadInfo.title,
+                            resCount = threadInfo.resCount
                         )
                     ) {
                         launchSingleTop = true

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/BookmarkRoute.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/BookmarkRoute.kt
@@ -86,7 +86,8 @@ fun NavGraphBuilder.addBookmarkRoute(
                             boardName = thread.boardName,
                             boardUrl = thread.boardUrl,
                             threadTitle = thread.title,
-                            boardId = thread.boardId
+                            boardId = thread.boardId,
+                            resCount = thread.resCount
                         )
                     ) {
                         launchSingleTop = true

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/ThreadRoute.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/ThreadRoute.kt
@@ -69,6 +69,7 @@ fun NavGraphBuilder.addThreadRoute(
                     boardName = threadRoute.boardName,
                     boardUrl = threadRoute.boardUrl,
                     boardId = threadRoute.boardId,
+                    resCount = threadRoute.resCount
                 )
             )
         }

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/tabs/OpenThreadsList.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/tabs/OpenThreadsList.kt
@@ -43,6 +43,7 @@ fun OpenThreadsList(
             items(openTabs, key = { it.key + it.boardUrl }) { tab ->
                 ListItem(
                     headlineContent = { Text(tab.title, maxLines = 1) },
+                    supportingContent = { Text("${tab.boardName} ${tab.resCount}") },
                     trailingContent = {
                         IconButton(onClick = { onCloseClick(tab) }) {
                             Icon(
@@ -59,7 +60,8 @@ fun OpenThreadsList(
                                 boardUrl = tab.boardUrl,
                                 boardName = tab.boardName,
                                 boardId = tab.boardId,
-                                threadTitle = tab.title
+                                threadTitle = tab.title,
+                                resCount = tab.resCount
                             )
                         ) {
                             launchSingleTop = true
@@ -77,9 +79,9 @@ fun OpenThreadsList(
 @Composable
 fun OpenThreadsListPreview() {
     val sampleTabs = listOf(
-        TabInfo("1", "スレッド1", "板1", "https://example.com/board1", 1),
-        TabInfo("2", "スレッド2", "板2", "https://example.com/board2", 2),
-        TabInfo("3", "スレッド3", "板3", "https://example.com/board3", 3)
+        TabInfo("1", "スレッド1", "板1", "https://example.com/board1", 1, 100),
+        TabInfo("2", "スレッド2", "板2", "https://example.com/board2", 2, 200),
+        TabInfo("3", "スレッド3", "板3", "https://example.com/board3", 3, 300)
     )
     OpenThreadsList(
         openTabs = sampleTabs,

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/tabs/TabInfo.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/tabs/TabInfo.kt
@@ -6,6 +6,7 @@ data class TabInfo(
     val boardName: String,
     val boardUrl: String,
     val boardId: Long,
+    val resCount: Int = 0,
     val firstVisibleItemIndex: Int = 0, // スクロール位置（インデックス）
     val firstVisibleItemScrollOffset: Int = 0 // スクロール位置（オフセット）
 )

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/tabs/TabsViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/tabs/TabsViewModel.kt
@@ -36,9 +36,14 @@ class TabsViewModel @Inject constructor(
                 currentTabs.indexOfFirst { it.key == newTabInfo.key && it.boardUrl == newTabInfo.boardUrl }
 
             if (tabIndex != -1) {
-                // 既存タブのタイトルのみを更新し、スクロール位置はそのまま維持する
+                // 既存タブの情報を更新し、スクロール位置はそのまま維持する
                 currentTabs.toMutableList().apply {
-                    this[tabIndex] = this[tabIndex].copy(title = newTabInfo.title)
+                    this[tabIndex] = this[tabIndex].copy(
+                        title = newTabInfo.title,
+                        boardName = newTabInfo.boardName,
+                        boardId = newTabInfo.boardId,
+                        resCount = newTabInfo.resCount
+                    )
                 }
             } else {
                 // 新規タブとして追加


### PR DESCRIPTION
## Summary
- add `resCount` to `TabInfo`
- display board name and res count in the open threads list
- update navigation to pass the count
- clean up unused bookmark parameter in `AppNavGraph` call

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68582bde31608332a37cbf47cde1504f