### PR TITLE
Unify favorite naming to bookmark

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/di/DatabaseCallback.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/di/DatabaseCallback.kt
@@ -48,17 +48,17 @@ class DatabaseCallback @Inject constructor(
         bbsServiceRepositoryProvider.get().addOrUpdateService("https://menu.5ch.net/bbsmenu.html")
 
         // 文字列リソースから「お気に入り」を取得
-        val favoriteGroupName = context.getString(R.string.bookmark) // ← Context を使って文字列を取得
+        val bookmarkGroupName = context.getString(R.string.bookmark) // ← Context を使って文字列を取得
 
         // デフォルトのお気に入りグループを登録
         bookmarkBoardRepositoryProvider.get().addGroupAtEnd(
-            name = favoriteGroupName, // ← 取得した文字列を使用
+            name = bookmarkGroupName, // ← 取得した文字列を使用
             colorHex = "#FFFF00" // 黄色のHEXコード
         )
 
-        val threadFavoriteGroupName = context.getString(R.string.bookmark)
+        val threadBookmarkGroupName = context.getString(R.string.bookmark)
         bookmarkThreadRepositoryProvider.get().addGroupAtEnd(
-            name = threadFavoriteGroupName,
+            name = threadBookmarkGroupName,
             colorHex = "#FFFF00"
         )
     }

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardUiState.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardUiState.kt
@@ -4,12 +4,12 @@ import com.websarva.wings.android.bbsviewer.data.datasource.local.entity.BoardBo
 import com.websarva.wings.android.bbsviewer.data.model.BoardInfo
 import com.websarva.wings.android.bbsviewer.data.model.ThreadInfo
 import com.websarva.wings.android.bbsviewer.ui.common.BaseUiState
