### PR TITLE
feat: add thread settings screen

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/AppNavGraph.kt
@@ -180,6 +180,9 @@ sealed class AppRoute {
     data object SettingsNg : AppRoute()
 
     @Serializable
+    data object SettingsThread : AppRoute()
+
+    @Serializable
     data object Tabs : AppRoute()
 
     @Serializable
@@ -197,6 +200,7 @@ sealed class AppRoute {
         const val SETTINGS_HOME = "SettingsHome"
         const val SETTINGS_GENERAL = "SettingsGeneral"
         const val SETTINGS_NG = "SettingsNg"
+        const val SETTINGS_THREAD = "SettingsThread"
         const val TABS = "Tabs"
         const val HISTORY_LIST = "HistoryList"
     }

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/SettingsRoute.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/SettingsRoute.kt
@@ -9,6 +9,7 @@ import androidx.navigation.compose.navigation
 import com.websarva.wings.android.bbsviewer.ui.settings.SettingsGeneralScreen
 import com.websarva.wings.android.bbsviewer.ui.settings.SettingsNgScreen
 import com.websarva.wings.android.bbsviewer.ui.settings.SettingsScreen
+import com.websarva.wings.android.bbsviewer.ui.settings.SettingsThreadScreen
 import com.websarva.wings.android.bbsviewer.ui.settings.SettingsViewModel
 
 fun NavGraphBuilder.addSettingsRoute(
@@ -25,6 +26,7 @@ fun NavGraphBuilder.addSettingsRoute(
         composable<AppRoute.SettingsHome> {
             SettingsScreen(
                 onGeneralClick = { navController.navigate(AppRoute.SettingsGeneral) },
+                onThreadClick = { navController.navigate(AppRoute.SettingsThread) },
                 onNgClick = { navController.navigate(AppRoute.SettingsNg) }
             )
         }
@@ -38,6 +40,11 @@ fun NavGraphBuilder.addSettingsRoute(
         }
         composable<AppRoute.SettingsNg> {
             SettingsNgScreen(
+                onNavigateUp = { navController.navigateUp() }
+            )
+        }
+        composable<AppRoute.SettingsThread> {
+            SettingsThreadScreen(
                 onNavigateUp = { navController.navigateUp() }
             )
         }

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/settings/SettingsScreen.kt
@@ -17,6 +17,7 @@ import com.websarva.wings.android.bbsviewer.ui.topbar.HomeTopAppBarScreen
 @Composable
 fun SettingsScreen(
     onGeneralClick: () -> Unit,
+    onThreadClick: () -> Unit,
     onNgClick: () -> Unit,
 ) {
     Scaffold(
@@ -37,6 +38,13 @@ fun SettingsScreen(
                 ListItem(
                     modifier = Modifier.clickable(onClick = onGeneralClick),
                     headlineContent = { Text("全般") }
+                )
+                HorizontalDivider()
+            }
+            item {
+                ListItem(
+                    modifier = Modifier.clickable(onClick = onThreadClick),
+                    headlineContent = { Text("スレッド") }
                 )
                 HorizontalDivider()
             }

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/settings/SettingsThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/settings/SettingsThreadScreen.kt
@@ -1,0 +1,37 @@
+package com.websarva.wings.android.bbsviewer.ui.settings
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.websarva.wings.android.bbsviewer.ui.topbar.SmallTopAppBarScreen
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsThreadScreen(
+    onNavigateUp: () -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            SmallTopAppBarScreen(
+                title = "スレッド",
+                onNavigateUp = onNavigateUp,
+            )
+        }
+    ) { innerPadding ->
+        Box(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(text = "スレッド設定")
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add "スレッド" option to settings menu
- implement thread settings screen and wire navigation

## Testing
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_68a5e1aad2bc833285664c6d7dd6c3fa