### PR TITLE
fix: preserve new thread markers during refresh

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardViewModel.kt
@@ -95,6 +95,7 @@ class BoardViewModel @AssistedInject constructor(
             // ignore
         } finally {
             _uiState.update { it.copy(isLoading = false, resetScroll = true) }
+            mergeHistory(currentHistoryMap)
         }
         if (!isObservingThreads) {
             startObservingThreads(boardInfo.boardId)
@@ -112,7 +113,9 @@ class BoardViewModel @AssistedInject constructor(
             }.collect { (threads, historyMap) ->
                 baseThreads = threads
                 currentHistoryMap = historyMap
-                mergeHistory(historyMap)
+                if (!_uiState.value.isLoading) {
+                    mergeHistory(historyMap)
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- avoid clearing new thread markers while refreshing threads
- apply history merge after refresh completes

## Testing
- `./gradlew :app:lintDebug` *(fails: Call requires API level 26 in BoardScreen.kt)*
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_68a5838ce880833298cfc4e27965803d