### PR TITLE
fix: reflect thread read status immediately on board

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/dao/ThreadHistoryDao.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/dao/ThreadHistoryDao.kt
@@ -35,6 +35,9 @@ interface ThreadHistoryDao {
     @Query("SELECT threadKey, resCount FROM thread_histories WHERE boardUrl = :boardUrl")
     suspend fun findByBoard(boardUrl: String): List<HistorySimple>
 
+    @Query("SELECT threadKey, resCount FROM thread_histories WHERE boardUrl = :boardUrl")
+    fun observeByBoard(boardUrl: String): Flow<List<HistorySimple>>
+
 
     @Insert
     suspend fun insert(history: ThreadHistoryEntity): Long

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/repository/ThreadHistoryRepository.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/repository/ThreadHistoryRepository.kt
@@ -6,6 +6,7 @@ import com.websarva.wings.android.bbsviewer.data.datasource.local.entity.ThreadH
 import com.websarva.wings.android.bbsviewer.data.model.BoardInfo
 import com.websarva.wings.android.bbsviewer.data.model.ThreadInfo
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -15,6 +16,11 @@ class ThreadHistoryRepository @Inject constructor(
 ) {
     fun observeHistories(): Flow<List<ThreadHistoryDao.HistoryWithLastAccess>> =
         dao.observeHistories()
+
+    fun observeHistoryMap(boardUrl: String): Flow<Map<String, Int>> =
+        dao.observeByBoard(boardUrl).map { list ->
+            list.associate { it.threadKey to it.resCount }
+        }
 
     suspend fun getHistoryMap(boardUrl: String): Map<String, Int> {
         return dao.findByBoard(boardUrl).associate { it.threadKey to it.resCount }


### PR DESCRIPTION
## Summary
- monitor thread history with Flow and merge into board threads to update read markers instantly
- expose DAO/repository Flow APIs for board-specific histories

## Testing
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_689e12d3b73883329a99adaa1273ea86