### PR TITLE
feat: add NG selection dialog

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/dialog/NgSelectDialog.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/dialog/NgSelectDialog.kt
@@ -1,0 +1,71 @@
+package com.websarva.wings.android.bbsviewer.ui.thread.dialog
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.websarva.wings.android.bbsviewer.R
+
+@Composable
+fun NgSelectDialog(
+    onNgIdClick: () -> Unit,
+    onNgNameClick: () -> Unit,
+    onNgWordClick: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    Dialog(onDismissRequest = onDismiss) {
+        Card(shape = MaterialTheme.shapes.medium) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Text(
+                    text = stringResource(R.string.ng_registration),
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.align(Alignment.CenterHorizontally),
+                )
+                Spacer(Modifier.height(8.dp))
+                Button(
+                    onClick = onNgIdClick,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(text = stringResource(R.string.add_to_ng_id))
+                }
+                Spacer(Modifier.height(8.dp))
+                Button(
+                    onClick = onNgNameClick,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(text = stringResource(R.string.add_to_ng_name))
+                }
+                Spacer(Modifier.height(8.dp))
+                Button(
+                    onClick = onNgWordClick,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(text = stringResource(R.string.add_to_ng_word))
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun NgSelectDialogPreview() {
+    NgSelectDialog(
+        onNgIdClick = {},
+        onNgNameClick = {},
+        onNgWordClick = {},
+        onDismiss = {},
+    )
+}

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/item/PostItem.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/item/PostItem.kt
@@ -47,6 +47,7 @@ import com.websarva.wings.android.bbsviewer.R
 import com.websarva.wings.android.bbsviewer.ui.thread.dialog.PostMenuDialog
 import com.websarva.wings.android.bbsviewer.ui.thread.dialog.TextMenuDialog
 import com.websarva.wings.android.bbsviewer.ui.thread.dialog.NgDialogRoute
+import com.websarva.wings.android.bbsviewer.ui.thread.dialog.NgSelectDialog
 import com.websarva.wings.android.bbsviewer.data.model.NgType
 import com.websarva.wings.android.bbsviewer.ui.thread.state.ReplyInfo
 
@@ -68,6 +69,7 @@ fun PostItem(
     var menuExpanded by remember { mutableStateOf(false) }
     var textMenuData by remember { mutableStateOf<Pair<String, NgType>?>(null) }
     var ngDialogData by remember { mutableStateOf<Pair<String, NgType>?>(null) }
+    var showNgSelectDialog by remember { mutableStateOf(false) }
     val idText = if (idTotal > 1) "${post.id} (${idIndex}/${idTotal})" else post.id
 
     Box {
@@ -204,8 +206,28 @@ fun PostItem(
             PostMenuDialog(
                 postNum = postNum,
                 onCopyClick = { menuExpanded = false },
-                onNgClick = { menuExpanded = false },
+                onNgClick = {
+                    menuExpanded = false
+                    showNgSelectDialog = true
+                },
                 onDismiss = { menuExpanded = false }
+            )
+        }
+        if (showNgSelectDialog) {
+            NgSelectDialog(
+                onNgIdClick = {
+                    showNgSelectDialog = false
+                    ngDialogData = post.id to NgType.USER_ID
+                },
+                onNgNameClick = {
+                    showNgSelectDialog = false
+                    ngDialogData = post.name to NgType.USER_NAME
+                },
+                onNgWordClick = {
+                    showNgSelectDialog = false
+                    ngDialogData = post.content to NgType.WORD
+                },
+                onDismiss = { showNgSelectDialog = false }
             )
         }
         textMenuData?.let { (text, type) ->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,6 +52,9 @@
     <string name="copy">コピー</string>
     <string name="ng_registration">NG登録</string>
     <string name="ng_setting">NG設定</string>
+    <string name="add_to_ng_id">NGIDに追加</string>
+    <string name="add_to_ng_name">NGNameに追加</string>
+    <string name="add_to_ng_word">NGWordに追加</string>
     <string name="string_literal">文字列</string>
     <string name="regular_expression">正規表現</string>
     <string name="target_board">対象の板</string>


### PR DESCRIPTION
## Summary
- PostMenuDialogからNG登録を選択した際にNGID/NGName/NGWordを選択できるダイアログを追加
- 投稿からNG種類を選択してNgDialogへ遷移

## Testing
- `./gradlew :app:testDebugUnitTest`
- `./gradlew :app:lintDebug` *(エラー: MainActivity must extend android.app.Activity)*

------
https://chatgpt.com/codex/tasks/task_e_689fe29407908332b2b411082924e8cd