### PR TITLE
feat: add default thread sort setting

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/SettingsLocalDataSource.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/SettingsLocalDataSource.kt
@@ -8,4 +8,10 @@ interface SettingsLocalDataSource {
 
     /** ダークモード設定を保存する */
     suspend fun setDarkMode(enabled: Boolean)
+
+    /** レスのデフォルト並び順（ツリー順か）を監視する */
+    fun observeIsTreeSort(): Flow<Boolean>
+
+    /** レスのデフォルト並び順を保存する */
+    suspend fun setTreeSort(enabled: Boolean)
 }

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/impl/SettingsLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/datasource/local/impl/SettingsLocalDataSourceImpl.kt
@@ -13,6 +13,7 @@ import javax.inject.Singleton
 
 private val Context.dataStore by preferencesDataStore(name = "settings")
 private val DARK_MODE_KEY = booleanPreferencesKey("dark_mode")
+private val TREE_SORT_KEY = booleanPreferencesKey("tree_sort")
 
 @Singleton
 class SettingsLocalDataSourceImpl @Inject constructor(
@@ -25,6 +26,16 @@ class SettingsLocalDataSourceImpl @Inject constructor(
     override suspend fun setDarkMode(enabled: Boolean) {
         context.dataStore.edit { prefs ->
             prefs[DARK_MODE_KEY] = enabled
+        }
+    }
+
+    override fun observeIsTreeSort(): Flow<Boolean> =
+        context.dataStore.data
+            .map { prefs -> prefs[TREE_SORT_KEY] ?: false }
+
+    override suspend fun setTreeSort(enabled: Boolean) {
+        context.dataStore.edit { prefs ->
+            prefs[TREE_SORT_KEY] = enabled
         }
     }
 }

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/data/repository/SettingsRepository.kt
@@ -14,4 +14,10 @@ class SettingsRepository @Inject constructor(
 
     suspend fun setDarkMode(enabled: Boolean) =
         local.setDarkMode(enabled)
+
+    fun observeIsTreeSort(): Flow<Boolean> =
+        local.observeIsTreeSort()
+
+    suspend fun setTreeSort(enabled: Boolean) =
+        local.setTreeSort(enabled)
 }

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/settings/SettingsThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/settings/SettingsThreadScreen.kt
@@ -1,37 +1,72 @@
 package com.websarva.wings.android.bbsviewer.ui.settings
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.websarva.wings.android.bbsviewer.R
 import com.websarva.wings.android.bbsviewer.ui.topbar.SmallTopAppBarScreen
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsThreadScreen(
     onNavigateUp: () -> Unit,
+    viewModel: SettingsThreadViewModel = hiltViewModel()
 ) {
+    val uiState by viewModel.uiState.collectAsState()
+
     Scaffold(
         topBar = {
             SmallTopAppBarScreen(
-                title = "スレッド",
+                title = stringResource(R.string.thread),
                 onNavigateUp = onNavigateUp,
             )
         }
     ) { innerPadding ->
-        Box(
+        Column(
             modifier = Modifier
                 .padding(innerPadding)
-                .fillMaxSize(),
-            contentAlignment = Alignment.Center
+                .fillMaxSize()
         ) {
-            Text(text = "スレッド設定")
+            Text(
+                text = stringResource(R.string.default_thread_sort_order),
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)
+            )
+            ListItem(
+                modifier = Modifier.clickable { viewModel.updateSort(false) },
+                headlineContent = { Text(stringResource(R.string.number_order)) },
+                trailingContent = {
+                    RadioButton(
+                        selected = !uiState.isTreeSort,
+                        onClick = { viewModel.updateSort(false) }
+                    )
+                }
+            )
+            HorizontalDivider()
+            ListItem(
+                modifier = Modifier.clickable { viewModel.updateSort(true) },
+                headlineContent = { Text(stringResource(R.string.tree_order)) },
+                trailingContent = {
+                    RadioButton(
+                        selected = uiState.isTreeSort,
+                        onClick = { viewModel.updateSort(true) }
+                    )
+                }
+            )
+            HorizontalDivider()
         }
     }
 }
-

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/settings/SettingsThreadViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/settings/SettingsThreadViewModel.kt
@@ -1,0 +1,38 @@
+package com.websarva.wings.android.bbsviewer.ui.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.websarva.wings.android.bbsviewer.data.repository.SettingsRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class SettingsThreadViewModel @Inject constructor(
+    private val repository: SettingsRepository
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(SettingsThreadUiState())
+    val uiState: StateFlow<SettingsThreadUiState> = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            repository.observeIsTreeSort().collect { isTree ->
+                _uiState.update { it.copy(isTreeSort = isTree) }
+            }
+        }
+    }
+
+    fun updateSort(isTree: Boolean) {
+        viewModelScope.launch {
+            repository.setTreeSort(isTree)
+        }
+    }
+}
+
+data class SettingsThreadUiState(
+    val isTreeSort: Boolean = false
+)

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/viewmodel/ThreadViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/viewmodel/ThreadViewModel.kt
@@ -13,8 +13,9 @@ import com.websarva.wings.android.bbsviewer.data.repository.DatRepository
 import com.websarva.wings.android.bbsviewer.data.repository.ImageUploadRepository
 import com.websarva.wings.android.bbsviewer.data.repository.PostRepository
 import com.websarva.wings.android.bbsviewer.data.repository.PostResult
