### PR TITLE
Fix flicker when saving open tabs

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/dao/OpenBoardTabDao.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/dao/OpenBoardTabDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
 import com.websarva.wings.android.bbsviewer.data.datasource.local.entity.OpenBoardTabEntity
 import kotlinx.coroutines.flow.Flow
 
@@ -17,4 +18,12 @@ interface OpenBoardTabDao {
 
     @Query("DELETE FROM open_board_tabs")
     suspend fun deleteAll()
+
+    @Transaction
+    suspend fun replaceAll(tabs: List<OpenBoardTabEntity>) {
+        deleteAll()
+        if (tabs.isNotEmpty()) {
+            insertAll(tabs)
+        }
+    }
 }

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/dao/OpenThreadTabDao.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/dao/OpenThreadTabDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
 import com.websarva.wings.android.bbsviewer.data.datasource.local.entity.OpenThreadTabEntity
 import kotlinx.coroutines.flow.Flow
 
@@ -17,4 +18,12 @@ interface OpenThreadTabDao {
 
     @Query("DELETE FROM open_thread_tabs")
     suspend fun deleteAll()
+
+    @Transaction
+    suspend fun replaceAll(tabs: List<OpenThreadTabEntity>) {
+        deleteAll()
+        if (tabs.isNotEmpty()) {
+            insertAll(tabs)
+        }
+    }
 }

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/repository/TabsRepository.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/repository/TabsRepository.kt
@@ -33,8 +33,7 @@ class TabsRepository @Inject constructor(
         }
 
     suspend fun saveOpenBoardTabs(tabs: List<BoardTabInfo>) = withContext(Dispatchers.IO) {
-        boardDao.deleteAll()
-        boardDao.insertAll(
+        boardDao.replaceAll(
             tabs.mapIndexed { index, info ->
                 OpenBoardTabEntity(
                     boardUrl = info.boardUrl,
@@ -66,8 +65,7 @@ class TabsRepository @Inject constructor(
         }
 
     suspend fun saveOpenThreadTabs(tabs: List<ThreadTabInfo>) = withContext(Dispatchers.IO) {
-        threadDao.deleteAll()
-        threadDao.insertAll(
+        threadDao.replaceAll(
             tabs.mapIndexed { index, info ->
                 OpenThreadTabEntity(
                     threadKey = info.key,


### PR DESCRIPTION
## Summary
- update tab DAO to replace all rows in a single transaction
- use new DAO methods in `TabsRepository`
- this avoids clearing the table mid-save, preventing flicker on recomposition

## Testing
- `./gradlew test --continue`

------
https://chatgpt.com/codex/tasks/task_e_6875ceaac42c83328e30340315715804