### PR TITLE
feat: persist NG IDs in local database

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/AppDatabase.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/AppDatabase.kt
@@ -13,6 +13,7 @@ import com.websarva.wings.android.bbsviewer.data.datasource.local.dao.ThreadBook
 import com.websarva.wings.android.bbsviewer.data.datasource.local.dao.OpenBoardTabDao
 import com.websarva.wings.android.bbsviewer.data.datasource.local.dao.OpenThreadTabDao
 import com.websarva.wings.android.bbsviewer.data.datasource.local.dao.ThreadHistoryDao
+import com.websarva.wings.android.bbsviewer.data.datasource.local.dao.NgIdDao
 import com.websarva.wings.android.bbsviewer.data.datasource.local.entity.BbsServiceEntity
 import com.websarva.wings.android.bbsviewer.data.datasource.local.entity.BoardCategoryCrossRef
 import com.websarva.wings.android.bbsviewer.data.datasource.local.entity.BoardEntity
@@ -25,6 +26,7 @@ import com.websarva.wings.android.bbsviewer.data.datasource.local.entity.OpenBoa
 import com.websarva.wings.android.bbsviewer.data.datasource.local.entity.OpenThreadTabEntity
 import com.websarva.wings.android.bbsviewer.data.datasource.local.entity.ThreadHistoryEntity
 import com.websarva.wings.android.bbsviewer.data.datasource.local.entity.ThreadHistoryAccessEntity
