### PR TITLE
Fix pager state recreation on tab swipe

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/RouteScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/RouteScaffold.kt
@@ -61,15 +61,20 @@ fun <TabInfo : Any, UiState : BaseUiState<UiState>, ViewModel : BaseViewModel<Ui
     scrollBehavior: TopAppBarScrollBehavior,
     optionalSheetContent: @Composable (viewModel: ViewModel, uiState: UiState) -> Unit = { _, _ -> }
 ) {
-    val currentTabInfo = openTabs.find(currentRoutePredicate)
+    val initialPage = remember(route, openTabs.size) {
+        openTabs.indexOfFirst(currentRoutePredicate).coerceAtLeast(0)
+    }
 
-    if (currentTabInfo != null) {
-        val initialPage = remember(route, openTabs.size) {
-            openTabs.indexOfFirst(currentRoutePredicate).coerceAtLeast(0)
+    val pagerState =
+        if (openTabs.isNotEmpty()) {
+            rememberPagerState(initialPage = initialPage, pageCount = { openTabs.size })
+        } else {
+            rememberPagerState(initialPage = 0, pageCount = { 1 })
         }
 
-        val pagerState =
-            rememberPagerState(initialPage = initialPage, pageCount = { openTabs.size })
+    val currentTabInfo = openTabs.find(currentRoutePredicate)
+
+    if (currentTabInfo != null && openTabs.isNotEmpty()) {
 
         LaunchedEffect(initialPage) {
             if (pagerState.currentPage != initialPage) {


### PR DESCRIPTION
## Summary
- keep pager state outside of the conditional to avoid recreation
- guard against empty tabs list with default PagerState

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6875390a254c8332b5387590814359f9