### PR TITLE
Fix pager resetting issue

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/RouteScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/RouteScaffold.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -19,6 +20,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -68,8 +70,13 @@ fun <TabInfo : Any, UiState : BaseUiState<UiState>, ViewModel : BaseViewModel<Ui
             openTabs.indexOfFirst(currentRoutePredicate).coerceAtLeast(0)
         }
 
-        val pagerState =
-            rememberPagerState(initialPage = initialPage, pageCount = { openTabs.size })
+        val pagerState = rememberSaveable(route, saver = PagerState.Saver) {
+            PagerState(initialPage = initialPage, pageCount = { openTabs.size })
+        }
+
+        LaunchedEffect(openTabs.size) {
+            pagerState.pageCountState.value = { openTabs.size }
+        }
 
         LaunchedEffect(initialPage) {
             if (pagerState.currentPage != initialPage) {

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/tabs/TabsPagerContent.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/tabs/TabsPagerContent.kt
@@ -4,6 +4,7 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
@@ -12,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavHostController
@@ -29,7 +31,9 @@ fun TabsPagerContent(
     val openThreadTabs by tabsViewModel.openThreadTabs.collectAsState()
     val openBoardTabs by tabsViewModel.openBoardTabs.collectAsState()
 
-    val pagerState = rememberPagerState(initialPage = 0, pageCount = { 2 })
+    val pagerState = rememberSaveable(saver = PagerState.Saver) {
+        PagerState(initialPage = 0, pageCount = { 2 })
+    }
     val scope = rememberCoroutineScope()
 
     Column(modifier = modifier) {


### PR DESCRIPTION
## Summary
- keep HorizontalPager state with rememberSaveable to avoid resetting to the first tab
- persist RouteScaffold pager state and update page count when tabs change

## Testing
- `./gradlew -q help`

------
https://chatgpt.com/codex/tasks/task_e_6874e08f6b3c8332ac73573ba91d6e1c