-import com.websarva.wings.android.bbsviewer.data.repository.ThreadHistoryRepository
 import com.websarva.wings.android.bbsviewer.data.repository.NgRepository
+import com.websarva.wings.android.bbsviewer.data.repository.ThreadHistoryRepository
+import com.websarva.wings.android.bbsviewer.data.repository.SettingsRepository
 import com.websarva.wings.android.bbsviewer.data.datasource.local.entity.NgEntity
 import com.websarva.wings.android.bbsviewer.data.model.NgType
 import com.websarva.wings.android.bbsviewer.ui.common.BaseViewModel
@@ -27,6 +28,7 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -39,6 +41,7 @@ class ThreadViewModel @AssistedInject constructor(
     private val historyRepository: ThreadHistoryRepository,
     private val singleBookmarkViewModelFactory: SingleBookmarkViewModelFactory,
     private val ngRepository: NgRepository,
+    private val settingsRepository: SettingsRepository,
     @Assisted val viewModelKey: String,
 ) : BaseViewModel<ThreadUiState>() {
 
@@ -96,7 +99,13 @@ class ThreadViewModel @AssistedInject constructor(
             }
         }
 
-        initialize() // BaseViewModelの初期化処理を呼び出す
+        viewModelScope.launch {
+            val isTree = settingsRepository.observeIsTreeSort().first()
+            _uiState.update { state ->
+                state.copy(sortType = if (isTree) ThreadSortType.TREE else ThreadSortType.NUMBER)
+            }
+            initialize() // BaseViewModelの初期化処理を呼び出す
+        }
     }
 
     @RequiresApi(Build.VERSION_CODES.O)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,5 +67,7 @@
     <string name="thread_title_label">スレタイ</string>
     <string name="all_boards">すべての板</string>
     <string name="search_board_hint">板名またはURLで検索</string>
-    <string name="new_label">new</string>\
+    <string name="new_label">new</string>
+
+    <string name="default_thread_sort_order">レスのデフォルトの並び順</string>
 </resources>


### PR DESCRIPTION
## Summary
- allow choosing default reply sort (number or tree)
- persist sort preference in DataStore and apply on thread open
- add thread settings screen with radio buttons

## Testing
- `./gradlew :app:testDebugUnitTest`
- `./gradlew :app:lintDebug` *(fails: MainActivity must extend android.app.Activity)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ea868b588332a08234ebb8a7f7fb