### PR TITLE
Exclude threads with key>=5e9 from momentum and date display

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/model/ThreadConstants.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/model/ThreadConstants.kt
@@ -1,0 +1,4 @@
+package com.websarva.wings.android.bbsviewer.data.model
+
+const val THREAD_KEY_THRESHOLD = 5_000_000_000L
+

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/util/ThreadListParser.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/util/ThreadListParser.kt
@@ -10,8 +10,7 @@ import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
 import kotlin.math.max
-
-private const val THREAD_KEY_THRESHOLD = 5_000_000_000L
+import com.websarva.wings.android.bbsviewer.data.model.THREAD_KEY_THRESHOLD
 
 object ThreadListParser {
     @RequiresApi(Build.VERSION_CODES.O)

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardScreen.kt
@@ -28,8 +28,7 @@ import androidx.compose.ui.unit.dp
 import com.websarva.wings.android.bbsviewer.data.model.ThreadDate
 import com.websarva.wings.android.bbsviewer.data.model.ThreadInfo
 import java.text.DecimalFormat
-
-private const val THREAD_KEY_THRESHOLD = 5_000_000_000L
+import com.websarva.wings.android.bbsviewer.data.model.THREAD_KEY_THRESHOLD
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardViewModel.kt
@@ -18,6 +18,7 @@ import com.websarva.wings.android.bbsviewer.ui.common.BaseViewModel
 import com.websarva.wings.android.bbsviewer.ui.common.bookmark.SingleBookmarkViewModel
 import com.websarva.wings.android.bbsviewer.ui.common.bookmark.SingleBookmarkViewModelFactory
 import com.websarva.wings.android.bbsviewer.ui.util.parseServiceName
+import com.websarva.wings.android.bbsviewer.data.model.THREAD_KEY_THRESHOLD
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -146,12 +147,19 @@ class BoardViewModel @AssistedInject constructor(
             } else {
                 allThreads
             }
+
+            // スレッドキーが閾値以上のものを常に末尾に回す
+            val (normalThreads, largeKeyThreads) = filteredList.partition { thread ->
+                thread.key.toLongOrNull()?.let { it < THREAD_KEY_THRESHOLD } ?: true
+            }
+
             // 2. ソート
             val sortedList = applySort(
-                filteredList,
+                normalThreads,
                 _uiState.value.currentSortKey,
                 _uiState.value.isSortAscending
-            )
+            ) + largeKeyThreads
+
             _uiState.update { it.copy(threads = sortedList) }
         }
     }


### PR DESCRIPTION
## Summary
- Skip momentum calculation and creation date parsing for threads with keys >= 5,000,000,000
- Hide momentum and creation date on the board screen for those threads
- Exclude such threads from board momentum stats

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_689857d89d6083329488536e99e52a8c