### PR TITLE
Display service name in board tab list

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardScaffold.kt
@@ -24,6 +24,7 @@ import com.websarva.wings.android.bbsviewer.ui.navigation.AppRoute
 import com.websarva.wings.android.bbsviewer.ui.navigation.RouteScaffold
 import com.websarva.wings.android.bbsviewer.ui.tabs.BoardTabInfo
 import com.websarva.wings.android.bbsviewer.ui.tabs.TabsViewModel
+import com.websarva.wings.android.bbsviewer.ui.util.parseServiceName
 import com.websarva.wings.android.bbsviewer.ui.topbar.SearchTopAppBar
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -42,7 +43,8 @@ fun BoardScaffold(
             BoardTabInfo(
                 boardId = boardRoute.boardId,
                 boardName = boardRoute.boardName,
-                boardUrl = boardRoute.boardUrl
+                boardUrl = boardRoute.boardUrl,
+                serviceName = parseServiceName(boardRoute.boardUrl)
             )
         )
     }

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardViewModel.kt
@@ -2,7 +2,6 @@ package com.websarva.wings.android.bbsviewer.ui.board
 
 import android.os.Build
 import androidx.annotation.RequiresApi
-import androidx.core.net.toUri
 import androidx.lifecycle.viewModelScope
 import com.websarva.wings.android.bbsviewer.data.model.BoardInfo
 import com.websarva.wings.android.bbsviewer.data.model.ThreadInfo
@@ -10,6 +9,7 @@ import com.websarva.wings.android.bbsviewer.data.repository.BoardRepository
 import com.websarva.wings.android.bbsviewer.ui.common.BaseViewModel
 import com.websarva.wings.android.bbsviewer.ui.common.bookmark.SingleBookmarkViewModel
 import com.websarva.wings.android.bbsviewer.ui.common.bookmark.SingleBookmarkViewModelFactory
+import com.websarva.wings.android.bbsviewer.ui.util.parseServiceName
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -170,15 +170,6 @@ class BoardViewModel @AssistedInject constructor(
         _uiState.update { it.copy(showInfoDialog = false) }
     }
 
-    private fun parseServiceName(url: String): String {
-        return try {
-            val host = url.toUri().host ?: return ""
-            val parts = host.split(".")
-            if (parts.size >= 2) parts.takeLast(2).joinToString(".") else host
-        } catch (e: Exception) {
-            ""
-        }
-    }
 }
 
 

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/tabs/BoardTabInfo.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/tabs/BoardTabInfo.kt
@@ -4,6 +4,7 @@ data class BoardTabInfo(
     val boardId: Long,
     val boardName: String,
     val boardUrl: String,
+    val serviceName: String,
     val firstVisibleItemIndex: Int = 0, // スクロール位置（インデックス）
     val firstVisibleItemScrollOffset: Int = 0 // スクロール位置（オフセット）
 )

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/tabs/OpenBoardsList.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/tabs/OpenBoardsList.kt
@@ -43,6 +43,7 @@ fun OpenBoardsList(
             items(openTabs, key = { it.boardUrl }) { tab ->
                 ListItem(
                     headlineContent = { Text(tab.boardName, maxLines = 1) },
+                    supportingContent = { Text(tab.serviceName) },
                     trailingContent = {
                         IconButton(onClick = { onCloseClick(tab) }) {
                             Icon(
@@ -75,9 +76,9 @@ fun OpenBoardsList(
 @Composable
 fun OpenBoardsListPreview() {
     val sampleBoards = listOf(
-        BoardTabInfo(1, "板1", "https://example.com/board1"),
-        BoardTabInfo(2, "板2", "https://example.com/board2"),
-        BoardTabInfo(3, "板3", "https://example.com/board3")
+        BoardTabInfo(1, "板1", "https://example.com/board1", "example.com"),
+        BoardTabInfo(2, "板2", "https://example.com/board2", "example.com"),
+        BoardTabInfo(3, "板3", "https://example.com/board3", "example.com")
     )
     OpenBoardsList(
         openTabs = sampleBoards,

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/util/UrlUtils.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/util/UrlUtils.kt
@@ -22,3 +22,17 @@ fun parseBoardUrl(url: String): Pair<String, String>? {
     val boardKey = segments[0]
     return host to boardKey
 }
+
+/**
+ * URL からサービス名（ドメイン部分）を抽出します。
+ * 例: https://agree.5ch.net/operate/ -> 5ch.net
+ */
+fun parseServiceName(url: String): String {
+    return try {
+        val host = url.toUri().host ?: return ""
+        val parts = host.split(".")
+        if (parts.size >= 2) parts.takeLast(2).joinToString(".") else host
+    } catch (e: Exception) {
+        ""
+    }
+}


### PR DESCRIPTION
## Summary
- parse service name from board URLs
- store service name in `BoardTabInfo`
- show service name in the open boards list

## Testing
- `./gradlew assembleDebug`

------
https://chatgpt.com/codex/tasks/task_e_68625e57a2048332b71876517e779918