### PR TITLE
feat: show download progress for thumbnails

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/remote/ImageDownloadRemoteDataSource.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/remote/ImageDownloadRemoteDataSource.kt
@@ -1,0 +1,8 @@
+package com.websarva.wings.android.bbsviewer.data.datasource.remote
+
+import com.websarva.wings.android.bbsviewer.data.model.ImageDownloadState
+import kotlinx.coroutines.flow.Flow
+
+interface ImageDownloadRemoteDataSource {
+    fun downloadImage(url: String): Flow<ImageDownloadState>
+}

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/remote/impl/ImageDownloadRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/remote/impl/ImageDownloadRemoteDataSourceImpl.kt
@@ -1,0 +1,43 @@
+package com.websarva.wings.android.bbsviewer.data.datasource.remote.impl
+
+import com.websarva.wings.android.bbsviewer.data.datasource.remote.ImageDownloadRemoteDataSource
+import com.websarva.wings.android.bbsviewer.data.model.ImageDownloadState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ImageDownloadRemoteDataSourceImpl @Inject constructor(
+    private val client: OkHttpClient
+) : ImageDownloadRemoteDataSource {
+    override fun downloadImage(url: String): Flow<ImageDownloadState> = flow {
+        try {
+            val request = Request.Builder().url(url).build()
+            client.newCall(request).execute().use { response ->
+                val body = response.body ?: throw IOException("Empty body")
+                val total = body.contentLength()
+                emit(ImageDownloadState.Progress(0, total))
+                val stream = body.byteStream()
+                val buffer = ByteArray(8 * 1024)
+                val output = ByteArrayOutputStream()
+                var downloaded = 0L
+                var read: Int
+                while (stream.read(buffer).also { read = it } != -1) {
+                    output.write(buffer, 0, read)
+                    downloaded += read
+                    emit(ImageDownloadState.Progress(downloaded, total))
+                }
+                emit(ImageDownloadState.Success(output.toByteArray()))
+            }
+        } catch (e: Exception) {
+            emit(ImageDownloadState.Error(e))
+        }
+    }.flowOn(Dispatchers.IO)
+}

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/model/ImageDownloadState.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/model/ImageDownloadState.kt
@@ -1,0 +1,7 @@
+package com.websarva.wings.android.bbsviewer.data.model
+
+sealed class ImageDownloadState {
+    data class Progress(val downloaded: Long, val total: Long) : ImageDownloadState()
+    data class Success(val data: ByteArray) : ImageDownloadState()
+    data class Error(val throwable: Throwable? = null) : ImageDownloadState()
+}

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/repository/ImageDownloadRepository.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/repository/ImageDownloadRepository.kt
@@ -1,0 +1,14 @@
+package com.websarva.wings.android.bbsviewer.data.repository
+
+import com.websarva.wings.android.bbsviewer.data.datasource.remote.ImageDownloadRemoteDataSource
+import com.websarva.wings.android.bbsviewer.data.model.ImageDownloadState
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ImageDownloadRepository @Inject constructor(
+    private val remote: ImageDownloadRemoteDataSource
+) {
+    fun downloadImage(url: String): Flow<ImageDownloadState> = remote.downloadImage(url)
+}

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/di/DataSourceModule.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/di/DataSourceModule.kt
@@ -19,7 +19,9 @@ import com.websarva.wings.android.bbsviewer.data.datasource.remote.ThreadCreateR
 import com.websarva.wings.android.bbsviewer.data.datasource.remote.impl.PostRemoteDataSourceImpl
 import com.websarva.wings.android.bbsviewer.data.datasource.remote.impl.ThreadCreateRemoteDataSourceImpl
 import com.websarva.wings.android.bbsviewer.data.datasource.remote.ImageUploadRemoteDataSource
+import com.websarva.wings.android.bbsviewer.data.datasource.remote.ImageDownloadRemoteDataSource
 import com.websarva.wings.android.bbsviewer.data.datasource.remote.impl.ImageUploadRemoteDataSourceImpl
