### PR TITLE
feat: show replies by ID in popup

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/dialog/ReplyPopup.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/dialog/ReplyPopup.kt
@@ -104,6 +104,20 @@ fun ReplyPopup(
                                     )
                                     popupStack.add(PopupInfo(listOf(target), offset))
                                 }
+                            },
+                            onIdClick = { id ->
+                                val base = popupStack[index]
+                                val offset = IntOffset(
+                                    base.offset.x,
+                                    (base.offset.y - base.size.height).coerceAtLeast(0)
+                                )
+                                val targets = posts.mapIndexedNotNull { idx, post ->
+                                    val num = idx + 1
+                                    if (post.id == id && num !in ngPostNumbers) post else null
+                                }
+                                if (targets.isNotEmpty()) {
+                                    popupStack.add(PopupInfo(targets, offset))
+                                }
                             }
                         )
                         if (i < info.posts.size - 1) {

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/item/PostItem.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/item/PostItem.kt
@@ -76,7 +76,8 @@ fun PostItem(
     indentLevel: Int = 0,
     replyFromNumbers: List<Int> = emptyList(),
     onReplyFromClick: ((List<Int>) -> Unit)? = null,
-    onReplyClick: ((Int) -> Unit)? = null
+    onReplyClick: ((Int) -> Unit)? = null,
+    onIdClick: ((String) -> Unit)? = null,
 ) {
     var menuExpanded by remember { mutableStateOf(false) }
     var textMenuData by remember { mutableStateOf<Pair<String, NgType>?>(null) }
@@ -249,6 +250,15 @@ fun PostItem(
                                         onFeedbackEnd = { isContentPressed = false },
                                         awaitRelease = { awaitRelease() }
                                     )
+                                },
+                                onTap = { offset ->
+                                    headerLayout?.let { layout ->
+                                        val pos = layout.getOffsetForPosition(offset)
+                                        headerText.getStringAnnotations("ID", pos, pos)
+                                            .firstOrNull()?.let { ann ->
+                                                onIdClick?.invoke(post.id)
+                                            }
+                                    }
                                 },
                                 onLongPress = { offset ->
                                     haptic.performHapticFeedback(HapticFeedbackType.LongPress)

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/screen/ThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/screen/ThreadScreen.kt
@@ -195,6 +195,24 @@ fun ThreadScreen(
                                 }
                                 popupStack.add(PopupInfo(listOf(target), offset))
                             }
+                        },
+                        onIdClick = { id ->
+                            val offset = if (popupStack.isEmpty()) {
+                                itemOffset
+                            } else {
+                                val last = popupStack.last()
+                                IntOffset(
+                                    last.offset.x,
+                                    (last.offset.y - last.size.height).coerceAtLeast(0)
+                                )
+                            }
+                            val targets = posts.mapIndexedNotNull { idx, p ->
+                                val num = idx + 1
+                                if (p.id == id && num !in ngNumbers) p else null
+                            }
+                            if (targets.isNotEmpty()) {
+                                popupStack.add(PopupInfo(targets, offset))
+                            }
                         }
                     )
                     HorizontalDivider(


### PR DESCRIPTION
## Summary
- show popup with all posts of tapped ID
- support ID popup inside reply popups

## Testing
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_68a850a7f7748332be5570e0bbddd046