### PR TITLE
Implement image preview grid

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/PostItem.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/PostItem.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.text.ClickableText
 import androidx.compose.foundation.background
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -29,6 +30,7 @@ import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import androidx.compose.material3.Text
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.layout.ContentScale
@@ -113,31 +115,33 @@ fun PostItem(
         val imageUrls = remember(post.content) { extractImageUrls(post.content) }
         if (imageUrls.isNotEmpty()) {
             Spacer(modifier = Modifier.height(8.dp))
-            LazyVerticalGrid(
-                columns = GridCells.Fixed(3),
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(4.dp),
-                verticalArrangement = Arrangement.spacedBy(4.dp),
-                userScrollEnabled = false
-            ) {
-                items(imageUrls) { url ->
-                    Box(
-                        modifier = Modifier
-                            .aspectRatio(1f)
-                            .fillMaxWidth()
-                            .background(MaterialTheme.colorScheme.surfaceVariant)
-                            .clickable {
-                                navController.navigate(
-                                    AppRoute.ImageViewer(imageUrl = URLEncoder.encode(url, StandardCharsets.UTF_8.toString()))
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                imageUrls.chunked(3).forEach { rowItems ->
+                    Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                        rowItems.forEach { url ->
+                            Box(
+                                modifier = Modifier
+                                    .weight(1f) // Row内の各要素の幅を均等に
+                                    .aspectRatio(1f)
+                                    .background(MaterialTheme.colorScheme.surfaceVariant)
+                                    .clickable {
+                                        navController.navigate(
+                                            AppRoute.ImageViewer(imageUrl = URLEncoder.encode(url, StandardCharsets.UTF_8.toString()))
+                                        )
+                                    }
+                            ) {
+                                AsyncImage(
+                                    model = url,
+                                    contentDescription = null,
+                                    contentScale = ContentScale.Crop,
+                                    modifier = Modifier.fillMaxSize()
                                 )
                             }
-                    ) {
-                        AsyncImage(
-                            model = url,
-                            contentDescription = null,
-                            contentScale = ContentScale.Crop,
-                            modifier = Modifier.fillMaxSize()
-                        )
+                        }
+                        // 行のアイテムが3つ未満の場合、残りをSpacerで埋めてレイアウトを維持
+                        repeat(3 - rowItems.size) {
+                            Spacer(modifier = Modifier.weight(1f))
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- add image placeholders arranged in a 3-column grid inside posts
- show thumbnails inside square boxes once loaded

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68760257546083329d42f409af4a8ab1