### PR TITLE
タブ画面の最終ページを復元

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/TabsPreferenceLocalDataSource.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/TabsPreferenceLocalDataSource.kt
@@ -1,0 +1,8 @@
+package com.websarva.wings.android.bbsviewer.data.datasource.local
+
+import kotlinx.coroutines.flow.Flow
+
+interface TabsPreferenceLocalDataSource {
+    fun observeLastTabPage(): Flow<Int>
+    suspend fun setLastTabPage(page: Int)
+}

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/impl/TabsPreferenceLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/impl/TabsPreferenceLocalDataSourceImpl.kt
@@ -1,0 +1,29 @@
+package com.websarva.wings.android.bbsviewer.data.datasource.local.impl
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.websarva.wings.android.bbsviewer.data.datasource.local.TabsPreferenceLocalDataSource
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private val Context.dataStore by preferencesDataStore(name = "tabs")
+private val LAST_TAB_PAGE_KEY = intPreferencesKey("last_tab_page")
+
+@Singleton
+class TabsPreferenceLocalDataSourceImpl @Inject constructor(
+    @ApplicationContext private val context: Context
+) : TabsPreferenceLocalDataSource {
+    override fun observeLastTabPage(): Flow<Int> =
+        context.dataStore.data.map { prefs -> prefs[LAST_TAB_PAGE_KEY] ?: 0 }
+
+    override suspend fun setLastTabPage(page: Int) {
+        context.dataStore.edit { prefs ->
+            prefs[LAST_TAB_PAGE_KEY] = page
+        }
+    }
+}

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/repository/TabsRepository.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/repository/TabsRepository.kt
@@ -1,6 +1,7 @@
 package com.websarva.wings.android.bbsviewer.data.repository
 
 import com.websarva.wings.android.bbsviewer.data.datasource.local.dao.OpenBoardTabDao
+import com.websarva.wings.android.bbsviewer.data.datasource.local.TabsPreferenceLocalDataSource
 import com.websarva.wings.android.bbsviewer.data.datasource.local.dao.OpenThreadTabDao
 import com.websarva.wings.android.bbsviewer.data.datasource.local.entity.OpenBoardTabEntity
 import com.websarva.wings.android.bbsviewer.data.datasource.local.entity.OpenThreadTabEntity
@@ -16,7 +17,8 @@ import javax.inject.Singleton
 @Singleton
 class TabsRepository @Inject constructor(
     private val boardDao: OpenBoardTabDao,
-    private val threadDao: OpenThreadTabDao
+    private val threadDao: OpenThreadTabDao,
+    private val tabsPrefs: TabsPreferenceLocalDataSource
 ) {
     fun observeOpenBoardTabs(): Flow<List<BoardTabInfo>> =
         boardDao.observeOpenBoardTabs().map { list ->
@@ -83,4 +85,8 @@ class TabsRepository @Inject constructor(
             }
         )
     }
+
+    fun observeLastTabPage(): Flow<Int> = tabsPrefs.observeLastTabPage()
+
+    suspend fun setLastTabPage(page: Int) = tabsPrefs.setLastTabPage(page)
 }

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/di/DataSourceModule.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/di/DataSourceModule.kt
@@ -3,9 +3,11 @@ package com.websarva.wings.android.bbsviewer.di
 import com.websarva.wings.android.bbsviewer.data.datasource.local.BbsLocalDataSource
 import com.websarva.wings.android.bbsviewer.data.datasource.local.CookieLocalDataSource
 import com.websarva.wings.android.bbsviewer.data.datasource.local.SettingsLocalDataSource
+import com.websarva.wings.android.bbsviewer.data.datasource.local.TabsPreferenceLocalDataSource
 import com.websarva.wings.android.bbsviewer.data.datasource.local.impl.BbsLocalDataSourceImpl
 import com.websarva.wings.android.bbsviewer.data.datasource.local.impl.CookieLocalDataSourceImpl
 import com.websarva.wings.android.bbsviewer.data.datasource.local.impl.SettingsLocalDataSourceImpl
+import com.websarva.wings.android.bbsviewer.data.datasource.local.impl.TabsPreferenceLocalDataSourceImpl
 import com.websarva.wings.android.bbsviewer.data.datasource.remote.BbsMenuDataSource
 import com.websarva.wings.android.bbsviewer.data.datasource.remote.BoardRemoteDataSource
 import com.websarva.wings.android.bbsviewer.data.datasource.remote.DatRemoteDataSource
