### PR TITLE
fix: URL注釈の色をテーマに合わせてダークモード対応

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/item/PostItem.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/item/PostItem.kt
@@ -33,11 +33,7 @@ import androidx.navigation.NavHostController
 import coil3.compose.AsyncImage
 import com.websarva.wings.android.bbsviewer.ui.navigation.AppRoute
 import com.websarva.wings.android.bbsviewer.ui.theme.idColor
-import com.websarva.wings.android.bbsviewer.ui.theme.imageUrlColor
-import com.websarva.wings.android.bbsviewer.ui.theme.replyColor
 import com.websarva.wings.android.bbsviewer.ui.theme.replyCountColor
-import com.websarva.wings.android.bbsviewer.ui.theme.threadUrlColor
-import com.websarva.wings.android.bbsviewer.ui.theme.urlColor
 import com.websarva.wings.android.bbsviewer.ui.util.buildUrlAnnotatedString
 import com.websarva.wings.android.bbsviewer.ui.util.extractImageUrls
 import com.websarva.wings.android.bbsviewer.ui.common.ImageThumbnailGrid
@@ -149,11 +145,7 @@ fun PostItem(
             val uriHandler = LocalUriHandler.current
             val annotatedText = buildUrlAnnotatedString(
                 text = post.content,
-                onOpenUrl = { uriHandler.openUri(it) },
-                replyColor = replyColor(),
-                imageColor = imageUrlColor(),
-                threadColor = threadUrlColor(),
-                urlColor = urlColor()
+                onOpenUrl = { uriHandler.openUri(it) }
             )
 
             Column(horizontalAlignment = Alignment.Start) {

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/util/LinkUtils.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/util/LinkUtils.kt
@@ -1,10 +1,15 @@
 package com.websarva.wings.android.bbsviewer.ui.util
 
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextDecoration
+import com.websarva.wings.android.bbsviewer.ui.theme.imageUrlColor
+import com.websarva.wings.android.bbsviewer.ui.theme.replyColor
+import com.websarva.wings.android.bbsviewer.ui.theme.threadUrlColor
+import com.websarva.wings.android.bbsviewer.ui.theme.urlColor
 import java.util.regex.Pattern
 
 private val urlRegex: Pattern =
@@ -15,13 +20,14 @@ private val replyRegex: Pattern = Pattern.compile(">>(\\d+)")
  * 入力されたテキストからURLと返信アンカー（>>1など）を検出し、
  * それぞれクリック可能な注釈（Annotation）を付けたAnnotatedStringを生成します。
  */
+@Composable
 fun buildUrlAnnotatedString(
     text: String,
     onOpenUrl: (String) -> Unit,
-    replyColor: Color = Color.Blue,
-    imageColor: Color = Color(0xFFFFA726),
-    threadColor: Color = Color(0xFF66BB6A),
-    urlColor: Color = Color.Blue,
+    replyColor: Color = replyColor(),
+    imageColor: Color = imageUrlColor(),
+    threadColor: Color = threadUrlColor(),
+    urlColor: Color = urlColor(),
 ): AnnotatedString {
     return buildAnnotatedString {
         var lastIndex = 0


### PR DESCRIPTION
## 概要
- buildUrlAnnotatedString を `@Composable` 化し、テーマカラーを使用するように変更
- PostItem から色のハードコードを除去

## テスト
- `./gradlew :app:testDebugUnitTest`
- `./gradlew :app:lintDebug` (既存の NewApi エラーにより失敗)


------
https://chatgpt.com/codex/tasks/task_e_68a0176384a08332ae8a66cf62f8cd7f