### PR TITLE
Improve reply anchor style

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/theme/ReplyColor.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/theme/ReplyColor.kt
@@ -1,0 +1,9 @@
+package com.websarva.wings.android.bbsviewer.ui.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+
+@Composable
+fun replyColor(): Color {
+    return if (LocalIsDarkTheme.current) md_theme_dark_blue else md_theme_light_blue
+}

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/ThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/ThreadScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupPositionProvider
 import com.websarva.wings.android.bbsviewer.ui.theme.idColor
+import com.websarva.wings.android.bbsviewer.ui.theme.replyColor
 import com.websarva.wings.android.bbsviewer.ui.util.buildUrlAnnotatedString
 
 data class PopupInfo(
@@ -223,7 +224,11 @@ fun PostItem(
         }
 
         val uriHandler = LocalUriHandler.current
-        val annotatedText = buildUrlAnnotatedString(post.content) { uriHandler.openUri(it) }
+        val annotatedText = buildUrlAnnotatedString(
+            text = post.content,
+            onOpenUrl = { uriHandler.openUri(it) },
+            replyColor = replyColor()
+        )
         ClickableText(
             text = annotatedText,
             style = MaterialTheme.typography.bodyMedium,

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/util/LinkUtils.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/util/LinkUtils.kt
@@ -1,5 +1,6 @@
 package com.websarva.wings.android.bbsviewer.ui.util
 
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -17,6 +18,7 @@ private val replyRegex: Pattern = Pattern.compile(">>(\\d+)")
 fun buildUrlAnnotatedString(
     text: String,
     onOpenUrl: (String) -> Unit,
+    replyColor: Color = Color.Blue,
 ): AnnotatedString {
     return buildAnnotatedString {
         var lastIndex = 0
@@ -45,7 +47,7 @@ fun buildUrlAnnotatedString(
                     val number = replyRegex.matcher(match).run { if (find()) group(1) else null }
                     pushStringAnnotation(tag = "REPLY", annotation = number ?: "")
                     addStyle(
-                        SpanStyle(textDecoration = TextDecoration.Underline),
+                        SpanStyle(color = replyColor),
                         start = length,
                         end = length + match.length
                     )


### PR DESCRIPTION
## Summary
- 返信アンカー(>>数字)の色をテーマに応じた青色に変更
- 返信アンカーの下線を削除
- `buildUrlAnnotatedString` に色指定を追加

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_686f1cae101483329e5cda7f93cbafcd