### PR TITLE
Add history list screen

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/bottombar/NavigationBottomBar.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/bottombar/NavigationBottomBar.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.History
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
@@ -43,6 +44,12 @@ fun NavigationBottomBar(
             name = stringResource(R.string.bookmark),
             icon = Icons.Default.Star,
             parentRoute = AppRoute.BookmarkList
+        ),
+        TopLevelRoute(
+            route = AppRoute.HistoryList,
+            name = stringResource(R.string.history),
+            icon = Icons.Default.History,
+            parentRoute = AppRoute.HistoryList
         ),
         TopLevelRoute(
             route = AppRoute.ServiceList,

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/bottombar/RenderBottomBar.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/bottombar/RenderBottomBar.kt
@@ -50,6 +50,24 @@ fun RenderBottomBar(
         }
 
         currentDestination.isInRoute(
+            AppRoute.RouteName.HISTORY_LIST
+        ) -> {
+            NavigationBottomBar(
+                modifier = modifier,
+                currentDestination = currentDestination,
+                onClick = { route ->
+                    navController.navigate(route) {
+                        popUpTo(navController.graph.startDestinationId) {
+                            saveState = true
+                        }
+                        launchSingleTop = true
+                        restoreState = true
+                    }
+                }
+            )
+        }
+
+        currentDestination.isInRoute(
             AppRoute.RouteName.BBS_SERVICE_GROUP,
             AppRoute.RouteName.TABS
         ) -> {

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/history/HistoryListScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/history/HistoryListScaffold.kt
@@ -1,0 +1,69 @@
+package com.websarva.wings.android.bbsviewer.ui.history
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.TopAppBarState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.res.stringResource
+import androidx.navigation.NavHostController
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.websarva.wings.android.bbsviewer.R
+import com.websarva.wings.android.bbsviewer.ui.navigation.AppRoute
+import com.websarva.wings.android.bbsviewer.ui.topbar.HomeTopAppBarScreen
+
+@OptIn(ExperimentalMaterial3Api::class)
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+fun HistoryListScaffold(
+    navController: NavHostController,
+    topBarState: TopAppBarState,
+    parentPadding: PaddingValues,
+) {
+    val viewModel: HistoryViewModel = hiltViewModel()
+    val uiState by viewModel.uiState.collectAsState()
+
+    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topBarState)
+
+    Scaffold(
+        topBar = {
+            HomeTopAppBarScreen(
+                title = stringResource(R.string.history),
+                scrollBehavior = scrollBehavior
+            )
+        },
+        modifier = Modifier
+    ) { innerPadding ->
+        HistoryListScreen(
+            modifier = Modifier.padding(
+                start = parentPadding.calculateStartPadding(LayoutDirection.Ltr),
+                top = innerPadding.calculateTopPadding(),
+                end = parentPadding.calculateEndPadding(LayoutDirection.Ltr),
+                bottom = parentPadding.calculateBottomPadding()
+            ),
+            histories = uiState.histories,
+            onThreadClick = { history ->
+                navController.navigate(
+                    AppRoute.Thread(
+                        threadKey = history.history.threadKey,
+                        boardUrl = history.history.boardUrl,
+                        boardName = history.history.boardName,
+                        boardId = history.history.boardId,
+                        threadTitle = history.history.title,
+                        resCount = history.history.resCount
+                    )
+                ) { launchSingleTop = true }
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/history/HistoryListScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/history/HistoryListScreen.kt
@@ -1,0 +1,92 @@
+package com.websarva.wings.android.bbsviewer.ui.history
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.websarva.wings.android.bbsviewer.R
+import com.websarva.wings.android.bbsviewer.data.datasource.local.dao.ThreadHistoryDao
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+fun HistoryListScreen(
+    histories: List<ThreadHistoryDao.HistoryWithLastAccess>,
+    onThreadClick: (ThreadHistoryDao.HistoryWithLastAccess) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    if (histories.isEmpty()) {
+        Column(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        ) {
+            Text(stringResource(R.string.no_history))
+        }
+        return
+    }
+
+    val formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd")
+        .withZone(ZoneId.systemDefault())
+
+    LazyColumn(modifier = modifier) {
+        var currentDate: String? = null
+        histories.forEach { history ->
+            val date = formatter.format(Instant.ofEpochMilli(history.lastAccess ?: 0L))
+            if (date != currentDate) {
+                currentDate = date
+                item(key = "header_$date") {
+                    Text(
+                        text = date,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 8.dp),
+                        style = MaterialTheme.typography.titleSmall
+                    )
+                }
+            }
+            item(key = history.history.id) {
+                ListItem(
+                    modifier = Modifier
+                        .clickable { onThreadClick(history) }
+                        .padding(horizontal = 8.dp),
+                    headlineContent = { Text(history.history.title) },
+                    supportingContent = {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            Text(
+                                text = history.history.boardName,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            Text(
+                                text = history.history.resCount.toString(),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                )
+                HorizontalDivider()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/history/HistoryViewModel.kt
@@ -1,0 +1,35 @@
+package com.websarva.wings.android.bbsviewer.ui.history
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.websarva.wings.android.bbsviewer.data.repository.ThreadHistoryRepository
+import com.websarva.wings.android.bbsviewer.data.datasource.local.dao.ThreadHistoryDao
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class HistoryViewModel @Inject constructor(
+    private val repository: ThreadHistoryRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(HistoryUiState())
+    val uiState: StateFlow<HistoryUiState> = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            repository.observeHistories()
+                .collect { histories ->
+                    _uiState.update { it.copy(histories = histories) }
+                }
+        }
+    }
+}
+
+data class HistoryUiState(
+    val histories: List<ThreadHistoryDao.HistoryWithLastAccess> = emptyList()
+)

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/AppNavGraph.kt
@@ -15,6 +15,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import com.websarva.wings.android.bbsviewer.ui.board.BoardScaffold
 import com.websarva.wings.android.bbsviewer.ui.bookmarklist.BookmarkListScaffold
+import com.websarva.wings.android.bbsviewer.ui.history.HistoryListScaffold
 import com.websarva.wings.android.bbsviewer.ui.settings.SettingsViewModel
 import com.websarva.wings.android.bbsviewer.ui.tabs.TabsScaffold
 import com.websarva.wings.android.bbsviewer.ui.tabs.TabsViewModel
@@ -50,6 +51,14 @@ fun AppNavGraph(
                 topBarState = topBarState,
                 navController = navController,
                 openDrawer = openDrawer
+            )
+        }
+        //履歴一覧
+        composable<AppRoute.HistoryList> {
+            HistoryListScaffold(
+                navController = navController,
+                topBarState = topBarState,
+                parentPadding = parentPadding
             )
         }
         //掲示板一覧
@@ -112,6 +121,9 @@ sealed class AppRoute {
     data object BookmarkList : AppRoute()
 
     @Serializable
+    data object HistoryList : AppRoute()
+
+    @Serializable
     data object BbsServiceGroup : AppRoute()
 
     @Serializable
@@ -160,5 +172,6 @@ sealed class AppRoute {
         const val THREAD = "Thread"
         const val SETTINGS = "Settings"
         const val TABS = "Tabs"
+        const val HISTORY_LIST = "HistoryList"
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,4 +46,6 @@
     <string name="open_url">URLを開く</string>
     <string name="enter_url">板またはスレッドのURLを入力してください</string>
     <string name="open">開く</string>
+    <string name="history">履歴</string>
+    <string name="no_history">履歴がありません</string>
 </resources>


### PR DESCRIPTION
## Summary
- add history list ViewModel, screen and scaffold
- add `HistoryList` navigation route
- update bottom navigation bar to include History tab
- show history items grouped by date

## Testing
- `./gradlew assembleDebug -x lint`

------
https://chatgpt.com/codex/tasks/task_e_68737e502f7483328625c69356253388