### PR TITLE
Add full-screen image viewer

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/FullScreenImageDialog.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/FullScreenImageDialog.kt
@@ -1,0 +1,36 @@
+package com.websarva.wings.android.bbsviewer.ui.thread
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.window.Dialog
+import coil.compose.AsyncImage
+
+@Composable
+fun FullScreenImageDialog(
+    imageUrl: String,
+    onDismissRequest: () -> Unit
+) {
+    Dialog(onDismissRequest = onDismissRequest) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black)
+                .clickable { onDismissRequest() },
+            contentAlignment = Alignment.Center
+        ) {
+            AsyncImage(
+                model = imageUrl,
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Fit
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/ThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/ThreadScreen.kt
@@ -53,6 +53,7 @@ import com.websarva.wings.android.bbsviewer.ui.theme.idColor
 import com.websarva.wings.android.bbsviewer.ui.theme.replyColor
 import com.websarva.wings.android.bbsviewer.ui.util.buildUrlAnnotatedString
 import com.websarva.wings.android.bbsviewer.ui.util.extractImageUrls
+import com.websarva.wings.android.bbsviewer.ui.thread.FullScreenImageDialog
 import coil.compose.AsyncImage
 
 data class PopupInfo(
@@ -78,6 +79,7 @@ fun ThreadScreen(
             idx
         }
     }
+    var selectedImageUrl by remember { mutableStateOf<String?>(null) }
 
     Box(modifier = modifier.fillMaxSize()) {
         Row(modifier = Modifier.fillMaxSize()) {
@@ -102,6 +104,7 @@ fun ThreadScreen(
                         postNum = index + 1,
                         idIndex = idIndexList[index],
                         idTotal = idCountMap[post.id] ?: 1,
+                        onImageClick = { selectedImageUrl = it },
                         onReplyClick = { num ->
                             if (num in 1..posts.size) {
                                 val target = posts[num - 1]
@@ -167,6 +170,7 @@ fun ThreadScreen(
                         postNum = posts.indexOf(info.post) + 1,
                         idIndex = idIndexList[posts.indexOf(info.post)],
                         idTotal = idCountMap[info.post.id] ?: 1,
+                        onImageClick = { selectedImageUrl = it },
                         onReplyClick = { num ->
                             if (num in 1..posts.size) {
                                 val target = posts[num - 1]
@@ -182,6 +186,13 @@ fun ThreadScreen(
                 }
             }
         }
+
+        selectedImageUrl?.let { url ->
+            FullScreenImageDialog(
+                imageUrl = url,
+                onDismissRequest = { selectedImageUrl = null }
+            )
+        }
     }
 }
 
@@ -192,6 +203,7 @@ fun PostItem(
     postNum: Int,
     idIndex: Int,
     idTotal: Int,
+    onImageClick: ((String) -> Unit)? = null,
     onReplyClick: ((Int) -> Unit)? = null
 ) {
     Column(
@@ -259,6 +271,7 @@ fun PostItem(
                 modifier = Modifier
                     .fillMaxWidth()
                     .heightIn(max = 200.dp)
+                    .clickable { onImageClick?.invoke(url) }
             )
         }
     }
@@ -380,6 +393,7 @@ fun ReplyCardPreview() {
         ),
         postNum = 1,
         idIndex = 1,
-        idTotal = 1
+        idTotal = 1,
+        onImageClick = {}
     )
 }


### PR DESCRIPTION
## Summary
- show images in full screen when tapped
- add `FullScreenImageDialog`
- update `ThreadScreen` to use the dialog

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6870936706b4833298d4a7466bb56836