### PR TITLE
Change link colors on thread screen

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/theme/UrlColor.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/theme/UrlColor.kt
@@ -1,0 +1,19 @@
+package com.websarva.wings.android.bbsviewer.ui.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+
+@Composable
+fun imageUrlColor(): Color {
+    return if (LocalIsDarkTheme.current) md_theme_dark_orange else md_theme_light_orange
+}
+
+@Composable
+fun threadUrlColor(): Color {
+    return if (LocalIsDarkTheme.current) md_theme_dark_green else md_theme_light_green
+}
+
+@Composable
+fun urlColor(): Color {
+    return if (LocalIsDarkTheme.current) md_theme_dark_blue else md_theme_light_blue
+}

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/PostItem.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/PostItem.kt
@@ -16,6 +16,9 @@ import com.websarva.wings.android.bbsviewer.ui.navigation.AppRoute
 import com.websarva.wings.android.bbsviewer.ui.theme.idColor
 import com.websarva.wings.android.bbsviewer.ui.theme.replyColor
 import com.websarva.wings.android.bbsviewer.ui.theme.replyCountColor
+import com.websarva.wings.android.bbsviewer.ui.theme.imageUrlColor
+import com.websarva.wings.android.bbsviewer.ui.theme.threadUrlColor
+import com.websarva.wings.android.bbsviewer.ui.theme.urlColor
 import com.websarva.wings.android.bbsviewer.ui.util.buildUrlAnnotatedString
 import com.websarva.wings.android.bbsviewer.ui.util.extractImageUrls
 import java.net.URLEncoder
@@ -77,7 +80,10 @@ fun PostItem(
         val annotatedText = buildUrlAnnotatedString(
             text = post.content,
             onOpenUrl = { uriHandler.openUri(it) },
-            replyColor = replyColor()
+            replyColor = replyColor(),
+            imageColor = imageUrlColor(),
+            threadColor = threadUrlColor(),
+            urlColor = urlColor()
         )
         ClickableText(
             text = annotatedText,

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/util/LinkUtils.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/util/LinkUtils.kt
@@ -19,6 +19,9 @@ fun buildUrlAnnotatedString(
     text: String,
     onOpenUrl: (String) -> Unit,
     replyColor: Color = Color.Blue,
+    imageColor: Color = Color(0xFFFFA726),
+    threadColor: Color = Color(0xFF66BB6A),
+    urlColor: Color = Color.Blue,
 ): AnnotatedString {
     return buildAnnotatedString {
         var lastIndex = 0
@@ -33,9 +36,14 @@ fun buildUrlAnnotatedString(
             val match = text.substring(start, end)
             when {
                 urlRegex.matcher(match).matches() -> {
+                    val color = when {
+                        imageExtensions.any { match.endsWith(it, ignoreCase = true) } -> imageColor
+                        parseThreadUrl(match) != null -> threadColor
+                        else -> urlColor
+                    }
                     pushStringAnnotation(tag = "URL", annotation = match)
                     addStyle(
-                        SpanStyle(textDecoration = TextDecoration.Underline),
+                        SpanStyle(color = color, textDecoration = TextDecoration.Underline),
                         start = length,
                         end = length + match.length
                     )


### PR DESCRIPTION
## Summary
- create `UrlColor` to provide color resources for URL types
- add link color options in `buildUrlAnnotatedString`
- show URLs in green/orange/blue within thread posts depending on type

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68747a221890833284f423096822b545