### PR TITLE
feat: add name long-press dialog

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/dialog/NgDialog.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/dialog/NgDialog.kt
@@ -37,26 +37,29 @@ import com.websarva.wings.android.bbsviewer.ui.thread.state.NgIdUiState
 import com.websarva.wings.android.bbsviewer.ui.thread.viewmodel.NgIdViewModel
 
 @Composable
-fun NgIdDialogRoute(
-    idText: String,
+fun NgDialogRoute(
+    text: String,
+    labelResId: Int = R.string.id_label,
     boardName: String = "",
     boardId: Long? = null,
     onDismiss: () -> Unit,
     viewModel: NgIdViewModel = hiltViewModel(),
+    onConfirm: () -> Unit = { viewModel.saveNgId() },
 ) {
     val uiState = viewModel.uiState.collectAsState().value
     val boards = viewModel.filteredBoards.collectAsState().value
 
     // 初期値反映
-    LaunchedEffect(idText, boardName, boardId) {
-        viewModel.initialize(idText, boardName, boardId)
+    LaunchedEffect(text, boardName, boardId) {
+        viewModel.initialize(text, boardName, boardId)
     }
 
-    NgIdDialog(
+    NgDialog(
         uiState = uiState,
+        labelResId = labelResId,
         onDismiss = onDismiss,
         onConfirmClick = {
-            viewModel.saveNgId()
+            onConfirm()
             onDismiss()
         },
         onTextChange = { viewModel.setText(it) },
@@ -70,8 +73,9 @@ fun NgIdDialogRoute(
 }
 
 @Composable
-fun NgIdDialog(
+fun NgDialog(
     uiState: NgIdUiState,
+    labelResId: Int,
     onDismiss: () -> Unit,
     onConfirmClick: () -> Unit,
     onTextChange: (String) -> Unit,
@@ -102,8 +106,8 @@ fun NgIdDialog(
                 OutlinedTextField(
                     value = uiState.text,
                     onValueChange = onTextChange,
-                    label = { Text(stringResource(R.string.id_label)) },
-                    modifier = Modifier.fillMaxWidth()
+                    label = { Text(stringResource(labelResId)) },
+                    modifier = Modifier.fillMaxWidth(),
                 )
                 Spacer(Modifier.height(8.dp))
                 Text(text = stringResource(R.string.target_board))
@@ -193,9 +197,10 @@ fun BoardListDialog(
 
 @Preview(showBackground = true)
 @Composable
-fun NgIdDialogPreview() {
-    NgIdDialog(
+fun NgDialogPreview() {
+    NgDialog(
         uiState = NgIdUiState(text = "abcd"),
+        labelResId = R.string.id_label,
         onDismiss = {},
         onConfirmClick = {},
         onTextChange = {},

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/dialog/TextMenuDialog.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/dialog/TextMenuDialog.kt
@@ -13,37 +13,37 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.tooling.preview.Preview
 import com.websarva.wings.android.bbsviewer.R
 
 @Composable
-fun IdMenuDialog(
-    idText: String,
+fun TextMenuDialog(
+    text: String,
     onCopyClick: () -> Unit,
     onNgClick: () -> Unit,
-    onDismiss: () -> Unit
+    onDismiss: () -> Unit,
 ) {
     Dialog(onDismissRequest = onDismiss) {
         Card(shape = MaterialTheme.shapes.medium) {
             Column(modifier = Modifier.padding(16.dp)) {
                 Text(
-                    text = idText,
+                    text = text,
                     style = MaterialTheme.typography.titleMedium,
-                    modifier = Modifier.align(Alignment.CenterHorizontally)
+                    modifier = Modifier.align(Alignment.CenterHorizontally),
                 )
                 Spacer(Modifier.height(8.dp))
                 Button(
                     onClick = onCopyClick,
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
                 ) {
                     Text(text = stringResource(R.string.copy))
                 }
                 Spacer(Modifier.height(8.dp))
                 Button(
                     onClick = onNgClick,
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
                 ) {
                     Text(text = stringResource(R.string.ng_registration))
                 }
@@ -54,11 +54,11 @@ fun IdMenuDialog(
 
 @Preview(showBackground = true)
 @Composable
-fun IdMenuDialogPreview() {
-    IdMenuDialog(
-        idText = "abcd",
+fun TextMenuDialogPreview() {
+    TextMenuDialog(
+        text = "abcd",
         onCopyClick = {},
         onNgClick = {},
-        onDismiss = {}
+        onDismiss = {},
     )
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,6 +57,7 @@
     <string name="target_board">対象の板</string>
     <string name="id_label">ID</string>
     <string name="name">name</string>
+    <string name="name_label">名前</string>
     <string name="all_boards">すべての板</string>
     <string name="search_board_hint">板名またはURLで検索</string>
 </resources>


### PR DESCRIPTION
## Summary
- show menu and NG dialogs when long-pressing names in thread view
- share menu and NG dialog components for ID and name actions

## Testing
- `./gradlew :app:testDebugUnitTest --no-daemon --console=plain`
- `./gradlew :app:lintDebug --no-daemon --console=plain` *(fails: NewApi in ThreadScaffold.kt)*

------
https://chatgpt.com/codex/tasks/task_e_689ecf0990a08332a72a00b622c5d143