+import com.websarva.wings.android.bbsviewer.data.datasource.remote.impl.ImageDownloadRemoteDataSourceImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -88,6 +90,13 @@ abstract class DataSourceModule {
     abstract fun bindImageUploadRemoteDataSource(
         impl: ImageUploadRemoteDataSourceImpl
     ): ImageUploadRemoteDataSource
+
+    /** 画像ダウンロード用 */
+    @Binds
+    @Singleton
+    abstract fun bindImageDownloadRemoteDataSource(
+        impl: ImageDownloadRemoteDataSourceImpl
+    ): ImageDownloadRemoteDataSource
 
     /** クッキー永続化用 */
     @Binds

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/common/ImageThumbnailGrid.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/common/ImageThumbnailGrid.kt
@@ -1,5 +1,6 @@
 package com.websarva.wings.android.bbsviewer.ui.common
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -9,12 +10,19 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
-import coil3.compose.AsyncImage
+import androidx.hilt.navigation.compose.hiltViewModel
 
 /**
  * 画像URLのリストをサムネイルとして表示するグリッド。
@@ -24,12 +32,17 @@ import coil3.compose.AsyncImage
 fun ImageThumbnailGrid(
     imageUrls: List<String>,
     modifier: Modifier = Modifier,
-    onImageClick: (String) -> Unit
+    onImageClick: (String) -> Unit,
+    viewModel: ImageThumbnailViewModel = hiltViewModel()
 ) {
+    val stateMap by viewModel.imageStates.collectAsState()
+
     Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(4.dp)) {
         imageUrls.chunked(3).forEach { rowItems ->
             Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
                 rowItems.forEach { url ->
+                    LaunchedEffect(url) { viewModel.loadImage(url) }
+                    val itemState = stateMap[url]
                     Box(
                         modifier = Modifier
                             .weight(1f)
@@ -37,12 +50,33 @@ fun ImageThumbnailGrid(
                             .background(MaterialTheme.colorScheme.surfaceVariant)
                             .clickable { onImageClick(url) }
                     ) {
-                        AsyncImage(
-                            model = url,
-                            contentDescription = null,
-                            contentScale = ContentScale.Fit,
-                            modifier = Modifier.fillMaxSize()
-                        )
+                        itemState?.bitmap?.let { bmp ->
+                            Image(
+                                bitmap = bmp.asImageBitmap(),
+                                contentDescription = null,
+                                contentScale = ContentScale.Fit,
+                                modifier = Modifier.fillMaxSize()
+                            )
+                        }
+
+                        if (itemState == null || itemState.isLoading) {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .background(MaterialTheme.colorScheme.surfaceVariant),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                                    CircularProgressIndicator()
+                                    if (itemState?.total?.let { it > 0L } == true) {
+                                        Text(
+                                            text = "${formatBytes(itemState.downloaded)} / ${formatBytes(itemState.total)}",
+                                            style = MaterialTheme.typography.labelSmall
+                                        )
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
                 repeat(3 - rowItems.size) {
@@ -50,6 +84,16 @@ fun ImageThumbnailGrid(
                 }
             }
         }
+    }
+}
+
+private fun formatBytes(bytes: Long): String {
+    val kb = bytes / 1024.0
+    val mb = kb / 1024.0
+    return when {
+        mb >= 1 -> String.format("%.1f MB", mb)
+        kb >= 1 -> String.format("%.1f KB", kb)
+        else -> "$bytes B"
     }
 }
 

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/common/ImageThumbnailViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/common/ImageThumbnailViewModel.kt
@@ -1,0 +1,60 @@
+package com.websarva.wings.android.bbsviewer.ui.common
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.websarva.wings.android.bbsviewer.data.model.ImageDownloadState
+import com.websarva.wings.android.bbsviewer.data.repository.ImageDownloadRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class ImageThumbnailViewModel @Inject constructor(
+    private val repository: ImageDownloadRepository
+) : ViewModel() {
+
+    private val _imageStates = MutableStateFlow<Map<String, ImageThumbnailItemState>>(emptyMap())
+    val imageStates: StateFlow<Map<String, ImageThumbnailItemState>> = _imageStates
+
+    fun loadImage(url: String) {
+        if (_imageStates.value.containsKey(url)) return
+
+        viewModelScope.launch {
+            repository.downloadImage(url).collect { result ->
+                when (result) {
+                    is ImageDownloadState.Progress -> {
+                        _imageStates.update { current ->
+                            val state = current[url] ?: ImageThumbnailItemState()
+                            current + (url to state.copy(downloaded = result.downloaded, total = result.total))
+                        }
+                    }
+                    is ImageDownloadState.Success -> {
+                        val bmp = BitmapFactory.decodeByteArray(result.data, 0, result.data.size)
+                        _imageStates.update { current ->
+                            val state = current[url] ?: ImageThumbnailItemState()
+                            current + (url to state.copy(bitmap = bmp, isLoading = false))
+                        }
+                    }
+                    is ImageDownloadState.Error -> {
+                        _imageStates.update { current ->
+                            val state = current[url] ?: ImageThumbnailItemState()
+                            current + (url to state.copy(isLoading = false))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+data class ImageThumbnailItemState(
+    val bitmap: Bitmap? = null,
+    val downloaded: Long = 0L,
+    val total: Long = 0L,
+    val isLoading: Boolean = true,
+)


### PR DESCRIPTION
## Summary
- separate image download logic into data, viewmodel, and UI layers
- show progress indicator via ImageThumbnailViewModel

## Testing
- `./gradlew :app:compileDebugKotlin`
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_689c57c3feb4833284b31bfa7d509a02