### PR TITLE
feat: add ID long-press menu

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/IdMenuDialog.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/IdMenuDialog.kt
@@ -56,7 +56,7 @@ fun IdMenuDialog(
 @Composable
 fun IdMenuDialogPreview() {
     IdMenuDialog(
-        idText = "ID:abcd",
+        idText = "abcd",
         onCopyClick = {},
         onNgClick = {},
         onDismiss = {}

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/PostItem.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/PostItem.kt
@@ -212,7 +212,7 @@ fun PostItem(
         if (idMenuExpanded) {
             val clipboardManager = LocalClipboardManager.current
             IdMenuDialog(
-                idText = idText,
+                idText = post.id,
                 onCopyClick = {
                     clipboardManager.setText(AnnotatedString(post.id))
                     idMenuExpanded = false


### PR DESCRIPTION
## Summary
- show dialog when long-pressing an ID
- allow copying or NG registration for that ID

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6896e5fcafa4833289351f6473dc9c4c