-import com.websarva.wings.android.bbsviewer.ui.favorite.FavoriteUiState
+import com.websarva.wings.android.bbsviewer.ui.bookmark.BookmarkState
 
 data class BoardUiState(
     val threads: List<ThreadInfo>? = null,
     val boardInfo: BoardInfo = BoardInfo(0, "", ""),
-    val favoriteState: FavoriteUiState = FavoriteUiState(),
+    val bookmarkState: BookmarkState = BookmarkState(),
     val showSortSheet: Boolean = false,
     val serviceName: String = "",
     val showInfoDialog: Boolean = false,

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardViewModel.kt
@@ -8,8 +8,8 @@ import com.websarva.wings.android.bbsviewer.data.model.BoardInfo
 import com.websarva.wings.android.bbsviewer.data.model.ThreadInfo
 import com.websarva.wings.android.bbsviewer.data.repository.BoardRepository
 import com.websarva.wings.android.bbsviewer.ui.common.BaseViewModel
-import com.websarva.wings.android.bbsviewer.ui.favorite.FavoriteViewModel
-import com.websarva.wings.android.bbsviewer.ui.favorite.FavoriteViewModelFactory
+import com.websarva.wings.android.bbsviewer.ui.bookmark.BookmarkStateViewModel
+import com.websarva.wings.android.bbsviewer.ui.bookmark.BookmarkStateViewModelFactory
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -20,7 +20,7 @@ import kotlinx.coroutines.launch
 @RequiresApi(Build.VERSION_CODES.O)
 class BoardViewModel @AssistedInject constructor(
     private val repository: BoardRepository,
-    private val favoriteViewModelFactory: FavoriteViewModelFactory,
+    private val bookmarkStateViewModelFactory: BookmarkStateViewModelFactory,
     @Assisted("viewModelKey") val viewModelKey: String
 ) : BaseViewModel<BoardUiState>() {
 
@@ -30,7 +30,7 @@ class BoardViewModel @AssistedInject constructor(
     private var originalThreads: List<ThreadInfo>? = null
 
     override val _uiState = MutableStateFlow(BoardUiState())
-    private var favoriteViewModel: FavoriteViewModel? = null
+    private var bookmarkStateViewModel: BookmarkStateViewModel? = null
 
     private var isInitialBoardLoad = true // このViewModelインスタンスでの初回読み込みフラグ
 
@@ -38,32 +38,32 @@ class BoardViewModel @AssistedInject constructor(
         if (isInitialized) return
         isInitialized = true
 
-        // Factoryを使ってFavoriteViewModelを生成
-        favoriteViewModel = favoriteViewModelFactory.create(boardInfo, null)
+        // Factoryを使ってBookmarkStateViewModelを生成
+        bookmarkStateViewModel = bookmarkStateViewModelFactory.create(boardInfo, null)
 
         val serviceName = parseServiceName(boardInfo.url)
         _uiState.update { it.copy(boardInfo = boardInfo, serviceName = serviceName) }
 
-        // FavoriteViewModelのUI状態を監視し、自身のUI状態にマージする
+        // BookmarkStateViewModelのUI状態を監視し、自身のUI状態にマージする
         viewModelScope.launch {
-            favoriteViewModel?.uiState?.collect { favState ->
-                _uiState.update { it.copy(favoriteState = favState) }
+            bookmarkStateViewModel?.uiState?.collect { favState ->
+                _uiState.update { it.copy(bookmarkState = favState) }
             }
         }
 
         loadThreadList(force = true)
     }
 
-    // --- お気に入り関連の処理はFavoriteViewModelに委譲 ---
-    fun saveBookmark(groupId: Long) = favoriteViewModel?.saveBookmark(groupId)
-    fun unbookmarkBoard() = favoriteViewModel?.unbookmark()
-    fun openAddGroupDialog() = favoriteViewModel?.openAddGroupDialog()
-    fun closeAddGroupDialog() = favoriteViewModel?.closeAddGroupDialog()
-    fun setEnteredGroupName(name: String) = favoriteViewModel?.setEnteredGroupName(name)
-    fun setSelectedColor(color: String) = favoriteViewModel?.setSelectedColor(color)
-    fun addGroup() = favoriteViewModel?.addGroup()
-    fun openBookmarkSheet() = favoriteViewModel?.openBookmarkSheet()
-    fun closeBookmarkSheet() = favoriteViewModel?.closeBookmarkSheet()
+    // --- お気に入り関連の処理はBookmarkStateViewModelに委譲 ---
+    fun saveBookmark(groupId: Long) = bookmarkStateViewModel?.saveBookmark(groupId)
+    fun unbookmarkBoard() = bookmarkStateViewModel?.unbookmark()
+    fun openAddGroupDialog() = bookmarkStateViewModel?.openAddGroupDialog()
+    fun closeAddGroupDialog() = bookmarkStateViewModel?.closeAddGroupDialog()
+    fun setEnteredGroupName(name: String) = bookmarkStateViewModel?.setEnteredGroupName(name)
+    fun setSelectedColor(color: String) = bookmarkStateViewModel?.setSelectedColor(color)
+    fun addGroup() = bookmarkStateViewModel?.addGroup()
+    fun openBookmarkSheet() = bookmarkStateViewModel?.openBookmarkSheet()
+    fun closeBookmarkSheet() = bookmarkStateViewModel?.closeBookmarkSheet()
 
     fun loadThreadList(force: Boolean = false) { // pull-to-refreshからは force=false で呼ばれる想定
         val boardUrl = uiState.value.boardInfo.url

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/bookmark/BookmarkState.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/bookmark/BookmarkState.kt
@@ -1,8 +1,8 @@
-package com.websarva.wings.android.bbsviewer.ui.favorite
+package com.websarva.wings.android.bbsviewer.ui.bookmark
 
 import com.websarva.wings.android.bbsviewer.data.model.Groupable
 
-data class FavoriteUiState(
+data class BookmarkState(
     val isBookmarked: Boolean = false,
     val groups: List<Groupable> = emptyList(),
     val selectedGroup: Groupable? = null,

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/bookmark/BookmarkStateViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/bookmark/BookmarkStateViewModel.kt
@@ -1,4 +1,4 @@
-package com.websarva.wings.android.bbsviewer.ui.favorite
+package com.websarva.wings.android.bbsviewer.ui.bookmark
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -19,15 +19,15 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
-class FavoriteViewModel @AssistedInject constructor(
+class BookmarkStateViewModel @AssistedInject constructor(
     private val boardBookmarkRepo: BookmarkBoardRepository,
     private val threadBookmarkRepo: ThreadBookmarkRepository,
     @Assisted private val boardInfo: BoardInfo,
     @Assisted private val threadInfo: ThreadInfo? // スレッド画面の場合のみ渡される
 ) : ViewModel() {
 
-    private val _uiState = MutableStateFlow(FavoriteUiState())
-    val uiState: StateFlow<FavoriteUiState> = _uiState.asStateFlow()
+    private val _uiState = MutableStateFlow(BookmarkState())
+    val uiState: StateFlow<BookmarkState> = _uiState.asStateFlow()
 
     init {
         // boardInfoは必須、threadInfoの有無で板画面かスレ画面かを判断
@@ -66,7 +66,7 @@ class FavoriteViewModel @AssistedInject constructor(
         }
     }
 
-//    fun handleFavoriteClick() {
+//    fun handleBookmarkClick() {
 //        if (_uiState.value.isBookmarked) {
 //            unbookmark()
 //        } else {
@@ -146,9 +146,9 @@ class FavoriteViewModel @AssistedInject constructor(
 
 // --- HiltがこのFactoryを生成できるように設定 ---
 @AssistedFactory
-interface FavoriteViewModelFactory {
+interface BookmarkStateViewModelFactory {
     fun create(
         boardInfo: BoardInfo,
         threadInfo: ThreadInfo?
-    ): FavoriteViewModel
+    ): BookmarkStateViewModel
 }

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/BoardRoute.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/BoardRoute.kt
@@ -98,7 +98,7 @@ fun NavGraphBuilder.addBoardRoute(
                 val viewModel: BoardViewModel =
                     tabsViewModel.getOrCreateBoardViewModel(tab.boardUrl)
                 val uiState by viewModel.uiState.collectAsState()
-                val favoriteState = uiState.favoriteState
+                val bookmarkState = uiState.bookmarkState
 
                 val listState = remember(tab.firstVisibleItemIndex, tab.firstVisibleItemScrollOffset) {
                     LazyListState(
@@ -142,9 +142,9 @@ fun NavGraphBuilder.addBoardRoute(
                 }
 
                 val bookmarkIconColor =
-                    if (favoriteState.isBookmarked && favoriteState.selectedGroup?.colorHex != null) {
+                    if (bookmarkState.isBookmarked && bookmarkState.selectedGroup?.colorHex != null) {
                         try {
-                            Color(favoriteState.selectedGroup.colorHex.toColorInt())
+                            Color(bookmarkState.selectedGroup.colorHex.toColorInt())
                         } catch (e: IllegalArgumentException) {
                             MaterialTheme.colorScheme.onSurfaceVariant
                         }
@@ -171,7 +171,7 @@ fun NavGraphBuilder.addBoardRoute(
                                     viewModel.openBookmarkSheet()
                                 },
                                 onInfoClick = { viewModel.openInfoDialog() },
-                                isBookmarked = favoriteState.isBookmarked,
+                                isBookmarked = bookmarkState.isBookmarked,
                                 bookmarkIconColor = bookmarkIconColor,
                                 scrollBehavior = scrollBehavior
                             )
@@ -213,26 +213,26 @@ fun NavGraphBuilder.addBoardRoute(
                         listState = listState
                     )
 
-                    if (favoriteState.showBookmarkSheet) {
+                    if (bookmarkState.showBookmarkSheet) {
                         BookmarkBottomSheet(
                             sheetState = bookmarkSheetState,
                             onDismissRequest = { viewModel.closeBookmarkSheet() },
-                            groups = favoriteState.groups,
-                            selectedGroupId = favoriteState.selectedGroup?.id,
+                            groups = bookmarkState.groups,
+                            selectedGroupId = bookmarkState.selectedGroup?.id,
                             onAddGroup = { viewModel.openAddGroupDialog() },
                             onGroupSelected = { viewModel.saveBookmark(it) },
                             onUnbookmarkRequested = { viewModel.unbookmarkBoard() }
                         )
                     }
 
-                    if (favoriteState.showAddGroupDialog) {
+                    if (bookmarkState.showAddGroupDialog) {
                         AddGroupDialog(
                             onDismissRequest = { viewModel.closeAddGroupDialog() },
                             onAdd = { viewModel.addGroup() },
                             onValueChange = { viewModel.setEnteredGroupName(it) },
-                            enteredValue = favoriteState.enteredGroupName,
+                            enteredValue = bookmarkState.enteredGroupName,
                             onColorSelected = { viewModel.setSelectedColor(it) },
-                            selectedColor = favoriteState.selectedColor,
+                            selectedColor = bookmarkState.selectedColor,
                         )
                     }
 

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/ThreadRoute.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/ThreadRoute.kt
@@ -113,7 +113,7 @@ fun NavGraphBuilder.addThreadRoute(
                 // 各タブ専用の ViewModel を取得。未登録なら Factory から生成
                 val viewModel: ThreadViewModel = tabsViewModel.getOrCreateThreadViewModel(viewModelKey)
                 val uiState by viewModel.uiState.collectAsState()
-                val favoriteState = uiState.favoriteState
+                val bookmarkState = uiState.bookmarkState
 
                 // rememberのキーにスクロール位置を渡す。
                 // これにより、ViewModelに保存されているスクロール位置(`tab`のプロパティ)が
@@ -173,7 +173,7 @@ fun NavGraphBuilder.addThreadRoute(
                     topBar = {
                         Column {
                             ThreadTopBar(
-                                onFavoriteClick = { viewModel.openBookmarkSheet() },
+                                onBookmarkClick = { viewModel.openBookmarkSheet() },
                                 uiState = uiState,
                                 onNavigationClick = openDrawer,
                                 scrollBehavior = scrollBehavior
@@ -210,12 +210,12 @@ fun NavGraphBuilder.addThreadRoute(
                 }
 
                 // ★ スレッドお気に入りグループ選択ボトムシート
-                if (favoriteState.showBookmarkSheet) {
+                if (bookmarkState.showBookmarkSheet) {
                     BookmarkBottomSheet(
                         sheetState = bookmarkSheetState,
                         onDismissRequest = { viewModel.closeBookmarkSheet() },
-                        groups = favoriteState.groups,
-                        selectedGroupId = favoriteState.selectedGroup?.id,
+                        groups = bookmarkState.groups,
+                        selectedGroupId = bookmarkState.selectedGroup?.id,
                         onGroupSelected = { viewModel.saveBookmark(it) },
                         onUnbookmarkRequested = { viewModel.unbookmarkBoard() },
                         onAddGroup = { viewModel.openAddGroupDialog() }
@@ -223,14 +223,14 @@ fun NavGraphBuilder.addThreadRoute(
                 }
 
                 // ★ スレッドお気に入りグループ追加ダイアログ
-                if (favoriteState.showAddGroupDialog) {
+                if (bookmarkState.showAddGroupDialog) {
                     AddGroupDialog(
                         onDismissRequest = { viewModel.closeAddGroupDialog() },
                         onAdd = { viewModel.addGroup() },
                         onValueChange = { name -> viewModel.setEnteredGroupName(name) },
-                        enteredValue = favoriteState.enteredGroupName,
+                        enteredValue = bookmarkState.enteredGroupName,
                         onColorSelected = { viewModel.setSelectedColor(it) },
-                        selectedColor = favoriteState.selectedColor
+                        selectedColor = bookmarkState.selectedColor
                     )
                 }
 

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/ThreadTopBar.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/ThreadTopBar.kt
@@ -27,14 +27,14 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.core.graphics.toColorInt
 import com.websarva.wings.android.bbsviewer.R
 import com.websarva.wings.android.bbsviewer.data.model.ThreadInfo
-import com.websarva.wings.android.bbsviewer.ui.favorite.FavoriteUiState
+import com.websarva.wings.android.bbsviewer.ui.bookmark.BookmarkState
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ThreadTopBar(
     modifier: Modifier = Modifier,
     scrollBehavior: TopAppBarScrollBehavior? = null,
-    onFavoriteClick: () -> Unit,
+    onBookmarkClick: () -> Unit,
     uiState: ThreadUiState,
     onNavigationClick: () -> Unit
 ) {
@@ -62,17 +62,17 @@ fun ThreadTopBar(
         },
         scrollBehavior = scrollBehavior,
         actions = {
-            IconButton(onClick = onFavoriteClick) {
-                val iconImage = if (uiState.favoriteState.isBookmarked) {
+            IconButton(onClick = onBookmarkClick) {
+                val iconImage = if (uiState.bookmarkState.isBookmarked) {
                     Icons.Filled.Star
                 } else {
                     Icons.Outlined.StarOutline
                 }
                 val iconTint = if (
-                    uiState.favoriteState.isBookmarked && uiState.favoriteState.selectedGroup?.colorHex != null
+                    uiState.bookmarkState.isBookmarked && uiState.bookmarkState.selectedGroup?.colorHex != null
                 ) {
                     try {
-                        Color(uiState.favoriteState.selectedGroup!!.colorHex.toColorInt())
+                        Color(uiState.bookmarkState.selectedGroup!!.colorHex.toColorInt())
                     } catch (e: Exception) {
                         LocalContentColor.current
                     }
@@ -120,12 +120,12 @@ fun ThreadTopBar(
 @Composable
 fun ThreadTopBarPreview() {
     ThreadTopBar(
-        onFavoriteClick = { /* お気に入り処理 */ },
+        onBookmarkClick = { /* お気に入り処理 */ },
         uiState = ThreadUiState(
             threadInfo = ThreadInfo(
                 title = "スレッドのタイトル",
             ),
-            favoriteState = FavoriteUiState(
+            bookmarkState = BookmarkState(
                 isBookmarked = false,
                 selectedGroup = null
             )

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/ThreadUiState.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/ThreadUiState.kt
@@ -6,7 +6,7 @@ import com.websarva.wings.android.bbsviewer.data.model.ThreadInfo
 import com.websarva.wings.android.bbsviewer.data.repository.ConfirmationData
 import com.websarva.wings.android.bbsviewer.ui.board.BoardUiState
 import com.websarva.wings.android.bbsviewer.ui.common.BaseUiState
-import com.websarva.wings.android.bbsviewer.ui.favorite.FavoriteUiState
+import com.websarva.wings.android.bbsviewer.ui.bookmark.BookmarkState
 
 data class ThreadUiState(
     val threadInfo: ThreadInfo = ThreadInfo(),
@@ -18,7 +18,7 @@ data class ThreadUiState(
     val isPosting: Boolean = false,
     val postConfirmation: ConfirmationData? = null,
     val isConfirmationScreen: Boolean = false,
-    val favoriteState: FavoriteUiState = FavoriteUiState(),
+    val bookmarkState: BookmarkState = BookmarkState(),
     override val isLoading: Boolean = false,
     override val showTabListSheet: Boolean = false,
 ) : BaseUiState<ThreadUiState> {

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/ThreadViewModel.kt
@@ -8,8 +8,8 @@ import com.websarva.wings.android.bbsviewer.data.repository.DatRepository
 import com.websarva.wings.android.bbsviewer.data.repository.PostRepository
 import com.websarva.wings.android.bbsviewer.data.repository.PostResult
 import com.websarva.wings.android.bbsviewer.ui.common.BaseViewModel
-import com.websarva.wings.android.bbsviewer.ui.favorite.FavoriteViewModel
-import com.websarva.wings.android.bbsviewer.ui.favorite.FavoriteViewModelFactory
+import com.websarva.wings.android.bbsviewer.ui.bookmark.BookmarkStateViewModel
+import com.websarva.wings.android.bbsviewer.ui.bookmark.BookmarkStateViewModelFactory
 import com.websarva.wings.android.bbsviewer.ui.util.keyToDatUrl
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -22,12 +22,12 @@ import kotlinx.coroutines.launch
 class ThreadViewModel @AssistedInject constructor(
     private val datRepository: DatRepository,
     private val postRepository: PostRepository,
-    private val favoriteViewModelFactory: FavoriteViewModelFactory,
+    private val bookmarkStateViewModelFactory: BookmarkStateViewModelFactory,
     @Assisted val viewModelKey: String,
 ) : BaseViewModel<ThreadUiState>() {
 
     override val _uiState = MutableStateFlow(ThreadUiState())
-    private var favoriteViewModel: FavoriteViewModel? = null
+    private var bookmarkStateViewModel: BookmarkStateViewModel? = null
 
     fun loadThread(datUrl: String) {
         _uiState.update { it.copy(isLoading = true, loadProgress = 0f) }
@@ -89,13 +89,13 @@ class ThreadViewModel @AssistedInject constructor(
         )
         _uiState.update { it.copy(boardInfo = boardInfo, threadInfo = threadInfo) }
 
-        // Factoryを使ってFavoriteViewModelを生成
-        favoriteViewModel = favoriteViewModelFactory.create(boardInfo, threadInfo)
+        // Factoryを使ってBookmarkStateViewModelを生成
+        bookmarkStateViewModel = bookmarkStateViewModelFactory.create(boardInfo, threadInfo)
 
         // 状態をマージ
         viewModelScope.launch {
-            favoriteViewModel?.uiState?.collect { favState ->
-                _uiState.update { it.copy(favoriteState = favState) }
+            bookmarkStateViewModel?.uiState?.collect { favState ->
+                _uiState.update { it.copy(bookmarkState = favState) }
             }
         }
 
@@ -103,16 +103,16 @@ class ThreadViewModel @AssistedInject constructor(
     }
 
 
-    // --- お気に入り関連の処理はFavoriteViewModelに委譲 ---
-    fun saveBookmark(groupId: Long) = favoriteViewModel?.saveBookmark(groupId)
-    fun unbookmarkBoard() = favoriteViewModel?.unbookmark()
-    fun openAddGroupDialog() = favoriteViewModel?.openAddGroupDialog()
-    fun closeAddGroupDialog() = favoriteViewModel?.closeAddGroupDialog()
-    fun setEnteredGroupName(name: String) = favoriteViewModel?.setEnteredGroupName(name)
-    fun setSelectedColor(color: String) = favoriteViewModel?.setSelectedColor(color)
-    fun addGroup() = favoriteViewModel?.addGroup()
-    fun openBookmarkSheet() = favoriteViewModel?.openBookmarkSheet()
-    fun closeBookmarkSheet() = favoriteViewModel?.closeBookmarkSheet()
+    // --- お気に入り関連の処理はBookmarkStateViewModelに委譲 ---
+    fun saveBookmark(groupId: Long) = bookmarkStateViewModel?.saveBookmark(groupId)
+    fun unbookmarkBoard() = bookmarkStateViewModel?.unbookmark()
+    fun openAddGroupDialog() = bookmarkStateViewModel?.openAddGroupDialog()
+    fun closeAddGroupDialog() = bookmarkStateViewModel?.closeAddGroupDialog()
+    fun setEnteredGroupName(name: String) = bookmarkStateViewModel?.setEnteredGroupName(name)
+    fun setSelectedColor(color: String) = bookmarkStateViewModel?.setSelectedColor(color)
+    fun addGroup() = bookmarkStateViewModel?.addGroup()
+    fun openBookmarkSheet() = bookmarkStateViewModel?.openBookmarkSheet()
+    fun closeBookmarkSheet() = bookmarkStateViewModel?.closeBookmarkSheet()
 
 
     fun reloadThread() {

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/topbar/RenderTopBar.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/topbar/RenderTopBar.kt
@@ -111,7 +111,7 @@ fun RenderTopBar(
             threadViewModel?.let { viewModel ->
                 val uiState by viewModel.uiState.collectAsState()
                 ThreadTopBar(
-                    onFavoriteClick = { viewModel.openBookmarkSheet() },
+                    onBookmarkClick = { viewModel.openBookmarkSheet() },
                     uiState = uiState,
                     onNavigationClick = {}
                 )


### PR DESCRIPTION
## Summary
- rename `Favorite` classes to `Bookmark*`
- adjust variables and imports for new names
- update usage in routes, ViewModels and top bars
- use `bookmark` naming in database setup

## Testing
- `./gradlew test --no-daemon` *(fails: Daemon compilation failed)*

------
https://chatgpt.com/codex/tasks/task_e_685ba679e7f08332999bbdfc322a4fc3