### PR TITLE
fix: reset board scroll after reload

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardScaffold.kt
@@ -132,6 +132,13 @@ fun BoardScaffold(
             )
         },
         content = { viewModel, uiState, listState, modifier, navController ->
+            LaunchedEffect(uiState.resetScroll) {
+                if (uiState.resetScroll) {
+                    listState.scrollToItem(0)
+                    tabsViewModel.updateBoardScrollPosition(uiState.boardInfo.url, 0, 0)
+                    viewModel.consumeResetScroll()
+                }
+            }
             BoardScreen(
                 modifier = modifier,
                 threads = uiState.threads ?: emptyList(),

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardUiState.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardUiState.kt
@@ -26,6 +26,7 @@ data class BoardUiState(
     val showErrorWebView: Boolean = false,
     val errorHtmlContent: String = "",
     val postResultMessage: String? = null,
+    val resetScroll: Boolean = false,
     override val isLoading: Boolean = false,
     override val showTabListSheet: Boolean = false,
 ) : BaseUiState<BoardUiState> {

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardViewModel.kt
@@ -103,13 +103,17 @@ class BoardViewModel @AssistedInject constructor(
             val normalizedUrl = boardUrl.trimEnd('/')
             repository.refreshThreadList(boardInfo.boardId, "$normalizedUrl/subject.txt", refreshStartAt, isRefresh)
         } finally {
-            _uiState.update { it.copy(isLoading = false) }
+            _uiState.update { it.copy(isLoading = false, resetScroll = true) }
         }
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
     fun refreshBoardData() { // Pull-to-refresh 用のメソッド
         initialize(force = true) // 強制的に初期化処理を再実行
+    }
+
+    fun consumeResetScroll() {
+        _uiState.update { it.copy(resetScroll = false) }
     }
 
     // --- お気に入り関連の処理はBookmarkStateViewModelに委譲 ---


### PR DESCRIPTION
## Summary
- 板のスレを再取得した際にスクロール位置を先頭にリセットする

## Testing
- `./gradlew :app:testDebugUnitTest` (missing `android-35` target)


------
https://chatgpt.com/codex/tasks/task_e_68a443d4618083328179b8bab37e0420