### PR TITLE
Use color names for bookmark groups

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/AppDatabase.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/AppDatabase.kt
@@ -30,7 +30,7 @@ import com.websarva.wings.android.bbsviewer.data.datasource.local.entity.ThreadB
         BookmarkThreadEntity::class,
         ThreadBookmarkGroupEntity::class
     ],
-    version = 1,
+    version = 2,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/Migrations.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/Migrations.kt
@@ -1,0 +1,31 @@
+package com.websarva.wings.android.bbsviewer.data.datasource.local
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+object Migrations {
+    val MIGRATION_1_2 = object : Migration(1, 2) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL("ALTER TABLE `groups` ADD COLUMN colorName TEXT NOT NULL DEFAULT 'yellow'")
+            db.execSQL("ALTER TABLE thread_bookmark_groups ADD COLUMN colorName TEXT NOT NULL DEFAULT 'yellow'")
+            // 旧HEX値から名称への変換
+            val map = mapOf(
+                "#EF5350" to "red", "#E57373" to "red",
+                "#EC407A" to "pink", "#F06292" to "pink",
+                "#AB47BC" to "purple", "#BA68C8" to "purple",
+                "#5C6BC0" to "indigo", "#7986CB" to "indigo",
+                "#42A5F5" to "blue", "#64B5F6" to "blue",
+                "#26A69A" to "teal", "#4DB6AC" to "teal",
+                "#66BB6A" to "green", "#81C784" to "green",
+                "#FFEE58" to "yellow", "#FFF176" to "yellow",
+                "#FFCA28" to "amber", "#FFD54F" to "amber",
+                "#8D6E63" to "brown", "#A1887F" to "brown",
+                "#FFFF00" to "yellow"
+            )
+            for ((hex, name) in map) {
+                db.execSQL("UPDATE `groups` SET colorName = '$name' WHERE colorHex = '$hex'")
+                db.execSQL("UPDATE thread_bookmark_groups SET colorName = '$name' WHERE colorHex = '$hex'")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/dao/BoardBookmarkGroupDao.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/dao/BoardBookmarkGroupDao.kt
@@ -28,8 +28,8 @@ interface BoardBookmarkGroupDao {
     @Update
     suspend fun updateGroups(groups: List<BoardBookmarkGroupEntity>)
 
-    @Query("UPDATE `groups` SET name = :name, colorHex = :colorHex WHERE groupId = :groupId")
-    suspend fun updateGroupInfo(groupId: Long, name: String, colorHex: String)
+    @Query("UPDATE `groups` SET name = :name, colorName = :colorName WHERE groupId = :groupId")
+    suspend fun updateGroupInfo(groupId: Long, name: String, colorName: String)
 
     @Query("DELETE FROM `groups` WHERE groupId = :groupId")
     suspend fun deleteGroupById(groupId: Long)

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/dao/BookmarkBoardDao.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/dao/BookmarkBoardDao.kt
@@ -18,7 +18,7 @@ interface BookmarkBoardDao {
           b.*,
           bm.groupId   AS groupId,
           g.name       AS groupName,
-          g.colorHex   AS groupColorHex
+          g.colorName   AS groupColorName
         FROM boards AS b
         INNER JOIN board_category_cross_ref AS bc
           ON b.boardId = bc.boardId
@@ -61,7 +61,7 @@ interface BookmarkBoardDao {
     b.*,
     bm.groupId   AS groupId,
     g.name       AS groupName,
-    g.colorHex   AS groupColorHex
+    g.colorName  AS groupColorName
         FROM boards AS b
         LEFT JOIN bookmark_boards AS bm
           ON bm.boardId = b.boardId

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/dao/ThreadBookmarkGroupDao.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/dao/ThreadBookmarkGroupDao.kt
@@ -24,8 +24,8 @@ interface ThreadBookmarkGroupDao {
     @Update
     suspend fun updateGroups(groups: List<ThreadBookmarkGroupEntity>)
 
-    @Query("UPDATE thread_bookmark_groups SET name = :name, colorHex = :colorHex WHERE groupId = :groupId")
-    suspend fun updateGroupInfo(groupId: Long, name: String, colorHex: String)
+    @Query("UPDATE thread_bookmark_groups SET name = :name, colorName = :colorName WHERE groupId = :groupId")
+    suspend fun updateGroupInfo(groupId: Long, name: String, colorName: String)
 
     @Query("DELETE FROM thread_bookmark_groups WHERE groupId = :groupId")
     suspend fun deleteGroupById(groupId: Long)

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/entity/BoardBookmarkGroupEntity.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/entity/BoardBookmarkGroupEntity.kt
@@ -11,7 +11,7 @@ import com.websarva.wings.android.bbsviewer.data.model.Groupable
 data class BoardBookmarkGroupEntity(
     @PrimaryKey(autoGenerate = true) val groupId: Long = 0,
     override val name: String,
-    override val colorHex: String,
+    override val colorName: String,
     override val sortOrder: Int
 ) : Groupable {
     override val id: Long

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/entity/ThreadBookmarkGroupEntity.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/entity/ThreadBookmarkGroupEntity.kt
@@ -10,7 +10,7 @@ import com.websarva.wings.android.bbsviewer.data.model.Groupable
 data class ThreadBookmarkGroupEntity(
     @PrimaryKey(autoGenerate = true) val groupId: Long = 0,
     override val name: String,
-    override val colorHex: String,
+    override val colorName: String,
     override val sortOrder: Int
 ) : Groupable {
     override val id: Long

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/model/Groupable.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/model/Groupable.kt
@@ -3,6 +3,6 @@ package com.websarva.wings.android.bbsviewer.data.model
 interface Groupable {
     val id: Long // グループの一意なID
     val name: String
-    val colorHex: String
+    val colorName: String
     val sortOrder: Int
 }

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/repository/BookmarkBoardRepository.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/repository/BookmarkBoardRepository.kt
@@ -26,19 +26,19 @@ class BookmarkBoardRepository @Inject constructor(
     }
 
     /** 新規グループを末尾に追加 */
-    suspend fun addGroupAtEnd(name: String, colorHex: String) {
+    suspend fun addGroupAtEnd(name: String, colorName: String) {
         // まず既存最大 + 1
         val nextOrder = groupDao.getMaxSortOrder() + 1
         val newGroup = BoardBookmarkGroupEntity(
             name      = name,
-            colorHex  = colorHex,
+            colorName = colorName,
             sortOrder = nextOrder
         )
         groupDao.insertGroup(newGroup)
     }
 
-    suspend fun updateGroup(groupId: Long, name: String, colorHex: String) {
-        groupDao.updateGroupInfo(groupId, name, colorHex)
+    suspend fun updateGroup(groupId: Long, name: String, colorName: String) {
+        groupDao.updateGroupInfo(groupId, name, colorName)
     }
 
     suspend fun deleteGroup(groupId: Long) {

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/repository/ThreadBookmarkRepository.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/repository/ThreadBookmarkRepository.kt
@@ -35,18 +35,18 @@ class ThreadBookmarkRepository @Inject constructor(
         return threadGroupDao.getAllGroupsSorted()
     }
 
-    suspend fun addGroupAtEnd(name: String, colorHex: String) {
+    suspend fun addGroupAtEnd(name: String, colorName: String) {
         val nextOrder = threadGroupDao.getMaxSortOrder() + 1
         val newGroup = ThreadBookmarkGroupEntity(
             name = name,
-            colorHex = colorHex,
+            colorName = colorName,
             sortOrder = nextOrder
         )
         threadGroupDao.insertGroup(newGroup)
     }
 
-    suspend fun updateGroup(groupId: Long, name: String, colorHex: String) {
-        threadGroupDao.updateGroupInfo(groupId, name, colorHex)
+    suspend fun updateGroup(groupId: Long, name: String, colorName: String) {
+        threadGroupDao.updateGroupInfo(groupId, name, colorName)
     }
 
     suspend fun deleteGroup(groupId: Long) {

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/di/DatabaseCallback.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/di/DatabaseCallback.kt
@@ -7,6 +7,7 @@ import com.websarva.wings.android.bbsviewer.R
 import com.websarva.wings.android.bbsviewer.data.repository.BbsServiceRepository
 import com.websarva.wings.android.bbsviewer.data.repository.BookmarkBoardRepository
 import com.websarva.wings.android.bbsviewer.data.repository.ThreadBookmarkRepository
+import com.websarva.wings.android.bbsviewer.ui.theme.BookmarkColor
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -53,13 +54,13 @@ class DatabaseCallback @Inject constructor(
         // デフォルトのお気に入りグループを登録
         bookmarkBoardRepositoryProvider.get().addGroupAtEnd(
             name = bookmarkGroupName, // ← 取得した文字列を使用
-            colorHex = "#FFFF00" // 黄色のHEXコード
+            colorName = BookmarkColor.YELLOW.value
         )
 
         val threadBookmarkGroupName = context.getString(R.string.bookmark)
         bookmarkThreadRepositoryProvider.get().addGroupAtEnd(
             name = threadBookmarkGroupName,
-            colorHex = "#FFFF00"
+            colorName = BookmarkColor.YELLOW.value
         )
     }
 }

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/di/DatabaseModule.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/di/DatabaseModule.kt
@@ -11,6 +11,7 @@ import com.websarva.wings.android.bbsviewer.data.datasource.local.dao.BoardBookm
 import com.websarva.wings.android.bbsviewer.data.datasource.local.dao.BookmarkBoardDao
 import com.websarva.wings.android.bbsviewer.data.datasource.local.dao.CategoryDao
 import com.websarva.wings.android.bbsviewer.data.datasource.local.dao.ThreadBookmarkGroupDao
+import com.websarva.wings.android.bbsviewer.data.datasource.local.Migrations
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -47,6 +48,7 @@ object DatabaseModule {
         )
             // マイグレーション未定義時は既存データを破棄し再生成
             .fallbackToDestructiveMigration(false)
+            .addMigrations(Migrations.MIGRATION_1_2)
             .addCallback(callback)
             .build()
     }

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardScaffold.kt
@@ -17,7 +17,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import androidx.core.graphics.toColorInt
+import com.websarva.wings.android.bbsviewer.ui.theme.bookmarkColor
 import androidx.navigation.NavHostController
 import com.websarva.wings.android.bbsviewer.data.model.BoardInfo
 import com.websarva.wings.android.bbsviewer.ui.navigation.AppRoute
@@ -76,12 +76,8 @@ fun BoardScaffold(
         topBar = { viewModel, uiState, drawer, scrollBehavior ->
             val bookmarkState = uiState.singleBookmarkState
             val bookmarkIconColor =
-                if (bookmarkState.isBookmarked && bookmarkState.selectedGroup?.colorHex != null) {
-                    try {
-                        Color(bookmarkState.selectedGroup.colorHex.toColorInt())
-                    } catch (e: IllegalArgumentException) {
-                        MaterialTheme.colorScheme.onSurfaceVariant
-                    }
+                if (bookmarkState.isBookmarked && bookmarkState.selectedGroup?.colorName != null) {
+                    bookmarkColor(bookmarkState.selectedGroup.colorName)
                 } else {
                     Color.Unspecified
                 }

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/bookmarklist/BookmarkListScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/bookmarklist/BookmarkListScreen.kt
@@ -33,6 +33,7 @@ import com.websarva.wings.android.bbsviewer.data.datasource.local.entity.GroupWi
 import com.websarva.wings.android.bbsviewer.data.datasource.local.entity.GroupWithThreadBookmarks
 import com.websarva.wings.android.bbsviewer.data.datasource.local.entity.ThreadBookmarkGroupEntity
 import com.websarva.wings.android.bbsviewer.data.model.GroupedData
+import com.websarva.wings.android.bbsviewer.ui.theme.BookmarkColor
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -269,7 +270,7 @@ fun BookmarkBoardScreenPreview() {
             GroupWithBoards(
                 group = BoardBookmarkGroupEntity(
                     name = "グループ1",
-                    colorHex = "#FF0E00",
+                    colorName = BookmarkColor.RED.value,
                     sortOrder = 1
                 ),
                 boards = listOf(
@@ -302,7 +303,7 @@ fun BookmarkThreadListScreenPreview() {
             group = ThreadBookmarkGroupEntity(
                 groupId = 0,
                 name = "お気に入りグループA",
-                colorHex = "#FF9800",
+                colorName = BookmarkColor.AMBER.value,
                 sortOrder = 0
             ),
             threads = listOf(
@@ -330,7 +331,7 @@ fun BookmarkThreadListScreenPreview() {
             group = ThreadBookmarkGroupEntity(
                 groupId = 1,
                 name = "お気に入りグループB",
-                colorHex = "#4CAF50",
+                colorName = BookmarkColor.GREEN.value,
                 sortOrder = 1
             ),
             threads = emptyList()

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/bookmarklist/GenericGroupedListScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/bookmarklist/GenericGroupedListScreen.kt
@@ -8,15 +8,14 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.core.graphics.toColorInt
 import com.websarva.wings.android.bbsviewer.data.model.Groupable
 import com.websarva.wings.android.bbsviewer.data.model.GroupedData
+import com.websarva.wings.android.bbsviewer.ui.theme.bookmarkColor
 
 @Composable
 fun <G : Groupable, I> GenericGroupedListScreen(
@@ -60,11 +59,7 @@ fun <G : Groupable, I> GenericGroupedListScreen(
 
                 // --- グループごとのアイテムカード ---
                 item(key = "group_card_${groupedData.group.id}") {
-                    val groupColor = try {
-                        Color(groupedData.group.colorHex.toColorInt())
-                    } catch (e: Exception) {
-                        MaterialTheme.colorScheme.surfaceVariant // 解析失敗時のフォールバック
-                    }
+                    val groupColor = bookmarkColor(groupedData.group.colorName)
                     Card(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -127,7 +122,7 @@ fun GenericGroupedListScreenPreview() {
         val color: String,
         override val sortOrder: Int = 0 // デフォルト値を設定
     ) : Groupable {
-        override val colorHex: String get() = color
+        override val colorName: String get() = color
     }
 
     // サンプルデータ

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/common/bookmark/AddGroupDialog.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/common/bookmark/AddGroupDialog.kt
@@ -2,7 +2,6 @@ package com.websarva.wings.android.bbsviewer.ui.common.bookmark
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
@@ -29,43 +28,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.core.graphics.toColorInt
 import com.websarva.wings.android.bbsviewer.R
-import com.websarva.wings.android.bbsviewer.ui.theme.md_theme_dark_amber
-import com.websarva.wings.android.bbsviewer.ui.theme.md_theme_dark_blue
-import com.websarva.wings.android.bbsviewer.ui.theme.md_theme_dark_blue_gray
-import com.websarva.wings.android.bbsviewer.ui.theme.md_theme_dark_brown
-import com.websarva.wings.android.bbsviewer.ui.theme.md_theme_dark_cyan
-import com.websarva.wings.android.bbsviewer.ui.theme.md_theme_dark_deep_purple
-import com.websarva.wings.android.bbsviewer.ui.theme.md_theme_dark_green
-import com.websarva.wings.android.bbsviewer.ui.theme.md_theme_dark_indigo
-import com.websarva.wings.android.bbsviewer.ui.theme.md_theme_dark_lime
-import com.websarva.wings.android.bbsviewer.ui.theme.md_theme_dark_orange
-import com.websarva.wings.android.bbsviewer.ui.theme.md_theme_dark_pink
-import com.websarva.wings.android.bbsviewer.ui.theme.md_theme_dark_purple
-import com.websarva.wings.android.bbsviewer.ui.theme.md_theme_dark_red
-import com.websarva.wings.android.bbsviewer.ui.theme.md_theme_dark_teal
-import com.websarva.wings.android.bbsviewer.ui.theme.md_theme_dark_yellow
-import com.websarva.wings.android.bbsviewer.ui.theme.md_theme_light_amber
-import com.websarva.wings.android.bbsviewer.ui.theme.md_theme_light_blue
-import com.websarva.wings.android.bbsviewer.ui.theme.md_theme_light_blue_gray
-import com.websarva.wings.android.bbsviewer.ui.theme.md_theme_light_brown
-import com.websarva.wings.android.bbsviewer.ui.theme.md_theme_light_cyan
-import com.websarva.wings.android.bbsviewer.ui.theme.md_theme_light_deep_purple
-import com.websarva.wings.android.bbsviewer.ui.theme.md_theme_light_green
-import com.websarva.wings.android.bbsviewer.ui.theme.md_theme_light_indigo
-import com.websarva.wings.android.bbsviewer.ui.theme.md_theme_light_lime
-import com.websarva.wings.android.bbsviewer.ui.theme.md_theme_light_orange
-import com.websarva.wings.android.bbsviewer.ui.theme.md_theme_light_pink
-import com.websarva.wings.android.bbsviewer.ui.theme.md_theme_light_purple
-import com.websarva.wings.android.bbsviewer.ui.theme.md_theme_light_red
-import com.websarva.wings.android.bbsviewer.ui.theme.md_theme_light_teal
-import com.websarva.wings.android.bbsviewer.ui.theme.md_theme_light_yellow
+import com.websarva.wings.android.bbsviewer.ui.theme.BookmarkColor
+import com.websarva.wings.android.bbsviewer.ui.theme.bookmarkColor
 
 @Composable
 fun AddGroupDialog(
@@ -79,19 +47,7 @@ fun AddGroupDialog(
     onColorSelected: (String) -> Unit,
     selectedColor: String,
 ) {
-    val colors = if (isSystemInDarkTheme()) {
-        listOf(
-            md_theme_dark_red, md_theme_dark_pink, md_theme_dark_purple, md_theme_dark_indigo,
-            md_theme_dark_blue, md_theme_dark_teal, md_theme_dark_green, md_theme_dark_yellow,
-            md_theme_dark_amber, md_theme_dark_brown
-        )
-    } else {
-        listOf(
-            md_theme_light_red, md_theme_light_pink, md_theme_light_purple, md_theme_light_indigo,
-            md_theme_light_blue, md_theme_light_teal, md_theme_light_green, md_theme_light_yellow,
-            md_theme_light_amber, md_theme_light_brown
-        )
-    }
+    val colors = BookmarkColor.values()
 
     AlertDialog(
         modifier = modifier,
@@ -121,8 +77,7 @@ fun AddGroupDialog(
                     verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     colors.forEach { color  ->
-                        val hex = String.format("#%06X", 0xFFFFFF and color.toArgb())
-                        val isSelected = hex.equals(selectedColor, ignoreCase = true)
+                        val isSelected = color.value.equals(selectedColor, ignoreCase = true)
                         val border = if (isSelected)
                             BorderStroke(2.dp, MaterialTheme.colorScheme.primary)
                         else null
@@ -130,9 +85,9 @@ fun AddGroupDialog(
                         Surface(
                             modifier = Modifier
                                 .size(40.dp)
-                                .clickable { onColorSelected(hex) },
+                                .clickable { onColorSelected(color.value) },
                             shape = CircleShape,
-                            color = color,
+                            color = bookmarkColor(color.value),
                             border = border
                         ) { /* 円形チップ */ }
                     }
@@ -171,8 +126,7 @@ fun AddGroupDialog(
 @Composable
 fun AddGroupDialogPreview() {
     var name by remember { mutableStateOf("") }
-    var selColor by remember { mutableStateOf("#FF4081") }
-    val palette = listOf("#FF4081", "#3F51B5", "#4CAF50", "#FF9800")
+    var selColor by remember { mutableStateOf(BookmarkColor.RED.value) }
 
     AddGroupDialog(
         isEdit = true,

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/common/bookmark/BookmarkBottomSheetScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/common/bookmark/BookmarkBottomSheetScreen.kt
@@ -37,9 +37,10 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.core.graphics.toColorInt
 import com.websarva.wings.android.bbsviewer.R
 import com.websarva.wings.android.bbsviewer.data.model.Groupable
+import com.websarva.wings.android.bbsviewer.ui.theme.bookmarkColor
+import com.websarva.wings.android.bbsviewer.ui.theme.BookmarkColor
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -116,7 +117,7 @@ private fun <T : Groupable> BookmarkSheetContent(
             items(groups, key = { group -> group.id }) { group ->
                 val isSelected = group.id == selectedGroupId
                 val bgColor = if (isSelected) {
-                    Color(group.colorHex.toColorInt())
+                    bookmarkColor(group.colorName)
                 } else {
                     MaterialTheme.colorScheme.surfaceVariant
                 }
@@ -144,7 +145,7 @@ private fun <T : Groupable> BookmarkSheetContent(
                             modifier = Modifier
                                 .fillMaxHeight()
                                 .width(10.dp)
-                                .background(color = Color(group.colorHex.toColorInt()))
+                                .background(color = bookmarkColor(group.colorName))
                         )
                         Spacer(modifier = Modifier.width(12.dp))
                         Text(
@@ -165,7 +166,7 @@ private fun <T : Groupable> BookmarkSheetContent(
 private data class PreviewGroup(
     override val id: Long,
     override val name: String,
-    override val colorHex: String,
+    override val colorName: String,
     override val sortOrder: Int
 ) : Groupable
 
@@ -173,10 +174,10 @@ private data class PreviewGroup(
 @Composable
 fun BookmarkSheetPreview() {
     val previewGroups = listOf(
-        PreviewGroup(1, "グループA", "#FF0000", 1),
-        PreviewGroup(2, "グループB", "#00FF00", 2),
-        PreviewGroup(3, "グループC", "#0000FF", 3),
-        PreviewGroup(4, "グループD（とても長い名前）", "#FFFF00", 4),
+        PreviewGroup(1, "グループA", BookmarkColor.RED.value, 1),
+        PreviewGroup(2, "グループB", BookmarkColor.GREEN.value, 2),
+        PreviewGroup(3, "グループC", BookmarkColor.BLUE.value, 3),
+        PreviewGroup(4, "グループD（とても長い名前）", BookmarkColor.YELLOW.value, 4),
     )
     MaterialTheme { // PreviewでもThemeを適用
         BookmarkSheetContent(

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/common/bookmark/SingleBookmarkState.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/common/bookmark/SingleBookmarkState.kt
@@ -1,6 +1,7 @@
 package com.websarva.wings.android.bbsviewer.ui.common.bookmark
 
 import com.websarva.wings.android.bbsviewer.data.model.Groupable
+import com.websarva.wings.android.bbsviewer.ui.theme.BookmarkColor
 
 data class SingleBookmarkState(
     val isBookmarked: Boolean = false,
@@ -9,6 +10,6 @@ data class SingleBookmarkState(
     val showBookmarkSheet: Boolean = false,
     val showAddGroupDialog: Boolean = false,
     val enteredGroupName: String = "",
-    val selectedColor: String = "#FF0000",
+    val selectedColor: String = BookmarkColor.RED.value,
     val editingGroupId: Long? = null
 )

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/common/bookmark/SingleBookmarkViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/common/bookmark/SingleBookmarkViewModel.kt
@@ -9,6 +9,7 @@ import com.websarva.wings.android.bbsviewer.data.model.Groupable
 import com.websarva.wings.android.bbsviewer.data.model.ThreadInfo
 import com.websarva.wings.android.bbsviewer.data.repository.BookmarkBoardRepository
 import com.websarva.wings.android.bbsviewer.data.repository.ThreadBookmarkRepository
+import com.websarva.wings.android.bbsviewer.ui.theme.BookmarkColor
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -120,7 +121,7 @@ class SingleBookmarkViewModel @AssistedInject constructor(
         it.copy(
             showAddGroupDialog = true,
             enteredGroupName = "",
-            selectedColor = "#FF0000",
+            selectedColor = BookmarkColor.RED.value,
             editingGroupId = null
         )
     }
@@ -129,7 +130,7 @@ class SingleBookmarkViewModel @AssistedInject constructor(
         it.copy(
             showAddGroupDialog = true,
             enteredGroupName = group.name,
-            selectedColor = group.colorHex,
+            selectedColor = group.colorName,
             editingGroupId = group.id
         )
     }
@@ -138,7 +139,7 @@ class SingleBookmarkViewModel @AssistedInject constructor(
         it.copy(
             showAddGroupDialog = false,
             enteredGroupName = "",
-            selectedColor = "#FF0000",
+            selectedColor = BookmarkColor.RED.value,
             editingGroupId = null
         )
     }

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/theme/BookmarkColor.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/theme/BookmarkColor.kt
@@ -1,0 +1,29 @@
+package com.websarva.wings.android.bbsviewer.ui.theme
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+
+enum class BookmarkColor(val value: String, val light: Color, val dark: Color) {
+    RED("red", md_theme_light_red, md_theme_dark_red),
+    PINK("pink", md_theme_light_pink, md_theme_dark_pink),
+    PURPLE("purple", md_theme_light_purple, md_theme_dark_purple),
+    INDIGO("indigo", md_theme_light_indigo, md_theme_dark_indigo),
+    BLUE("blue", md_theme_light_blue, md_theme_dark_blue),
+    TEAL("teal", md_theme_light_teal, md_theme_dark_teal),
+    GREEN("green", md_theme_light_green, md_theme_dark_green),
+    YELLOW("yellow", md_theme_light_yellow, md_theme_dark_yellow),
+    AMBER("amber", md_theme_light_amber, md_theme_dark_amber),
+    BROWN("brown", md_theme_light_brown, md_theme_dark_brown);
+
+    companion object {
+        fun fromValue(value: String): BookmarkColor? =
+            values().firstOrNull { it.value.equals(value, ignoreCase = true) }
+    }
+}
+
+@Composable
+fun bookmarkColor(name: String): Color {
+    val color = BookmarkColor.fromValue(name) ?: BookmarkColor.RED
+    return if (isSystemInDarkTheme()) color.dark else color.light
+}

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/ThreadTopBar.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/ThreadTopBar.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.core.graphics.toColorInt
+import com.websarva.wings.android.bbsviewer.ui.theme.bookmarkColor
 import com.websarva.wings.android.bbsviewer.R
 import com.websarva.wings.android.bbsviewer.data.model.ThreadInfo
 import com.websarva.wings.android.bbsviewer.ui.common.bookmark.SingleBookmarkState
@@ -61,13 +61,9 @@ fun ThreadTopBar(
                     Icons.Outlined.StarOutline
                 }
                 val iconTint = if (
-                    uiState.singleBookmarkState.isBookmarked && uiState.singleBookmarkState.selectedGroup?.colorHex != null
+                    uiState.singleBookmarkState.isBookmarked && uiState.singleBookmarkState.selectedGroup?.colorName != null
                 ) {
-                    try {
-                        Color(uiState.singleBookmarkState.selectedGroup!!.colorHex.toColorInt())
-                    } catch (e: Exception) {
-                        LocalContentColor.current
-                    }
+                    bookmarkColor(uiState.singleBookmarkState.selectedGroup!!.colorName)
                 } else {
                     LocalContentColor.current
                 }


### PR DESCRIPTION
## Summary
- add BookmarkColor enum and theme-dependent color mapping
- store group colors by name in Room and add migration from v1 to v2
- update DAOs, repositories, and view models to use `colorName`
- update UI components to resolve colors dynamically based on current theme

## Testing
- `./gradlew test --quiet` *(failed: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_686e01224c648332b6c0b88919bc4686