### PR TITLE
Fix BE icon URL parsing

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/util/DatParser.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/util/DatParser.kt
@@ -82,7 +82,7 @@ private fun cleanContent(contentHtml: String): Pair<String, String> {
 
     // 1. <br> タグとBEアイコンを処理
     val removedIcon = contentHtml.replace(
-        Regex("<img[^>]*src=\"(sssp://[^\"]+)\"[^>]*>", RegexOption.IGNORE_CASE)
+        Regex("<img[^>]*src=['\"]?(sssp://[^'\" >]+)['\"]?[^>]*>", RegexOption.IGNORE_CASE)
     ) { matchResult ->
         beIconUrl = matchResult.groupValues[1].replace("sssp://", "http://")
         ""


### PR DESCRIPTION
## Summary
- fix regex to capture BE icon URL when quotes are not used

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68766324f0388332b45daa2abf893f09