### PR TITLE
fix: stabilize thread momentum

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/dao/BoardFetchMetaDao.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/dao/BoardFetchMetaDao.kt
@@ -5,11 +5,15 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import com.websarva.wings.android.bbsviewer.data.datasource.local.entity.BoardFetchMetaEntity
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface BoardFetchMetaDao {
     @Query("SELECT * FROM board_fetch_meta WHERE boardId = :boardId")
     suspend fun get(boardId: Long): BoardFetchMetaEntity?
+
+    @Query("SELECT * FROM board_fetch_meta WHERE boardId = :boardId")
+    fun observe(boardId: Long): Flow<BoardFetchMetaEntity?>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsert(entity: BoardFetchMetaEntity)


### PR DESCRIPTION
## Summary
- avoid recalculating thread momentum with current time on each recomposition
- expose `BoardFetchMetaDao.observe` to supply last fetched time for momentum

## Testing
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_68a3e498b9a0833282bb8bcbe32ab841