### PR TITLE
Fix unstable tab swiping

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardScaffold.kt
@@ -85,6 +85,18 @@ fun BoardScaffold(
         updateScrollPosition = { tab, index, offset ->
             tabsViewModel.updateBoardScrollPosition(tab.boardUrl, index, offset)
         },
+        navigateToTab = { tab ->
+            navController.navigate(
+                AppRoute.Board(
+                    boardId = tab.boardId,
+                    boardName = tab.boardName,
+                    boardUrl = tab.boardUrl
+                )
+            ) {
+                launchSingleTop = true
+                restoreState = true
+            }
+        },
         scrollBehavior = scrollBehavior ,
         topBar = { viewModel, uiState, drawer, scrollBehavior ->
             val bookmarkState = uiState.singleBookmarkState

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/RouteScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/RouteScaffold.kt
@@ -58,6 +58,7 @@ fun <TabInfo : Any, UiState : BaseUiState<UiState>, ViewModel : BaseViewModel<Ui
     topBar: @Composable (viewModel: ViewModel, uiState: UiState, openDrawer: () -> Unit, scrollBehavior: TopAppBarScrollBehavior) -> Unit,
     bottomBar: @Composable (viewModel: ViewModel, uiState: UiState) -> Unit,
     content: @Composable (viewModel: ViewModel, uiState: UiState, listState: LazyListState, modifier: Modifier,navController: NavHostController) -> Unit,
+    navigateToTab: (TabInfo) -> Unit,
     scrollBehavior: TopAppBarScrollBehavior,
     optionalSheetContent: @Composable (viewModel: ViewModel, uiState: UiState) -> Unit = { _, _ -> }
 ) {
@@ -74,6 +75,15 @@ fun <TabInfo : Any, UiState : BaseUiState<UiState>, ViewModel : BaseViewModel<Ui
         LaunchedEffect(initialPage) {
             if (pagerState.currentPage != initialPage) {
                 pagerState.scrollToPage(initialPage)
+            }
+        }
+
+        LaunchedEffect(pagerState.currentPage, openTabs) {
+            val index = pagerState.currentPage
+            openTabs.getOrNull(index)?.let { tab ->
+                if (!currentRoutePredicate(tab)) {
+                    navigateToTab(tab)
+                }
             }
         }
 

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/ThreadScaffold.kt
@@ -82,6 +82,21 @@ fun ThreadScaffold(
         updateScrollPosition = { tab, index, offset ->
             tabsViewModel.updateThreadScrollPosition(tab.key, tab.boardUrl, index, offset)
         },
+        navigateToTab = { tab ->
+            navController.navigate(
+                AppRoute.Thread(
+                    threadKey = tab.key,
+                    boardUrl = tab.boardUrl,
+                    boardName = tab.boardName,
+                    boardId = tab.boardId,
+                    threadTitle = tab.title,
+                    resCount = tab.resCount
+                )
+            ) {
+                launchSingleTop = true
+                restoreState = true
+            }
+        },
         scrollBehavior = scrollBehavior,
         topBar = { viewModel, uiState, drawer, scrollBehavior ->
             Column {


### PR DESCRIPTION
## Summary
- keep current page when swiping tabs by tracking pager state
- update navigation route on page change in `RouteScaffold`
- integrate new navigation hook in board and thread scaffolds

## Testing
- `./gradlew test --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_687478d5eb888332acef4bfe7c250078