### PR TITLE
Fix subject path generation

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardViewModel.kt
@@ -58,8 +58,9 @@ class BoardViewModel @AssistedInject constructor(
 
         _uiState.update { it.copy(isLoading = true) }
         try {
+            val normalizedUrl = boardUrl.trimEnd('/')
             val threads =
-                repository.getThreadList("$boardUrl/subject.txt", forceRefresh = isRefresh)
+                repository.getThreadList("$normalizedUrl/subject.txt", forceRefresh = isRefresh)
             if (threads != null) {
                 originalThreads = threads
                 applyFiltersAndSort()


### PR DESCRIPTION
## Summary
- board URL with a trailing slash caused `//subject.txt` to be requested
- trim trailing slash before adding `/subject.txt`

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6874703460e08332b0129b914f6f4c87