### PR TITLE
fix: expand PostMenuDialog long-press area

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/item/PostItem.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/item/PostItem.kt
@@ -100,7 +100,7 @@ fun PostItem(
             modifier = Modifier
                 .fillMaxWidth()
                 .background(
-                    if (isPressed) MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.12f)
+                    if (isPressed) MaterialTheme.colorScheme.surfaceVariant
                     else Color.Transparent
                 )
                 .pointerInput(Unit) {


### PR DESCRIPTION
## Summary
- open PostMenuDialog on long-press of header or body text
- highlight post while long-pressing to give user feedback

## Testing
- `./gradlew :app:lintDebug :app:testDebugUnitTest` *(fails: MainActivity must extend android.app.Activity)*

------
https://chatgpt.com/codex/tasks/task_e_68a403dc2f2c8332b9f1581e5f2c998e