### PR TITLE
feat: boardId をルート遷移時に自動解決できるよう変更

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/AppNavGraph.kt
@@ -141,14 +141,18 @@ sealed class AppRoute {
     ) : AppRoute()
 
     @Serializable
-    data class Board(val boardId: Long, val boardName: String, val boardUrl: String) : AppRoute()
+    data class Board(
+        val boardId: Long? = null,
+        val boardName: String,
+        val boardUrl: String
+    ) : AppRoute()
 
     @Serializable
     data class Thread(
         val threadKey: String,     // 必須：スレッド識別子
         val boardUrl: String,      // 必須：板URL（datUrl導出、投稿情報のため）
         val boardName: String,     // 推奨：表示用
-        val boardId: Long,         // 推奨：将来的な機能（板情報連携）のため
+        val boardId: Long? = null, // 推奨：将来的な機能（板情報連携）のため
         val threadTitle: String,   // 推奨：UX向上（即時タイトル表示）のため
         val resCount: Int = 0      // 表示用: レス数
     ) : AppRoute()

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/tabs/TabScreenContent.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/tabs/TabScreenContent.kt
@@ -80,7 +80,7 @@ fun TabScreenContent(
                                 threadKey = key,
                                 boardUrl = boardUrl,
                                 boardName = board,
-                                boardId = 0L,
+                                boardId = null,
                                 threadTitle = url
                             )
                         ) { launchSingleTop = true }
@@ -89,7 +89,7 @@ fun TabScreenContent(
                             val boardUrl = "https://$host/$board/"
                             navController.navigate(
                                 AppRoute.Board(
-                                    boardId = 0L,
+                                    boardId = null,
                                     boardName = boardUrl,
                                     boardUrl = boardUrl
                                 )

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/tabs/TabsViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/tabs/TabsViewModel.kt
@@ -170,15 +170,16 @@ class TabsViewModel @Inject constructor(
         viewModelScope.launch { repository.saveOpenBoardTabs(_uiState.value.openBoardTabs) }
     }
 
-    suspend fun resolveBoardInfo(boardId: Long, boardUrl: String, boardName: String): BoardInfo {
-        if (boardId != 0L) return BoardInfo(boardId, boardName, boardUrl)
+    suspend fun resolveBoardInfo(boardId: Long?, boardUrl: String, boardName: String): BoardInfo {
+        boardId?.let { return BoardInfo(it, boardName, boardUrl) }
 
         bookmarkBoardRepo.findBoardByUrl(boardUrl)?.let { entity ->
             return BoardInfo(entity.boardId, entity.name, entity.url)
         }
 
-        val name = boardRepository.fetchBoardName("${boardUrl}SETTING.TXT")
-        return BoardInfo(0L, name ?: boardName, boardUrl)
+        val name = boardRepository.fetchBoardName("${boardUrl}SETTING.TXT") ?: boardName
+        val id = bookmarkBoardRepo.insertBoardIfNotExists(boardUrl, name)
+        return BoardInfo(id, name, boardUrl)
     }
 
     /**


### PR DESCRIPTION
## Summary
- AppRoute.Board と Thread の `boardId` を null 許容 & 省略可能に変更
- boardId が null で遷移した場合、boardUrl から DB を検索し未登録なら登録して ID を取得
- URL ダイアログでの遷移時に boardId を省略して自動解決を利用

## Testing
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_689df1b40b048332a9b3bac415930e39