### PR TITLE
Disable post button when required fields are empty

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/common/PostDialog.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/common/PostDialog.kt
@@ -130,8 +130,15 @@ fun PostDialog(
                     }
                 }
 
+                val isPostButtonEnabled = if (title != null && onTitleChange != null) {
+                    title.isNotBlank() && message.isNotBlank()
+                } else {
+                    message.isNotBlank()
+                }
+
                 Button(
                     onClick = { onPostClick() },
+                    enabled = isPostButtonEnabled,
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(8.dp)


### PR DESCRIPTION
## Summary
- disable post button if message is blank when posting
- require both title and message for thread creation

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6898164fceb0833292d059262335ddb5