### PR TITLE
Implement reply count color coding

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/theme/ReplyCountColor.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/theme/ReplyCountColor.kt
@@ -1,0 +1,23 @@
+package com.websarva.wings.android.bbsviewer.ui.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+
+enum class ReplyCountColor(val light: Color, val dark: Color) {
+    LEVEL1(md_theme_light_blue, md_theme_dark_blue),
+    LEVEL2(md_theme_light_purple, md_theme_dark_purple),
+    LEVEL3(md_theme_light_pink, md_theme_dark_pink),
+    LEVEL4(md_theme_light_red, md_theme_dark_red)
+}
+
+@Composable
+fun replyCountColor(count: Int): Color {
+    val color = when (count) {
+        in 1..2 -> ReplyCountColor.LEVEL1
+        in 3..4 -> ReplyCountColor.LEVEL2
+        in 5..6 -> ReplyCountColor.LEVEL3
+        in 7..Int.MAX_VALUE -> ReplyCountColor.LEVEL4
+        else -> return Color.Unspecified
+    }
+    return if (LocalIsDarkTheme.current) color.dark else color.light
+}

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/PostItem.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/PostItem.kt
@@ -15,6 +15,7 @@ import androidx.navigation.NavHostController
 import com.websarva.wings.android.bbsviewer.ui.navigation.AppRoute
 import com.websarva.wings.android.bbsviewer.ui.theme.idColor
 import com.websarva.wings.android.bbsviewer.ui.theme.replyColor
+import com.websarva.wings.android.bbsviewer.ui.theme.replyCountColor
 import com.websarva.wings.android.bbsviewer.ui.util.buildUrlAnnotatedString
 import com.websarva.wings.android.bbsviewer.ui.util.extractImageUrls
 import java.net.URLEncoder
@@ -54,13 +55,14 @@ fun PostItem(
 
         Row {
             val replyCount = replyFromNumbers.size
+            val postNumColor = if (replyCount > 0) replyCountColor(replyCount) else MaterialTheme.colorScheme.onSurfaceVariant
             Text(
                 modifier = Modifier
                     .alignByBaseline()
                     .clickable(enabled = replyCount > 0) { onReplyFromClick?.invoke(replyFromNumbers) },
                 text = if (replyCount > 0) "$postNum ($replyCount)" else postNum.toString(),
                 style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+                color = postNumColor
             )
             Spacer(modifier = Modifier.width(4.dp))
             Text(


### PR DESCRIPTION
## Summary
- add color scheme for post number by reply count
- adjust PostItem to use `replyCountColor`

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6871439ad4648332b3090348a324c55c