@@ -51,6 +53,13 @@ abstract class DataSourceModule {
     abstract fun bindSettingsLocalDataSource(
         impl: SettingsLocalDataSourceImpl
     ): SettingsLocalDataSource
+
+    /** タブ表示ページ保存用 */
+    @Binds
+    @Singleton
+    abstract fun bindTabsPreferenceLocalDataSource(
+        impl: TabsPreferenceLocalDataSourceImpl
+    ): TabsPreferenceLocalDataSource
 
     /** スレッド一覧取得用 */
     @Binds

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/tabs/TabScreenContent.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/tabs/TabScreenContent.kt
@@ -33,7 +33,8 @@ fun TabScreenContent(
     tabsViewModel: TabsViewModel,
     navController: NavHostController,
     closeDrawer: () -> Unit,
-    initialPage: Int = 0
+    initialPage: Int? = null,
+    saveCurrentPage: Boolean = true
 ) {
     var showUrlDialog by remember { mutableStateOf(false) }
     val uiState by tabsViewModel.uiState.collectAsState()
@@ -59,7 +60,8 @@ fun TabScreenContent(
                 tabsViewModel = tabsViewModel,
                 navController = navController,
                 closeDrawer = closeDrawer,
-                initialPage = initialPage
+                initialPage = initialPage ?: uiState.lastTabPage,
+                saveCurrentPage = saveCurrentPage
             )
         }
 

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/tabs/TabsBottomSheet.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/tabs/TabsBottomSheet.kt
@@ -31,7 +31,8 @@ fun TabsBottomSheet(
             tabsViewModel = tabsViewModel,
             navController = navController,
             closeDrawer = onDismissRequest, // ボトムシートを閉じる
-            initialPage = initialPage
+            initialPage = initialPage,
+            saveCurrentPage = false
         )
     }
 }

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/tabs/TabsPagerContent.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/tabs/TabsPagerContent.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -25,12 +26,22 @@ fun TabsPagerContent(
     tabsViewModel: TabsViewModel,
     navController: NavHostController,
     closeDrawer: () -> Unit,
-    initialPage: Int = 0
+    initialPage: Int = 0,
+    saveCurrentPage: Boolean = true
 ) {
     val uiState by tabsViewModel.uiState.collectAsState()
-
-    val pagerState = rememberPagerState(initialPage = initialPage, pageCount = { 2 })
+    val pagerState = rememberPagerState(pageCount = { 2 })
     val scope = rememberCoroutineScope()
+
+    LaunchedEffect(initialPage) {
+        pagerState.scrollToPage(initialPage)
+    }
+
+    LaunchedEffect(pagerState.currentPage) {
+        if (saveCurrentPage) {
+            tabsViewModel.setLastTabPage(pagerState.currentPage)
+        }
+    }
 
     Column(modifier = modifier) {
         TabRow(selectedTabIndex = pagerState.currentPage) {

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/tabs/TabsUiState.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/tabs/TabsUiState.kt
@@ -10,6 +10,7 @@ data class TabsUiState(
     val threadLoaded: Boolean = false,
     val isRefreshing: Boolean = false,
     val newResCounts: Map<String, Int> = emptyMap(),
+    val lastTabPage: Int = 0,
 ) {
     // isLoadingを他の状態から計算する算出プロパティとして定義
     val isLoading: Boolean

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/tabs/TabsViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/tabs/TabsViewModel.kt
@@ -91,6 +91,11 @@ class TabsViewModel @Inject constructor(
                 }
             }
         }
+        viewModelScope.launch {
+            repository.observeLastTabPage().collect { page ->
+                _uiState.update { current -> current.copy(lastTabPage = page) }
+            }
+        }
     }
 
     /**
@@ -159,6 +164,10 @@ class TabsViewModel @Inject constructor(
             state.copy(openBoardTabs = updated)
         }
         viewModelScope.launch { repository.saveOpenBoardTabs(_uiState.value.openBoardTabs) }
+    }
+
+    fun setLastTabPage(page: Int) {
+        viewModelScope.launch { repository.setLastTabPage(page) }
     }
 
     suspend fun resolveBoardInfo(boardId: Long, boardUrl: String, boardName: String): BoardInfo {


### PR DESCRIPTION
## Summary
- DataStoreに最後に表示したタブページを保存し、再起動後も復元
- アプリ内タブ画面でページ切替を記憶し、板/スレ画面のボトムシートでは保存を行わない

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6897211ded248332bdd29c59ea58c3d9