### PR TITLE
fix: hide new label for visited threads

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardScreen.kt
@@ -126,7 +126,7 @@ fun ThreadCard(
         Spacer(modifier = Modifier.padding(4.dp))
         Row{
             if (showInfo) {
-                if (threadInfo.isNew) {
+                if (threadInfo.isNew && !threadInfo.isVisited) {
                     Text(
                         text = stringResource(R.string.new_label),
                         modifier = Modifier

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardViewModel.kt
@@ -212,7 +212,7 @@ class BoardViewModel @AssistedInject constructor(
             val oldRes = historyMap[thread.key]
             if (oldRes != null) {
                 val diff = (thread.resCount - oldRes).coerceAtLeast(0)
-                thread.copy(isVisited = true, newResCount = diff)
+                thread.copy(isVisited = true, newResCount = diff, isNew = false)
             } else {
                 thread
             }


### PR DESCRIPTION
## Summary
- avoid showing "new" badge for threads that have already been read

## Testing
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_68a4014babc8833282fd8a5aa2a54363