### PR TITLE
feat: display NG list in settings with tabs

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/settings/SettingsNgScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/settings/SettingsNgScreen.kt
@@ -3,19 +3,41 @@ package com.websarva.wings.android.bbsviewer.ui.settings
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.ListItem
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.websarva.wings.android.bbsviewer.R
+import com.websarva.wings.android.bbsviewer.data.model.NgType
 import com.websarva.wings.android.bbsviewer.ui.topbar.SmallTopAppBarScreen
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsNgScreen(
     onNavigateUp: () -> Unit,
+    viewModel: SettingsNgViewModel = hiltViewModel(),
 ) {
+    val uiState by viewModel.uiState.collectAsState()
+    val tabs = listOf(
+        NgType.USER_ID,
+        NgType.USER_NAME,
+        NgType.WORD,
+        NgType.THREAD_TITLE,
+    )
+    val selectedIndex = tabs.indexOf(uiState.selectedTab)
+
     Scaffold(
         topBar = {
             SmallTopAppBarScreen(
@@ -29,10 +51,30 @@ fun SettingsNgScreen(
                 .padding(innerPadding)
                 .fillMaxSize()
         ) {
-            Text(
-                text = "NG設定",
-                modifier = Modifier.padding(16.dp)
-            )
+            TabRow(selectedTabIndex = selectedIndex) {
+                tabs.forEachIndexed { index, type ->
+                    val labelRes = when (type) {
+                        NgType.USER_ID -> R.string.id_label
+                        NgType.USER_NAME -> R.string.name_label
+                        NgType.WORD -> R.string.word_label
+                        NgType.THREAD_TITLE -> R.string.thread_title_label
+                    }
+                    Tab(
+                        selected = selectedIndex == index,
+                        onClick = { viewModel.selectTab(type) },
+                        text = { Text(stringResource(labelRes)) },
+                    )
+                }
+            }
+            val filtered = uiState.ngs.filter { it.type == uiState.selectedTab }
+            LazyColumn(modifier = Modifier.fillMaxSize()) {
+                items(filtered, key = { it.id }) { ng ->
+                    ListItem(
+                        headlineContent = { Text(ng.pattern) },
+                    )
+                    HorizontalDivider()
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/settings/SettingsNgViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/settings/SettingsNgViewModel.kt
@@ -1,0 +1,40 @@
+package com.websarva.wings.android.bbsviewer.ui.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.websarva.wings.android.bbsviewer.data.datasource.local.entity.NgEntity
+import com.websarva.wings.android.bbsviewer.data.model.NgType
+import com.websarva.wings.android.bbsviewer.data.repository.NgRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class SettingsNgViewModel @Inject constructor(
+    private val repository: NgRepository
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(SettingsNgUiState())
+    val uiState: StateFlow<SettingsNgUiState> = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            repository.observeNgs().collect { ngs ->
+                _uiState.update { it.copy(ngs = ngs) }
+            }
+        }
+    }
+
+    fun selectTab(type: NgType) {
+        _uiState.update { it.copy(selectedTab = type) }
+    }
+}
+
+data class SettingsNgUiState(
+    val ngs: List<NgEntity> = emptyList(),
+    val selectedTab: NgType = NgType.USER_ID
+)
+


### PR DESCRIPTION
## Summary
- show registered NG entries on SettingsNgScreen
- allow switching between ID, name, word and thread title via TabRow
- add SettingsNgViewModel to load NG list

## Testing
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_68a035b6ce308332a529424a238e2b4e