### PR TITLE
Prevent duplicate bookmark group names

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/dao/BoardBookmarkGroupDao.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/dao/BoardBookmarkGroupDao.kt
@@ -31,6 +31,9 @@ interface BoardBookmarkGroupDao {
     @Query("UPDATE `groups` SET name = :name, colorName = :colorName WHERE groupId = :groupId")
     suspend fun updateGroupInfo(groupId: Long, name: String, colorName: String)
 
+    @Query("SELECT * FROM `groups` WHERE name = :name LIMIT 1")
+    suspend fun findByName(name: String): BoardBookmarkGroupEntity?
+
     @Query("DELETE FROM `groups` WHERE groupId = :groupId")
     suspend fun deleteGroupById(groupId: Long)
 

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/dao/ThreadBookmarkGroupDao.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/dao/ThreadBookmarkGroupDao.kt
@@ -34,6 +34,9 @@ interface ThreadBookmarkGroupDao {
     @Query("SELECT * FROM thread_bookmark_groups WHERE groupId = :groupId LIMIT 1")
     suspend fun getGroupById(groupId: Long): ThreadBookmarkGroupEntity?
 
+    @Query("SELECT * FROM thread_bookmark_groups WHERE name = :name LIMIT 1")
+    suspend fun findByName(name: String): ThreadBookmarkGroupEntity?
+
     // グループとそのグループに属するスレッドブックマークをまとめて取得し、グループの表示順でソート
     @Transaction // 複数のテーブルにまたがるクエリのためトランザクション化
     @Query("SELECT * FROM thread_bookmark_groups ORDER BY sortOrder ASC")

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/repository/BookmarkBoardRepository.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/repository/BookmarkBoardRepository.kt
@@ -35,18 +35,23 @@ class BookmarkBoardRepository @Inject constructor(
 
     /** 新規グループを末尾に追加 */
     suspend fun addGroupAtEnd(name: String, colorName: String) {
-        // まず既存最大 + 1
-        val nextOrder = groupDao.getMaxSortOrder() + 1
-        val newGroup = BoardBookmarkGroupEntity(
-            name      = name,
-            colorName = colorName,
-            sortOrder = nextOrder
-        )
-        groupDao.insertGroup(newGroup)
+        if (groupDao.findByName(name) == null) {
+            // まず既存最大 + 1
+            val nextOrder = groupDao.getMaxSortOrder() + 1
+            val newGroup = BoardBookmarkGroupEntity(
+                name      = name,
+                colorName = colorName,
+                sortOrder = nextOrder
+            )
+            groupDao.insertGroup(newGroup)
+        }
     }
 
     suspend fun updateGroup(groupId: Long, name: String, colorName: String) {
-        groupDao.updateGroupInfo(groupId, name, colorName)
+        val existing = groupDao.findByName(name)
+        if (existing == null || existing.groupId == groupId) {
+            groupDao.updateGroupInfo(groupId, name, colorName)
+        }
     }
 
     suspend fun deleteGroup(groupId: Long) {

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/repository/ThreadBookmarkRepository.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/repository/ThreadBookmarkRepository.kt
@@ -36,17 +36,22 @@ class ThreadBookmarkRepository @Inject constructor(
     }
 
     suspend fun addGroupAtEnd(name: String, colorName: String) {
-        val nextOrder = threadGroupDao.getMaxSortOrder() + 1
-        val newGroup = ThreadBookmarkGroupEntity(
-            name = name,
-            colorName = colorName,
-            sortOrder = nextOrder
-        )
-        threadGroupDao.insertGroup(newGroup)
+        if (threadGroupDao.findByName(name) == null) {
+            val nextOrder = threadGroupDao.getMaxSortOrder() + 1
+            val newGroup = ThreadBookmarkGroupEntity(
+                name = name,
+                colorName = colorName,
+                sortOrder = nextOrder
+            )
+            threadGroupDao.insertGroup(newGroup)
+        }
     }
 
     suspend fun updateGroup(groupId: Long, name: String, colorName: String) {
-        threadGroupDao.updateGroupInfo(groupId, name, colorName)
+        val existing = threadGroupDao.findByName(name)
+        if (existing == null || existing.groupId == groupId) {
+            threadGroupDao.updateGroupInfo(groupId, name, colorName)
+        }
     }
 
     suspend fun deleteGroup(groupId: Long) {


### PR DESCRIPTION
## Summary
- add `findByName` queries to bookmark group DAOs
- skip insert/update when the name already exists in the same group type

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_687641efb3508332bc206d4d9b9e30b3