### PR TITLE
feat: add board selection to NG ID dialog

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/dao/BoardDao.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/dao/BoardDao.kt
@@ -28,6 +28,9 @@ interface BoardDao {
     @Query("SELECT * FROM boards WHERE serviceId = :serviceId")
     fun getBoardsForService(serviceId: Long): Flow<List<BoardEntity>>
 
+    @Query("SELECT * FROM boards")
+    fun getAllBoards(): Flow<List<BoardEntity>>
+
     @Transaction
     @Query("SELECT * FROM boards WHERE boardId = :boardId")
     fun getBoardWithCategories(boardId: Long): Flow<BoardWithCategories>

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/repository/BookmarkBoardRepository.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/repository/BookmarkBoardRepository.kt
@@ -110,6 +110,9 @@ class BookmarkBoardRepository @Inject constructor(
         return boardDao.getBoardWithBookmarkAndGroupByUrlFlow(boardUrl)
     }
 
+    fun observeAllBoards(): Flow<List<BoardEntity>> =
+        boardEntityDao.getAllBoards()
+
     suspend fun findBoardByUrl(boardUrl: String): BoardEntity? =
         boardDao.findBoardByUrl(boardUrl)
 }

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/NgIdDialog.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/NgIdDialog.kt
@@ -1,42 +1,51 @@
 package com.websarva.wings.android.bbsviewer.ui.thread
 
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Card
-import androidx.compose.ui.window.Dialog
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.websarva.wings.android.bbsviewer.R
+import com.websarva.wings.android.bbsviewer.data.datasource.local.entity.BoardEntity
+import androidx.compose.ui.window.Dialog
 
 @Composable
 fun NgIdDialog(
     idText: String,
     boardText: String = "",
+    boards: List<BoardEntity>,
     onConfirm: (String, Boolean, String) -> Unit,
     onDismiss: () -> Unit
 ) {
     var text by remember { mutableStateOf(idText) }
     var board by remember { mutableStateOf(boardText) }
     var isRegex by remember { mutableStateOf(false) }
+    var showBoardDialog by remember { mutableStateOf(false) }
 
     Dialog(onDismissRequest = onDismiss) {
         Card(shape = MaterialTheme.shapes.medium) {
@@ -62,12 +71,18 @@ fun NgIdDialog(
                     modifier = Modifier.fillMaxWidth()
                 )
                 Spacer(Modifier.height(8.dp))
-                OutlinedTextField(
-                    value = board,
-                    onValueChange = { board = it },
-                    label = { Text(stringResource(R.string.target_board)) },
-                    modifier = Modifier.fillMaxWidth()
-                )
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .border(1.dp, MaterialTheme.colorScheme.outline, MaterialTheme.shapes.small)
+                        .clickable { showBoardDialog = true }
+                        .padding(16.dp)
+                ) {
+                    Text(
+                        text = if (board.isNotBlank()) board else stringResource(R.string.target_board),
+                        color = if (board.isNotBlank()) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
                 Spacer(Modifier.height(16.dp))
                 Row(
                     horizontalArrangement = Arrangement.End,
@@ -84,6 +99,17 @@ fun NgIdDialog(
             }
         }
     }
+
+    if (showBoardDialog) {
+        BoardListDialog(
+            boards = boards,
+            onSelect = {
+                board = it.name
+                showBoardDialog = false
+            },
+            onDismiss = { showBoardDialog = false }
+        )
+    }
 }
 
 @Preview(showBackground = true)
@@ -91,7 +117,49 @@ fun NgIdDialog(
 fun NgIdDialogPreview() {
     NgIdDialog(
         idText = "abcd",
+        boardText = "板1",
+        boards = listOf(BoardEntity(1, 1, "https://example.com/board1", "板1")),
         onConfirm = { _, _, _ -> },
-        onDismiss = {}
+        onDismiss = {},
     )
+}
+
+@Composable
+private fun BoardListDialog(
+    boards: List<BoardEntity>,
+    onSelect: (BoardEntity) -> Unit,
+    onDismiss: () -> Unit
+) {
+    Dialog(onDismissRequest = onDismiss) {
+        Card(shape = MaterialTheme.shapes.medium) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Text(
+                    text = stringResource(R.string.boardList),
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.align(Alignment.CenterHorizontally)
+                )
+                Spacer(Modifier.height(8.dp))
+                LazyColumn(modifier = Modifier.heightIn(max = 300.dp)) {
+                    items(boards) { b ->
+                        Text(
+                            text = b.name,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { onSelect(b) }
+                                .padding(vertical = 8.dp)
+                        )
+                    }
+                }
+                Spacer(Modifier.height(8.dp))
+                Row(
+                    horizontalArrangement = Arrangement.End,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    TextButton(onClick = onDismiss) {
+                        Text(text = stringResource(R.string.cancel))
+                    }
+                }
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/NgIdViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/NgIdViewModel.kt
@@ -1,0 +1,23 @@
+package com.websarva.wings.android.bbsviewer.ui.thread
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.websarva.wings.android.bbsviewer.data.datasource.local.entity.BoardEntity
+import com.websarva.wings.android.bbsviewer.data.repository.BookmarkBoardRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+
+@HiltViewModel
+class NgIdViewModel @Inject constructor(
+    repository: BookmarkBoardRepository
+) : ViewModel() {
+    val boards: StateFlow<List<BoardEntity>> =
+        repository.observeAllBoards().stateIn(
+            viewModelScope,
+            SharingStarted.WhileSubscribed(5000),
+            emptyList()
+        )
+}

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/PostItem.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/PostItem.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import coil3.compose.AsyncImage
+import com.websarva.wings.android.bbsviewer.data.datasource.local.entity.BoardEntity
 import com.websarva.wings.android.bbsviewer.ui.navigation.AppRoute
 import com.websarva.wings.android.bbsviewer.ui.theme.idColor
 import com.websarva.wings.android.bbsviewer.ui.theme.imageUrlColor
@@ -56,6 +57,8 @@ fun PostItem(
     idIndex: Int,
     idTotal: Int,
     navController: NavHostController,
+    boardName: String,
+    boardList: List<BoardEntity>,
     replyFromNumbers: List<Int> = emptyList(),
     onReplyFromClick: ((List<Int>) -> Unit)? = null,
     onReplyClick: ((Int) -> Unit)? = null
@@ -228,6 +231,8 @@ fun PostItem(
         if (ngDialogExpanded) {
             NgIdDialog(
                 idText = post.id,
+                boardText = boardName,
+                boards = boardList,
                 onConfirm = { _, _, _ -> ngDialogExpanded = false },
                 onDismiss = { ngDialogExpanded = false }
             )
@@ -253,5 +258,7 @@ fun ReplyCardPreview() {
         idIndex = 1,
         idTotal = 1,
         navController = NavHostController(LocalContext.current),
+        boardName = "板1",
+        boardList = listOf(BoardEntity(1, 1, "https://example.com/board1", "板1")),
     )
 }

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/ReplyPopup.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/ReplyPopup.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupPositionProvider
 import androidx.navigation.NavHostController
+import com.websarva.wings.android.bbsviewer.data.datasource.local.entity.BoardEntity
 
 data class PopupInfo(
     val posts: List<ReplyInfo>,
@@ -29,10 +30,12 @@ data class PopupInfo(
 fun ReplyPopup(
     popupStack: SnapshotStateList<PopupInfo>,
     posts: List<ReplyInfo>,
-    replySourceMap: Map<Int, List<Int>>, 
+    replySourceMap: Map<Int, List<Int>>,
     idCountMap: Map<String, Int>,
     idIndexList: List<Int>,
     navController: NavHostController,
+    boardName: String,
+    boardList: List<BoardEntity>,
     onClose: () -> Unit
 ) {
     popupStack.forEachIndexed { index, info ->
@@ -73,6 +76,8 @@ fun ReplyPopup(
                             idIndex = idIndexList[posts.indexOf(p)],
                             idTotal = if (p.id.isBlank()) 1 else idCountMap[p.id] ?: 1,
                         navController = navController,
+                        boardName = boardName,
+                        boardList = boardList,
                         replyFromNumbers = replySourceMap[posts.indexOf(p) + 1] ?: emptyList(),
                         onReplyFromClick = { nums ->
                             val off = IntOffset(

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/ThreadScaffold.kt
@@ -28,6 +28,8 @@ import com.websarva.wings.android.bbsviewer.ui.navigation.RouteScaffold
 import com.websarva.wings.android.bbsviewer.ui.tabs.TabsViewModel
 import com.websarva.wings.android.bbsviewer.ui.tabs.ThreadTabInfo
 import com.websarva.wings.android.bbsviewer.ui.util.parseBoardUrl
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.websarva.wings.android.bbsviewer.ui.thread.NgIdViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @RequiresApi(Build.VERSION_CODES.O)
@@ -40,6 +42,8 @@ fun ThreadScaffold(
     topBarState: TopAppBarState,
 ) {
     val tabsUiState by tabsViewModel.uiState.collectAsState()
+    val ngViewModel: NgIdViewModel = hiltViewModel()
+    val boardList by ngViewModel.boards.collectAsState()
 
     LaunchedEffect(threadRoute) {
         val info = tabsViewModel.resolveBoardInfo(
@@ -130,6 +134,8 @@ fun ThreadScaffold(
             ThreadScreen(
                 modifier = modifier,
                 posts = uiState.posts ?: emptyList(),
+                boardName = uiState.boardInfo.name,
+                boardList = boardList,
                 listState = listState,
                 navController = navController,
                 isRefreshing = uiState.isLoading,

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/ThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/ThreadScreen.kt
@@ -41,12 +41,15 @@ import androidx.compose.ui.unit.Velocity
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.ui.draw.rotate
 import androidx.navigation.NavHostController
+import com.websarva.wings.android.bbsviewer.data.datasource.local.entity.BoardEntity
 
 @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
 @Composable
 fun ThreadScreen(
     modifier: Modifier = Modifier,
     posts: List<ReplyInfo>,
+    boardName: String,
+    boardList: List<BoardEntity>,
     listState: LazyListState = rememberLazyListState(),
     navController: NavHostController,
     isRefreshing: Boolean = false,
@@ -135,6 +138,8 @@ fun ThreadScreen(
                         idIndex = idIndexList[index],
                         idTotal = if (post.id.isBlank()) 1 else idCountMap[post.id] ?: 1,
                         navController = navController,
+                        boardName = boardName,
+                        boardList = boardList,
                         replyFromNumbers = replySourceMap[index + 1] ?: emptyList(),
                         onReplyFromClick = { nums ->
                             val offset = if (popupStack.isEmpty()) {
@@ -190,6 +195,8 @@ fun ThreadScreen(
             idCountMap = idCountMap,
             idIndexList = idIndexList,
             navController = navController,
+            boardName = boardName,
+            boardList = boardList,
             onClose = { if (popupStack.isNotEmpty()) popupStack.removeLast() }
         )
 
@@ -218,6 +225,7 @@ fun ThreadScreen(
 }
 
 @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
+
 @Preview(showBackground = true)
 @Composable
 fun ThreadScreenPreview() {
@@ -231,16 +239,18 @@ fun ThreadScreenPreview() {
                 beLoginId = "12345",
                 beRank = "DIA(20000)",
                 beIconUrl = "http://img.2ch.net/ico/hikky2.gif",
-                content = "これはテスト投稿です。"
+                content = "これはテスト投稿です。",
             ),
             ReplyInfo(
                 name = "名無しさん",
                 email = "sage",
                 date = "2025/07/09(水) 19:41:00.123",
                 id = "test2",
-                content = "別のテスト投稿です。"
+                content = "別のテスト投稿です。",
             )
         ),
+        boardName = "板1",
+        boardList = listOf(BoardEntity(1, 1, "https://example.com/board1", "板1")),
         navController = NavHostController(LocalContext.current),
         isRefreshing = false,
         onBottomRefresh = {}


### PR DESCRIPTION
## Summary
- default NG ID board name to current board
- replace board input with selectable list of local boards

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68986caa4ce4833281eb7f557a8fae14