+import com.websarva.wings.android.bbsviewer.data.datasource.local.entity.NgIdEntity
 
 @Database(
     entities = [
@@ -39,9 +41,10 @@ import com.websarva.wings.android.bbsviewer.data.datasource.local.entity.ThreadH
         OpenBoardTabEntity::class,
         OpenThreadTabEntity::class,
         ThreadHistoryEntity::class,
-        ThreadHistoryAccessEntity::class
+        ThreadHistoryAccessEntity::class,
+        NgIdEntity::class
     ],
-    version = 4,
+    version = 5,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -56,4 +59,5 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun openBoardTabDao(): OpenBoardTabDao
     abstract fun openThreadTabDao(): OpenThreadTabDao
     abstract fun threadHistoryDao(): ThreadHistoryDao
+    abstract fun ngIdDao(): NgIdDao
 }

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/dao/NgIdDao.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/dao/NgIdDao.kt
@@ -1,0 +1,17 @@
+package com.websarva.wings.android.bbsviewer.data.datasource.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.websarva.wings.android.bbsviewer.data.datasource.local.entity.NgIdEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface NgIdDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(ngId: NgIdEntity): Long
+
+    @Query("SELECT * FROM ng_ids")
+    fun getAll(): Flow<List<NgIdEntity>>
+}

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/entity/NgIdEntity.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/entity/NgIdEntity.kt
@@ -1,0 +1,25 @@
+package com.websarva.wings.android.bbsviewer.data.datasource.local.entity
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "ng_ids",
+    foreignKeys = [
+        ForeignKey(
+            entity = BoardEntity::class,
+            parentColumns = ["boardId"],
+            childColumns = ["boardId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index("boardId")]
+)
+data class NgIdEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val pattern: String,
+    val isRegex: Boolean,
+    val boardId: Long?
+)

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/repository/NgIdRepository.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/repository/NgIdRepository.kt
@@ -1,0 +1,15 @@
+package com.websarva.wings.android.bbsviewer.data.repository
+
+import com.websarva.wings.android.bbsviewer.data.datasource.local.dao.NgIdDao
+import com.websarva.wings.android.bbsviewer.data.datasource.local.entity.NgIdEntity
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class NgIdRepository @Inject constructor(
+    private val dao: NgIdDao
+) {
+    suspend fun addNgId(pattern: String, isRegex: Boolean, boardId: Long?) {
+        dao.insert(NgIdEntity(pattern = pattern, isRegex = isRegex, boardId = boardId))
+    }
+}

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/dialog/NgIdDialog.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/dialog/NgIdDialog.kt
@@ -39,8 +39,8 @@ import com.websarva.wings.android.bbsviewer.ui.thread.viewmodel.NgIdViewModel
 @Composable
 fun NgIdDialogRoute(
     idText: String,
-    boardText: String = "",
-    onConfirm: (String, Boolean, String) -> Unit,
+    boardName: String = "",
+    boardId: Long? = null,
     onDismiss: () -> Unit,
     viewModel: NgIdViewModel = hiltViewModel(),
 ) {
@@ -48,14 +48,17 @@ fun NgIdDialogRoute(
     val boards = viewModel.filteredBoards.collectAsState().value
 
     // 初期値反映
-    LaunchedEffect(idText, boardText) {
-        viewModel.initialize(idText, boardText)
+    LaunchedEffect(idText, boardName, boardId) {
+        viewModel.initialize(idText, boardName, boardId)
     }
 
     NgIdDialog(
         uiState = uiState,
         onDismiss = onDismiss,
-        onConfirmClick = { onConfirm(uiState.text, uiState.isRegex, uiState.board) },
+        onConfirmClick = {
+            viewModel.saveNgId()
+            onDismiss()
+        },
         onTextChange = { viewModel.setText(it) },
         onRegexChange = { viewModel.setRegex(it) },
         onOpenBoardDialog = { viewModel.setShowBoardDialog(true) },
@@ -113,7 +116,7 @@ fun NgIdDialog(
                         if (uiState.isAllBoards) {
                             stringResource(R.string.all_boards)
                         } else {
-                            uiState.board.ifEmpty { stringResource(R.string.board) }
+                            uiState.boardName.ifEmpty { stringResource(R.string.board) }
                         }
                     )
                 }

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/dialog/ReplyPopup.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/dialog/ReplyPopup.kt
@@ -36,6 +36,7 @@ fun ReplyPopup(
     idIndexList: List<Int>,
     navController: NavHostController,
     boardName: String,
+    boardId: Long,
     onClose: () -> Unit
 ) {
     popupStack.forEachIndexed { index, info ->
@@ -77,6 +78,7 @@ fun ReplyPopup(
                             idTotal = if (p.id.isBlank()) 1 else idCountMap[p.id] ?: 1,
                         navController = navController,
                         boardName = boardName,
+                        boardId = boardId,
                         replyFromNumbers = replySourceMap[posts.indexOf(p) + 1] ?: emptyList(),
                         onReplyFromClick = { nums ->
                             val off = IntOffset(

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/item/PostItem.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/item/PostItem.kt
@@ -58,6 +58,7 @@ fun PostItem(
     idTotal: Int,
     navController: NavHostController,
     boardName: String,
+    boardId: Long,
     replyFromNumbers: List<Int> = emptyList(),
     onReplyFromClick: ((List<Int>) -> Unit)? = null,
     onReplyClick: ((Int) -> Unit)? = null
@@ -208,8 +209,8 @@ fun PostItem(
         if (ngDialogExpanded) {
             NgIdDialogRoute(
                 idText = post.id,
-                boardText = boardName,
-                onConfirm = { _, _, _ -> ngDialogExpanded = false },
+                boardName = boardName,
+                boardId = boardId.takeIf { it != 0L },
                 onDismiss = { ngDialogExpanded = false }
             )
         }
@@ -235,5 +236,6 @@ fun ReplyCardPreview() {
         idTotal = 1,
         navController = NavHostController(LocalContext.current),
         boardName = "board",
+        boardId = 0L,
     )
 }

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/screen/ThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/screen/ThreadScreen.kt
@@ -118,6 +118,7 @@ fun ThreadScreen(
                         idTotal = if (post.id.isBlank()) 1 else uiState.idCountMap[post.id] ?: 1,
                         navController = navController,
                         boardName = uiState.boardInfo.name,
+                        boardId = uiState.boardInfo.boardId,
                         replyFromNumbers = uiState.replySourceMap[index + 1] ?: emptyList(),
                         onReplyFromClick = { nums ->
                             val offset = if (popupStack.isEmpty()) {
@@ -174,6 +175,7 @@ fun ThreadScreen(
             idIndexList = uiState.idIndexList,
             navController = navController,
             boardName = uiState.boardInfo.name,
+            boardId = uiState.boardInfo.boardId,
             onClose = { if (popupStack.isNotEmpty()) popupStack.removeLast() }
         )
 

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/state/NgIdUiState.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/state/NgIdUiState.kt
@@ -2,7 +2,8 @@ package com.websarva.wings.android.bbsviewer.ui.thread.state
 
 data class NgIdUiState(
     val text: String = "",
-    val board: String = "",
+    val boardName: String = "",
+    val boardId: Long? = null,
     val boardQuery: String = "",
     val isAllBoards: Boolean = false,
     val isRegex: Boolean = false,


### PR DESCRIPTION
## Summary
- NgIdDialogの保存操作でNG対象をRoomに永続化
- NG IDエンティティとDAOを追加し、板IDはnullで全板を示す
- Thread画面から板IDを渡せるようUI層を調整

## Testing
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_689d9a0965b8833282f7a477b80ad6b2