### PR TITLE
Handle posts without ID

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/util/DatParser.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/util/DatParser.kt
@@ -36,7 +36,7 @@ fun parseDat(datContent: String): Pair<List<ReplyInfo>, String?> {
                     name = name,
                     email = email,
                     date = dateAndId.replace(Regex("\\s+ID:.*$"), "").trim(), // IDの部分を除去
-                    id = id ?: "???", // ID抽出に失敗した場合のデフォルト値
+                    id = id ?: "",
                     content = content
                 )
             )

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/PostItem.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/PostItem.kt
@@ -50,9 +50,12 @@ fun PostItem(
     ) {
         val idColor = idColor(idTotal)
         val headerText = buildAnnotatedString {
-            append("${post.name} ${post.email} ${post.date} ")
-            withStyle(style = SpanStyle(color = idColor)) {
-                append(if (idTotal > 1) "${post.id} (${idIndex}/${idTotal})" else post.id)
+            append("${post.name} ${post.email} ${post.date}")
+            if (post.id.isNotBlank()) {
+                append(" ")
+                withStyle(style = SpanStyle(color = idColor)) {
+                    append(if (idTotal > 1) "${post.id} (${idIndex}/${idTotal})" else post.id)
+                }
             }
         }
 

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/ReplyPopup.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/ReplyPopup.kt
@@ -59,7 +59,7 @@ fun ReplyPopup(
                         post = p,
                         postNum = posts.indexOf(p) + 1,
                         idIndex = idIndexList[posts.indexOf(p)],
-                        idTotal = idCountMap[p.id] ?: 1,
+                        idTotal = if (p.id.isBlank()) 1 else idCountMap[p.id] ?: 1,
                         navController = navController,
                         replyFromNumbers = replySourceMap[posts.indexOf(p) + 1] ?: emptyList(),
                         onReplyFromClick = { nums ->

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/ThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/ThreadScreen.kt
@@ -133,7 +133,7 @@ fun ThreadScreen(
                         post = post,
                         postNum = index + 1,
                         idIndex = idIndexList[index],
-                        idTotal = idCountMap[post.id] ?: 1,
+                        idTotal = if (post.id.isBlank()) 1 else idCountMap[post.id] ?: 1,
                         navController = navController,
                         replyFromNumbers = replySourceMap[index + 1] ?: emptyList(),
                         onReplyFromClick = { nums ->


### PR DESCRIPTION
## Summary
- avoid placeholder IDs in dat parser
- hide ID display if post lacks an ID
- guard thread/ popup displays from blank IDs

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6875f8067d98833287aebc21077eee7a