### PR TITLE
feat: add general settings screen

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/bottombar/NavigationBottomBar.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/bottombar/NavigationBottomBar.kt
@@ -59,7 +59,7 @@ fun NavigationBottomBar(
             parentRoute = AppRoute.BbsServiceGroup
         ),
         TopLevelRoute(
-            route = AppRoute.Settings,
+            route = AppRoute.SettingsHome,
             name = stringResource(R.string.settings),
             icon = Icons.Default.Settings,
             parentRoute = AppRoute.Settings

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/AppNavGraph.kt
@@ -161,6 +161,15 @@ sealed class AppRoute {
     data object Settings : AppRoute()
 
     @Serializable
+    data object SettingsHome : AppRoute()
+
+    @Serializable
+    data object SettingsGeneral : AppRoute()
+
+    @Serializable
+    data object SettingsNg : AppRoute()
+
+    @Serializable
     data object Tabs : AppRoute()
 
     @Serializable
@@ -175,7 +184,10 @@ sealed class AppRoute {
         const val BOARD = "Board"
         const val THREAD = "Thread"
         const val SETTINGS = "Settings"
+        const val SETTINGS_HOME = "SettingsHome"
+        const val SETTINGS_GENERAL = "SettingsGeneral"
+        const val SETTINGS_NG = "SettingsNg"
         const val TABS = "Tabs"
         const val HISTORY_LIST = "HistoryList"
-    }
-}
+      }
+  }

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/SettingsRoute.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/SettingsRoute.kt
@@ -5,6 +5,9 @@ import androidx.compose.runtime.getValue
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.navigation
+import com.websarva.wings.android.bbsviewer.ui.settings.SettingsGeneralScreen
+import com.websarva.wings.android.bbsviewer.ui.settings.SettingsNgScreen
 import com.websarva.wings.android.bbsviewer.ui.settings.SettingsScreen
 import com.websarva.wings.android.bbsviewer.ui.settings.SettingsViewModel
 
@@ -12,11 +15,26 @@ fun NavGraphBuilder.addSettingsRoute(
     navController: NavHostController,
     viewModel: SettingsViewModel
 ) {
-    composable<AppRoute.Settings> {
-        val uiState by viewModel.uiState.collectAsState()
-        SettingsScreen(
-            isDark = uiState.isDark,
-            onToggleTheme = {viewModel.toggleTheme()}
-        )
+    navigation<AppRoute.Settings>(startDestination = AppRoute.SettingsHome) {
+        composable<AppRoute.SettingsHome> {
+            SettingsScreen(
+                onGeneralClick = { navController.navigate(AppRoute.SettingsGeneral) },
+                onNgClick = { navController.navigate(AppRoute.SettingsNg) }
+            )
+        }
+        composable<AppRoute.SettingsGeneral> {
+            val uiState by viewModel.uiState.collectAsState()
+            SettingsGeneralScreen(
+                isDark = uiState.isDark,
+                onToggleTheme = { viewModel.toggleTheme() },
+                onNavigateUp = { navController.navigateUp() }
+            )
+        }
+        composable<AppRoute.SettingsNg> {
+            SettingsNgScreen(
+                onNavigateUp = { navController.navigateUp() }
+            )
+        }
     }
 }
+

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/settings/SettingsGeneralScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/settings/SettingsGeneralScreen.kt
@@ -1,0 +1,61 @@
+package com.websarva.wings.android.bbsviewer.ui.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.websarva.wings.android.bbsviewer.ui.topbar.SmallTopAppBarScreen
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsGeneralScreen(
+    isDark: Boolean,
+    onToggleTheme: () -> Unit,
+    onNavigateUp: () -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            SmallTopAppBarScreen(
+                title = "全般",
+                onNavigateUp = onNavigateUp,
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize()
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "ダークテーマ",
+                    style = MaterialTheme.typography.bodyLarge
+                )
+                Switch(
+                    checked = isDark,
+                    onCheckedChange = { onToggleTheme() }
+                )
+            }
+            HorizontalDivider()
+        }
+    }
+}
+

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/settings/SettingsNgScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/settings/SettingsNgScreen.kt
@@ -1,0 +1,39 @@
+package com.websarva.wings.android.bbsviewer.ui.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.websarva.wings.android.bbsviewer.ui.topbar.SmallTopAppBarScreen
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsNgScreen(
+    onNavigateUp: () -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            SmallTopAppBarScreen(
+                title = "NG",
+                onNavigateUp = onNavigateUp,
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize()
+        ) {
+            Text(
+                text = "NG設定",
+                modifier = Modifier.padding(16.dp)
+            )
+        }
+    }
+}
+

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/settings/SettingsScreen.kt
@@ -1,18 +1,15 @@
 package com.websarva.wings.android.bbsviewer.ui.settings
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ListItem
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.websarva.wings.android.bbsviewer.ui.topbar.HomeTopAppBarScreen
@@ -20,8 +17,8 @@ import com.websarva.wings.android.bbsviewer.ui.topbar.HomeTopAppBarScreen
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(
-    isDark: Boolean,
-    onToggleTheme: () -> Unit,
+    onGeneralClick: () -> Unit,
+    onNgClick: () -> Unit,
 ) {
     Scaffold(
         topBar = {
@@ -32,31 +29,26 @@ fun SettingsScreen(
             )
         }
     ) { innerPadding ->
-        Column(
+        LazyColumn(
             modifier = Modifier
                 .padding(innerPadding)
                 .fillMaxSize()
         ) {
-            // 「ダークテーマ」スイッチ
-            Row(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(horizontal = 16.dp, vertical = 12.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceBetween
-            ) {
-                Text(
-                    text = "ダークテーマ",
-                    style = MaterialTheme.typography.bodyLarge
+            item {
+                ListItem(
+                    modifier = Modifier.clickable(onClick = onGeneralClick),
+                    headlineContent = { Text("全般") }
                 )
-                Switch(
-                    checked = isDark,
-                    onCheckedChange = { onToggleTheme() }
-                )
+                HorizontalDivider()
             }
-            HorizontalDivider()
-            // → 他の設定項目も同様に Row＋Switch/TextField 等で追加
+            item {
+                ListItem(
+                    modifier = Modifier.clickable(onClick = onNgClick),
+                    headlineContent = { Text("NG") }
+                )
+                HorizontalDivider()
+            }
         }
     }
-
 }
+


### PR DESCRIPTION
## Summary
- add General and NG entries in settings screen
- move dark theme toggle to new General settings screen
- stub NG settings screen and update navigation

## Testing
- `./gradlew :app:lintDebug` *(fails: NewApi in ThreadScaffold.kt)*
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_689ec1764618833287b40e08b30d043e