### PR TITLE
codex/pager-state-fix

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardScaffold.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.TopAppBarState
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
@@ -44,6 +45,17 @@ fun BoardScaffold(
 ) {
     val openBoards by tabsViewModel.openBoardTabs.collectAsState()
 
+    val initialPage = remember(boardRoute, openBoards.size) {
+        openBoards.indexOfFirst { it.boardUrl == boardRoute.boardUrl }.coerceAtLeast(0)
+    }
+    val pagerState = rememberPagerState(initialPage = initialPage, pageCount = { openBoards.size })
+
+    LaunchedEffect(initialPage) {
+        if (pagerState.currentPage != initialPage) {
+            pagerState.scrollToPage(initialPage)
+        }
+    }
+
     LaunchedEffect(boardRoute) {
         val info = tabsViewModel.resolveBoardInfo(
             boardId = boardRoute.boardId,
@@ -66,6 +78,7 @@ fun BoardScaffold(
         route = boardRoute,
         tabsViewModel = tabsViewModel,
         navController = navController,
+        pagerState = pagerState,
         openDrawer = openDrawer,
         openTabs = openBoards,
         currentRoutePredicate = { it.boardUrl == boardRoute.boardUrl },

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/RouteScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/RouteScaffold.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
@@ -46,6 +45,7 @@ fun <TabInfo : Any, UiState : BaseUiState<UiState>, ViewModel : BaseViewModel<Ui
     route: AppRoute,
     tabsViewModel: TabsViewModel,
     navController: NavHostController,
+    pagerState: androidx.compose.foundation.pager.PagerState,
     openDrawer: () -> Unit,
     openTabs: List<TabInfo>,
     currentRoutePredicate: (TabInfo) -> Boolean,
@@ -64,19 +64,6 @@ fun <TabInfo : Any, UiState : BaseUiState<UiState>, ViewModel : BaseViewModel<Ui
     val currentTabInfo = openTabs.find(currentRoutePredicate)
 
     if (currentTabInfo != null) {
-        val initialPage = remember(route, openTabs.size) {
-            openTabs.indexOfFirst(currentRoutePredicate).coerceAtLeast(0)
-        }
-
-        val pagerState =
-            rememberPagerState(initialPage = initialPage, pageCount = { openTabs.size })
-
-        LaunchedEffect(initialPage) {
-            if (pagerState.currentPage != initialPage) {
-                pagerState.scrollToPage(initialPage)
-            }
-        }
-
         val bookmarkSheetState = rememberModalBottomSheetState()
         val tabListSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/ThreadScaffold.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarState
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -37,6 +38,17 @@ fun ThreadScaffold(
 ) {
     val openTabs by tabsViewModel.openThreadTabs.collectAsState()
 
+    val initialPage = remember(threadRoute, openTabs.size) {
+        openTabs.indexOfFirst { it.key == threadRoute.threadKey && it.boardUrl == threadRoute.boardUrl }.coerceAtLeast(0)
+    }
+    val pagerState = rememberPagerState(initialPage = initialPage, pageCount = { openTabs.size })
+
+    LaunchedEffect(initialPage) {
+        if (pagerState.currentPage != initialPage) {
+            pagerState.scrollToPage(initialPage)
+        }
+    }
+
     LaunchedEffect(threadRoute) {
         val info = tabsViewModel.resolveBoardInfo(
             boardId = threadRoute.boardId,
@@ -61,6 +73,7 @@ fun ThreadScaffold(
         route = threadRoute,
         tabsViewModel = tabsViewModel,
         navController = navController,
+        pagerState = pagerState,
         openDrawer = openDrawer,
         openTabs = openTabs,
         currentRoutePredicate = { it.key == threadRoute.threadKey && it.boardUrl == threadRoute.boardUrl },


### PR DESCRIPTION
## Summary
- preserve `pagerState` across tab updates in `RouteScaffold`
- manage pager state in `BoardScaffold` and `ThreadScaffold`

## Testing
- `./gradlew help --no-daemon`
- `./gradlew assembleDebug --no-daemon --dry-run`

------
https://chatgpt.com/codex/tasks/task_e_6875390a254c8332b5387590814359f9