### PR TITLE
feat: highlight high-reply posts on momentum bar

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/components/MomentumBar.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/components/MomentumBar.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.unit.dp
 import com.websarva.wings.android.bbsviewer.ui.thread.state.ReplyInfo
 import com.websarva.wings.android.bbsviewer.ui.theme.imageUrlColor
+import com.websarva.wings.android.bbsviewer.ui.theme.replyCountColor
 import com.websarva.wings.android.bbsviewer.ui.theme.threadUrlColor
 import com.websarva.wings.android.bbsviewer.ui.theme.urlColor
 import kotlinx.coroutines.launch
@@ -31,7 +32,8 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 fun MomentumBar(
     modifier: Modifier = Modifier,
     posts: List<ReplyInfo>,
-    lazyListState: LazyListState
+    lazyListState: LazyListState,
+    replyCounts: List<Int> = emptyList()
 ) {
     val barColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.6f)
     val indicatorColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.2f)
@@ -40,6 +42,9 @@ fun MomentumBar(
     val imageColor = imageUrlColor()
     val threadColor = threadUrlColor()
     val otherColor = urlColor()
+    val highlightColors = replyCounts.map { count ->
+        if (count >= 5) replyCountColor(count) else Color.Unspecified
+    }
 
     var barHeight by remember { mutableStateOf(0) }
     val scope = rememberCoroutineScope()
@@ -125,6 +130,21 @@ fun MomentumBar(
                         topLeft = Offset(x = 0f, y = indicatorTop),
                         size = Size(width = canvasWidth, height = indicatorHeight)
                     )
+                }
+            }
+
+            val triangleWidth = 6.dp.toPx()
+            highlightColors.forEachIndexed { index, color ->
+                if (color != Color.Unspecified) {
+                    val top = index * postHeight
+                    val bottom = top + postHeight
+                    val path = Path().apply {
+                        moveTo(0f, top)
+                        lineTo(triangleWidth, (top + bottom) / 2f)
+                        lineTo(0f, bottom)
+                        close()
+                    }
+                    drawPath(path, color = color)
                 }
             }
 

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/screen/ThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/thread/screen/ThreadScreen.kt
@@ -78,6 +78,7 @@ fun ThreadScreen(
     }
     val visiblePosts = filteredPosts.filterNot { it.first in uiState.ngPostNumbers }
     val displayPosts = visiblePosts.map { it.second }
+    val replyCountList = visiblePosts.map { (num, _) -> uiState.replySourceMap[num]?.size ?: 0 }
     val popupStack = remember { androidx.compose.runtime.mutableStateListOf<PopupInfo>() }
     val ngNumbers = uiState.ngPostNumbers
 
@@ -234,7 +235,8 @@ fun ThreadScreen(
                     .width(32.dp)
                     .fillMaxHeight(),
                 posts = displayPosts,
-                lazyListState = listState
+                lazyListState = listState,
+                replyCounts = replyCountList
             )
         }
 


### PR DESCRIPTION
## Summary
- mark momentum bar with right-pointing triangle for posts receiving 5+ replies
- pass reply counts from `ThreadScreen` to `MomentumBar`

## Testing
- `./gradlew :app:testDebugUnitTest`
- `./gradlew :app:lintDebug` *(fails: Lint found errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a91b24c7ec8332a7a98513f6712503