### PR TITLE
Add pull-to-refresh to thread tabs

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/tabs/TabsPagerContent.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/tabs/TabsPagerContent.kt
@@ -28,6 +28,8 @@ fun TabsPagerContent(
 ) {
     val openThreadTabs by tabsViewModel.openThreadTabs.collectAsState()
     val openBoardTabs by tabsViewModel.openBoardTabs.collectAsState()
+    val isRefreshing by tabsViewModel.isThreadsRefreshing.collectAsState()
+    val newResCounts by tabsViewModel.newResCounts.collectAsState()
 
     val pagerState = rememberPagerState(initialPage = 0, pageCount = { 2 })
     val scope = rememberCoroutineScope()
@@ -57,7 +59,11 @@ fun TabsPagerContent(
                     openTabs = openThreadTabs,
                     onCloseClick = { tabsViewModel.closeThreadTab(it) },
                     navController = navController,
-                    closeDrawer = closeDrawer
+                    closeDrawer = closeDrawer,
+                    isRefreshing = isRefreshing,
+                    onRefresh = { tabsViewModel.refreshOpenThreads() },
+                    newResCounts = newResCounts,
+                    onItemClick = { tabsViewModel.clearNewResCount(it.key, it.boardUrl) }
                 )
             }
         }


### PR DESCRIPTION
## Summary
- enable swipe refresh for thread tab list
- highlight new responses after refresh
- connect refresh behavior to TabsViewModel

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6875ffc0fad08332b6b99d613c0e78f3