### PR TITLE
feat: pass loaded image data to viewer

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/common/ImageThumbnailGrid.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/common/ImageThumbnailGrid.kt
@@ -29,7 +29,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 fun ImageThumbnailGrid(
     imageUrls: List<String>,
     modifier: Modifier = Modifier,
-    onImageClick: (String) -> Unit,
+    onImageClick: (String, ByteArray?) -> Unit,
     viewModel: ImageThumbnailViewModel = hiltViewModel(),
 ) {
     LaunchedEffect(imageUrls) {
@@ -47,7 +47,7 @@ fun ImageThumbnailGrid(
                             .weight(1f)
                             .aspectRatio(1f)
                             .background(MaterialTheme.colorScheme.surfaceVariant)
-                            .clickable { onImageClick(url) }
+                            .clickable { onImageClick(url, itemState?.bytes) }
                     ) {
                         itemState?.bitmap?.let { bmp ->
                             Image(

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/common/ImageThumbnailUiState.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/common/ImageThumbnailUiState.kt
@@ -4,6 +4,7 @@ import android.graphics.Bitmap
 
 data class ImageThumbnailItemState(
     val bitmap: Bitmap? = null,
+    val bytes: ByteArray? = null,
     val downloaded: Long = 0L,
     val total: Long = 0L,
     val isLoading: Boolean = true

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/common/ImageThumbnailViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/common/ImageThumbnailViewModel.kt
@@ -49,6 +49,7 @@ class ImageThumbnailViewModel @Inject constructor(
                                 current.copy(
                                     items = current.items + (url to item.copy(
                                         bitmap = bitmap,
+                                        bytes = state.bytes,
                                         isLoading = false
                                     ))
                                 )

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/common/PostDialog.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/common/PostDialog.kt
@@ -140,7 +140,7 @@ fun PostDialog(
                             modifier = Modifier
                                 .padding(horizontal = 8.dp),
                             imageUrls = imageUrls,
-                            onImageClick = { url -> onImageUrlClick?.invoke(url) }
+                            onImageClick = { url, _ -> onImageUrlClick?.invoke(url) }
                         )
                     }
                 }

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/AppNavGraph.kt
@@ -115,10 +115,12 @@ fun AppNavGraph(
         composable<AppRoute.ImageViewer> { backStackEntry ->
             val imageViewerRoute: AppRoute.ImageViewer = backStackEntry.toRoute()
             // URLデコード処理
-            val decodedUrl =
-                URLDecoder.decode(imageViewerRoute.imageUrl, StandardCharsets.UTF_8.toString())
+            val decodedUrl = imageViewerRoute.imageUrl?.let {
+                URLDecoder.decode(it, StandardCharsets.UTF_8.toString())
+            }
             ImageViewerScreen(
                 imageUrl = decodedUrl,
+                imageBytes = imageViewerRoute.imageBytes,
                 onNavigateUp = { navController.navigateUp() }
             )
         }
@@ -183,7 +185,10 @@ sealed class AppRoute {
     data object Tabs : AppRoute()
 
     @Serializable
-    data class ImageViewer(val imageUrl: String) : AppRoute()
+    data class ImageViewer(
+        val imageUrl: String? = null,
+        val imageBytes: ByteArray? = null
+    ) : AppRoute()
 
     data object RouteName {
         const val BOOKMARK_LIST = "BookmarkList"

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/item/PostItem.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/item/PostItem.kt
@@ -337,13 +337,14 @@ fun PostItem(
                 Spacer(modifier = Modifier.height(8.dp))
                 ImageThumbnailGrid(
                     imageUrls = imageUrls,
-                    onImageClick = { url ->
+                    onImageClick = { url, bytes ->
                         navController.navigate(
                             AppRoute.ImageViewer(
                                 imageUrl = URLEncoder.encode(
                                     url,
                                     StandardCharsets.UTF_8.toString()
-                                )
+                                ),
+                                imageBytes = bytes
                             )
                         )
                     }

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/viewer/ImageViewerScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/viewer/ImageViewerScreen.kt
@@ -1,6 +1,5 @@
 package com.websarva.wings.android.bbsviewer.ui.viewer
 
-import android.util.Log
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -11,8 +10,11 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import android.graphics.BitmapFactory
 import me.saket.telephoto.zoomable.OverzoomEffect
 import me.saket.telephoto.zoomable.ZoomSpec
 import me.saket.telephoto.zoomable.coil3.ZoomableAsyncImage
@@ -22,7 +24,8 @@ import me.saket.telephoto.zoomable.rememberZoomableState
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ImageViewerScreen(
-    imageUrl: String,
+    imageUrl: String? = null,
+    imageBytes: ByteArray? = null,
     onNavigateUp: () -> Unit
 ) {
     Scaffold(
@@ -52,9 +55,12 @@ fun ImageViewerScreen(
             )
         )
         val imageState = rememberZoomableImageState(zoomableState)
+        val imageBitmap = remember(imageBytes) {
+            imageBytes?.let { BitmapFactory.decodeByteArray(it, 0, it.size).asImageBitmap() }
+        }
 
         ZoomableAsyncImage(
-            model = imageUrl,
+            model = imageBitmap ?: imageUrl,
             contentDescription = null,
             state = imageState,
             modifier = Modifier


### PR DESCRIPTION
## Summary
- pass downloaded image bytes through navigation to viewer
- render viewer from provided bytes to avoid re-downloading

## Testing
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_68a5e479b2d08332876199fe1692c48e