### PR TITLE
refactor: use combinedClickable with link annotations

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/item/PostItem.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/item/PostItem.kt
@@ -2,7 +2,13 @@ package com.websarva.wings.android.bbsviewer.ui.thread.item
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.awaitLongPressOrCancellation
+import androidx.compose.foundation.gestures.waitForUpOrCancellation
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -23,14 +29,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.ExperimentalTextApi
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.LinkInteractionListener
 import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
@@ -54,6 +61,7 @@ import java.nio.charset.StandardCharsets
 import java.time.LocalDate
 
 
+@OptIn(ExperimentalTextApi::class)
 @Composable
 fun PostItem(
     modifier: Modifier = Modifier,
@@ -73,9 +81,12 @@ fun PostItem(
     var textMenuData by remember { mutableStateOf<Pair<String, NgType>?>(null) }
     var ngDialogData by remember { mutableStateOf<Pair<String, NgType>?>(null) }
     var showNgSelectDialog by remember { mutableStateOf(false) }
-    var isColumnPressed by remember { mutableStateOf(false) }
-    var isHeaderPressed by remember { mutableStateOf(false) }
-    var isContentPressed by remember { mutableStateOf(false) }
+    val columnInteraction = remember { MutableInteractionSource() }
+    val headerInteraction = remember { MutableInteractionSource() }
+    val contentInteraction = remember { MutableInteractionSource() }
+    val isColumnPressed by columnInteraction.collectIsPressedAsState()
+    val isHeaderPressed by headerInteraction.collectIsPressedAsState()
+    val isContentPressed by contentInteraction.collectIsPressedAsState()
     val isPressed = isColumnPressed || isHeaderPressed || isContentPressed
     val idText = if (idTotal > 1) "${post.id} (${idIndex}/${idTotal})" else post.id
 
@@ -104,15 +115,20 @@ fun PostItem(
                     else Color.Transparent
                 )
                 .pointerInput(Unit) {
-                    detectTapGestures(
-                        onPress = {
-                            isColumnPressed = true
-                            tryAwaitRelease()
-                            isColumnPressed = false
-                        },
-                        onLongPress = { menuExpanded = true }
-                    )
+                    awaitEachGesture {
+                        val down = awaitFirstDown()
+                        val up = awaitLongPressOrCancellation(down.id)
+                        if (up == null) {
+                            menuExpanded = true
+                            waitForUpOrCancellation()
+                        }
+                    }
                 }
+                .combinedClickable(
+                    interactionSource = columnInteraction,
+                    indication = null,
+                    onClick = {}
+                )
                 .padding(horizontal = 16.dp, vertical = 8.dp),
         ) {
             val idColor = idColor(idTotal)
@@ -141,7 +157,14 @@ fun PostItem(
                     }
                     if (post.name.isNotBlank()) {
                         appendSpaceIfNeeded()
-                        pushStringAnnotation(tag = "NAME", annotation = post.name)
+                        pushLink(
+                            LinkAnnotation.Clickable(
+                                tag = "NAME",
+                                linkInteractionListener = LinkInteractionListener {
+                                    textMenuData = post.name to NgType.USER_NAME
+                                }
+                            )
+                        )
                         withStyle(SpanStyle(color = MaterialTheme.colorScheme.onSurfaceVariant)) {
                             append(post.name)
                         }
@@ -164,7 +187,14 @@ fun PostItem(
                     }
                     if (post.id.isNotBlank()) {
                         appendSpaceIfNeeded()
-                        pushStringAnnotation(tag = "ID", annotation = idText)
+                        pushLink(
+                            LinkAnnotation.Clickable(
+                                tag = "ID",
+                                linkInteractionListener = LinkInteractionListener {
+                                    textMenuData = idText to NgType.USER_ID
+                                }
+                            )
+                        )
                         withStyle(SpanStyle(color = idColor)) {
                             append(idText)
                         }
@@ -177,50 +207,24 @@ fun PostItem(
                         }
                     }
                 }
-                var headerLayout by remember { mutableStateOf<TextLayoutResult?>(null) }
                 Text(
                     modifier = Modifier
                         .alignByBaseline()
-                        .pointerInput(Unit) {
-                            detectTapGestures(
-                                onPress = {
-                                    isHeaderPressed = true
-                                    tryAwaitRelease()
-                                    isHeaderPressed = false
-                                },
-                                onLongPress = { offset ->
-                                    headerLayout?.let { layout ->
-                                        val pos = layout.getOffsetForPosition(offset)
-                                        val nameAnn =
-                                            headerText.getStringAnnotations("NAME", pos, pos)
-                                                .firstOrNull()
-                                        val idAnn =
-                                            headerText.getStringAnnotations("ID", pos, pos)
-                                                .firstOrNull()
-                                        when {
-                                            nameAnn != null ->
-                                                textMenuData = nameAnn.item to NgType.USER_NAME
-                                            idAnn != null ->
-                                                textMenuData = idAnn.item to NgType.USER_ID
-                                            else -> menuExpanded = true
-                                        }
-                                    } ?: run { menuExpanded = true }
-                                }
-                            )
-                        },
+                        .combinedClickable(
+                            interactionSource = headerInteraction,
+                            indication = null,
+                            onClick = {}
+                        ),
                     text = headerText,
                     style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    onTextLayout = { headerLayout = it }
                 )
             }
 
-            val uriHandler = LocalUriHandler.current
             val annotatedText = buildUrlAnnotatedString(
                 text = post.content,
-                onOpenUrl = { uriHandler.openUri(it) }
+                onReplyClick = { onReplyClick?.invoke(it) }
             )
-            var contentLayout by remember { mutableStateOf<TextLayoutResult?>(null) }
 
             Column(horizontalAlignment = Alignment.Start) {
                 if (post.beIconUrl.isNotBlank()) {
@@ -233,37 +237,15 @@ fun PostItem(
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
                     modifier = Modifier
-                        .pointerInput(Unit) {
-                            detectTapGestures(
-                                onPress = {
-                                    isContentPressed = true
-                                    tryAwaitRelease()
-                                    isContentPressed = false
-                                },
-                                onTap = { offset ->
-                                    contentLayout?.let { layout ->
-                                        val pos = layout.getOffsetForPosition(offset)
-                                        annotatedText.getStringAnnotations("URL", pos, pos)
-                                            .firstOrNull()?.let { ann ->
-                                                uriHandler.openUri(ann.item)
-                                            }
-                                        annotatedText.getStringAnnotations("REPLY", pos, pos)
-                                            .firstOrNull()?.let { ann ->
-                                                ann.item.toIntOrNull()
-                                                    ?.let { onReplyClick?.invoke(it) }
-                                            }
-                                    }
-                                },
-                                onLongPress = {
-                                    menuExpanded = true
-                                }
-                            )
-                        },
+                        .combinedClickable(
+                            interactionSource = contentInteraction,
+                            indication = null,
+                            onClick = {}
+                        ),
                     text = annotatedText,
                     style = MaterialTheme.typography.bodyMedium.copy(
                         color = MaterialTheme.colorScheme.onSurface
                     ),
-                    onTextLayout = { contentLayout = it }
                 )
             }
 


### PR DESCRIPTION
## Summary
- replace pointer-based tap detection in `PostItem` with `combinedClickable`
- use `LinkAnnotation.Clickable` to handle link taps and reply actions
- trigger post menu immediately on long press

## Testing
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_68a5476f9c348332815aa7a595698747