### PR TITLE
Add long-press popup menu for posts

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/PostItem.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/PostItem.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.text.ClickableText
 import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -64,12 +65,10 @@ fun PostItem(
         Column(
             modifier = modifier
                 .fillMaxWidth()
-                .pointerInput(Unit) {
-                    detectTapGestures(
-                        onLongPress = { menuExpanded = true },
-                        onTap = { /* クリック処理が必要な場合はここに実装 */ }
-                    )
-                }
+                .combinedClickable(
+                    onClick = { /* クリック処理が必要な場合はここに実装 */ },
+                    onLongClick = { menuExpanded = true }
+                )
                 .padding(horizontal = 16.dp, vertical = 8.dp),
         ) {
         val idColor = idColor(idTotal)


### PR DESCRIPTION
## Summary
- show a popup menu when long pressing a post in the thread screen
- menu displays the post number, a copy action and an NG action

## Testing
- `./gradlew assembleDebug`
- `./gradlew testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_68760fe7d1e48332b4141ed38af95e3d