### PR TITLE
feat: hide current year in thread timestamps

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardScreen.kt
@@ -35,6 +35,7 @@ import com.websarva.wings.android.bbsviewer.data.model.ThreadDate
 import com.websarva.wings.android.bbsviewer.data.model.ThreadInfo
 import java.text.DecimalFormat
 import com.websarva.wings.android.bbsviewer.data.model.THREAD_KEY_THRESHOLD
+import java.time.LocalDate
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -138,8 +139,17 @@ fun ThreadCard(
                     )
                     Spacer(modifier = Modifier.width(4.dp))
                 }
+                val dateText = threadInfo.date.run {
+                    val currentYear = LocalDate.now().year
+                    val datePart = if (year == currentYear) {
+                        "$month/$day"
+                    } else {
+                        "$year/$month/$day"
+                    }
+                    "$datePart $hour:%02d".format(minute)
+                }
                 Text(
-                    text = threadInfo.date.run { "$year/$month/$day $hour:%02d".format(minute) },
+                    text = dateText,
                     modifier = Modifier.alignByBaseline(),
                     style = MaterialTheme.typography.labelMedium
                 )

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/item/PostItem.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/item/PostItem.kt
@@ -38,6 +38,7 @@ import coil3.compose.AsyncImage
 import com.websarva.wings.android.bbsviewer.ui.navigation.AppRoute
 import com.websarva.wings.android.bbsviewer.ui.theme.idColor
 import com.websarva.wings.android.bbsviewer.ui.theme.replyCountColor
+import java.time.LocalDate
 import com.websarva.wings.android.bbsviewer.ui.util.buildUrlAnnotatedString
 import com.websarva.wings.android.bbsviewer.ui.util.extractImageUrls
 import com.websarva.wings.android.bbsviewer.ui.common.ImageThumbnailGrid
@@ -114,7 +115,14 @@ fun PostItem(
                         }
                         pop()
                     }
-                    val emailDate = listOf(post.email, post.date).filter { it.isNotBlank() }.joinToString(" ")
+                    val currentYearPrefix = "${LocalDate.now().year}/"
+                    val displayDate =
+                        if (post.date.startsWith(currentYearPrefix)) {
+                            post.date.removePrefix(currentYearPrefix)
+                        } else {
+                            post.date
+                        }
+                    val emailDate = listOf(post.email, displayDate).filter { it.isNotBlank() }.joinToString(" ")
                     if (emailDate.isNotBlank()) {
                         appendSpaceIfNeeded()
                         withStyle(SpanStyle(color = MaterialTheme.colorScheme.onSurfaceVariant)) {


### PR DESCRIPTION
## Summary
- hide year if thread creation date falls in current year on board screen
- hide year if response date falls in current year on thread screen

## Testing
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_68a2bfce164c83329e096b3261d87887