### PR TITLE
feat: add board loading progress bar

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/remote/BoardRemoteDataSource.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/remote/BoardRemoteDataSource.kt
@@ -8,7 +8,12 @@ data class SubjectFetchResult(
 )
 
 interface BoardRemoteDataSource {
-    suspend fun fetchSubjectTxt(url: String, etag: String?, lastModified: String?): SubjectFetchResult?
+    suspend fun fetchSubjectTxt(
+        url: String,
+        etag: String?,
+        lastModified: String?,
+        onProgress: (Float) -> Unit = {},
+    ): SubjectFetchResult?
 
     suspend fun fetchSettingTxt(url: String): String?
 }

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/remote/impl/BoardRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/remote/impl/BoardRemoteDataSourceImpl.kt
@@ -8,6 +8,8 @@ import kotlinx.coroutines.withContext
 import okhttp3.CacheControl
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.ResponseBody
+import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.nio.charset.Charset
 import javax.inject.Inject
@@ -20,8 +22,12 @@ class BoardRemoteDataSourceImpl @Inject constructor(
     @Named("UserAgent") private val userAgent: String
 ) : BoardRemoteDataSource {
 
-    override suspend fun fetchSubjectTxt(url: String, etag: String?, lastModified: String?): SubjectFetchResult? =
-        withContext(Dispatchers.IO) {
+    override suspend fun fetchSubjectTxt(
+        url: String,
+        etag: String?,
+        lastModified: String?,
+        onProgress: (Float) -> Unit,
+    ): SubjectFetchResult? = withContext(Dispatchers.IO) {
             val requestBuilder = Request.Builder()
                 .url(url)
                 .header("User-Agent", userAgent)
@@ -37,26 +43,32 @@ class BoardRemoteDataSourceImpl @Inject constructor(
             val request = requestBuilder.build()
 
             try {
-                val response = client.newCall(request).execute()
-                val newEtag = response.header("ETag")
-                val newLastModified = response.header("Last-Modified")
-                return@withContext when (response.code) {
-                    200 -> {
-                        val body = response.body?.bytes()?.toString(Charset.forName("Shift_JIS"))
-                        SubjectFetchResult(body, newEtag, newLastModified, 200)
-                    }
-                    304 -> {
-                        SubjectFetchResult(null, newEtag, newLastModified, 304)
-                    }
-                    else -> {
-                        Log.e("BoardRemoteDataSource", "Unexpected response code ${response.code} for $url")
-                        null
+                client.newCall(request).execute().use { response ->
+                    val newEtag = response.header("ETag")
+                    val newLastModified = response.header("Last-Modified")
+                    return@withContext when (response.code) {
+                        200 -> {
+                            val body = response.body ?: return@withContext null
+                            val bytes = readBytesWithProgress(body, onProgress)
+                            SubjectFetchResult(bytes.toString(Charset.forName("Shift_JIS")), newEtag, newLastModified, 200)
+                        }
+                        304 -> {
+                            onProgress(1f)
+                            SubjectFetchResult(null, newEtag, newLastModified, 304)
+                        }
+                        else -> {
+                            onProgress(1f)
+                            Log.e("BoardRemoteDataSource", "Unexpected response code ${response.code} for $url")
+                            null
+                        }
                     }
                 }
             } catch (e: IOException) {
+                onProgress(1f)
                 Log.e("BoardRemoteDataSource", "IOException for $url: ${e.message}", e)
                 null
             } catch (e: Exception) {
+                onProgress(1f)
                 Log.e("BoardRemoteDataSource", "Exception for $url: ${e.message}", e)
                 null
             }
@@ -81,4 +93,22 @@ class BoardRemoteDataSourceImpl @Inject constructor(
                 null
             }
         }
+
+    private fun readBytesWithProgress(body: ResponseBody, onProgress: (Float) -> Unit): ByteArray {
+        val contentLength = body.contentLength()
+        val input = body.byteStream()
+        val buffer = ByteArray(8 * 1024)
+        var bytesRead: Int
+        var total = 0L
+        val output = ByteArrayOutputStream()
+        while (input.read(buffer).also { bytesRead = it } != -1) {
+            output.write(buffer, 0, bytesRead)
+            total += bytesRead
+            if (contentLength > 0) {
+                onProgress(total.toFloat() / contentLength)
+            }
+        }
+        onProgress(1f)
+        return output.toByteArray()
+    }
 }

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/repository/BoardRepository.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/repository/BoardRepository.kt
@@ -86,10 +86,12 @@ class BoardRepository @Inject constructor(
         boardId: Long,
         subjectUrl: String,
         refreshStartAt: Long,
-        isManual: Boolean
+        isManual: Boolean,
+        onProgress: (Float) -> Unit = {},
     ): Boolean = withContext(Dispatchers.IO) {
         val meta = fetchMetaDao.get(boardId)
-        val result = remote.fetchSubjectTxt(subjectUrl, meta?.etag, meta?.lastModified) ?: return@withContext false
+        val result = remote.fetchSubjectTxt(subjectUrl, meta?.etag, meta?.lastModified, onProgress)
+            ?: return@withContext false
         val now = System.currentTimeMillis()
         when (result.statusCode) {
             304 -> {

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardScaffold.kt
@@ -158,6 +158,7 @@ fun BoardScaffold(
                 },
                 isRefreshing = uiState.isLoading,
                 onRefresh = { viewModel.refreshBoardData() },
+                loadProgress = uiState.loadProgress,
                 listState = listState
             )
             if (uiState.showInfoDialog) {

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardScreen.kt
@@ -3,6 +3,7 @@ package com.websarva.wings.android.bbsviewer.ui.board
 import android.R.attr.onClick
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -17,8 +18,10 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.ProgressIndicatorDefaults
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -45,6 +48,7 @@ fun BoardScreen(
     onClick: (ThreadInfo) -> Unit,
     isRefreshing: Boolean,
     onRefresh: () -> Unit,
+    loadProgress: Float,
     listState: LazyListState = rememberLazyListState()
 ) {
     val (momentumMean, momentumStd) = remember(threads) {
@@ -65,11 +69,12 @@ fun BoardScreen(
         isRefreshing = isRefreshing,
         onRefresh = onRefresh,
     ) {
-        LazyColumn(
-            modifier = Modifier
-                .fillMaxSize(),
-            state = listState,
-        ) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize(),
+                state = listState,
+            ) {
             // リスト全体の先頭に区切り線を追加
             if (threads.isNotEmpty()) { // リストが空でない場合のみ線を表示
                 item {
@@ -91,7 +96,19 @@ fun BoardScreen(
                 HorizontalDivider()
             }
         }
+        if (isRefreshing) {
+            LinearProgressIndicator(
+                progress = { loadProgress },
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .fillMaxWidth(),
+                color = ProgressIndicatorDefaults.linearColor,
+                trackColor = ProgressIndicatorDefaults.linearTrackColor,
+                strokeCap = ProgressIndicatorDefaults.LinearStrokeCap,
+            )
+        }
     }
+}
 }
 
 @Composable

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardUiState.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardUiState.kt
@@ -27,6 +27,7 @@ data class BoardUiState(
     val errorHtmlContent: String = "",
     val postResultMessage: String? = null,
     val resetScroll: Boolean = false,
+    val loadProgress: Float = 0f,
     override val isLoading: Boolean = false,
     override val showTabListSheet: Boolean = false,
 ) : BaseUiState<BoardUiState> {

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/board/BoardViewModel.kt
@@ -86,15 +86,22 @@ class BoardViewModel @AssistedInject constructor(
             _uiState.update { it.copy(boardInfo = boardInfo) }
         }
 
-        _uiState.update { it.copy(isLoading = true) }
+        _uiState.update { it.copy(isLoading = true, loadProgress = 0f) }
         val refreshStartAt = System.currentTimeMillis()
         val normalizedUrl = boardUrl.trimEnd('/')
         try {
-            repository.refreshThreadList(boardInfo.boardId, "$normalizedUrl/subject.txt", refreshStartAt, isRefresh)
+            repository.refreshThreadList(
+                boardInfo.boardId,
+                "$normalizedUrl/subject.txt",
+                refreshStartAt,
+                isRefresh
+            ) { progress ->
+                _uiState.update { state -> state.copy(loadProgress = progress) }
+            }
         } catch (_: Exception) {
             // ignore
         } finally {
-            _uiState.update { it.copy(isLoading = false, resetScroll = true) }
+            _uiState.update { it.copy(isLoading = false, loadProgress = 1f, resetScroll = true) }
             mergeHistory(currentHistoryMap)
         }
         if (!isObservingThreads) {


### PR DESCRIPTION
## Summary
- 板読み込みの進行度を管理する `loadProgress` を追加
- subject.txt 取得時に進捗を通知し、画面上部に水平インジケータを表示

## Testing
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_68a5dd6190288332b366854b52348e57