### PR TITLE
feat: add more screen and restructure navigation

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/bottombar/NavigationBottomBar.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/bottombar/NavigationBottomBar.kt
@@ -3,11 +3,8 @@ package com.websarva.wings.android.bbsviewer.ui.bottombar
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.height
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.Menu
-import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Star
-import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Tab
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -47,22 +44,10 @@ fun NavigationBottomBar(
             parentRoute = AppRoute.BookmarkList
         ),
         TopLevelRoute(
-            route = AppRoute.HistoryList,
-            name = stringResource(R.string.history),
-            icon = Icons.Default.History,
-            parentRoute = AppRoute.HistoryList
-        ),
-        TopLevelRoute(
-            route = AppRoute.ServiceList,
-            name = stringResource(R.string.boardList),
-            icon = Icons.AutoMirrored.Filled.List,
-            parentRoute = AppRoute.BbsServiceGroup
-        ),
-        TopLevelRoute(
-            route = AppRoute.SettingsHome,
-            name = stringResource(R.string.settings),
-            icon = Icons.Default.Settings,
-            parentRoute = AppRoute.Settings
+            route = AppRoute.OthersHome,
+            name = stringResource(R.string.more),
+            icon = Icons.Default.Menu,
+            parentRoute = AppRoute.Others
         ),
     )
     NavigationBar(modifier = modifier) {

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/bottombar/RenderBottomBar.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/bottombar/RenderBottomBar.kt
@@ -16,12 +16,12 @@ import com.websarva.wings.android.bbsviewer.ui.util.isInRoute
 fun RenderBottomBar(
     modifier: Modifier = Modifier,
     navController: NavHostController,
-    navBackStackEntry: NavBackStackEntry?
+    navBackStackEntry: NavBackStackEntry?,
 ) {
     val currentDestination = navBackStackEntry?.destination
     when {
         currentDestination.isInRoute(
-            AppRoute.RouteName.BOOKMARK_LIST
+            AppRoute.RouteName.BOOKMARK_LIST,
         ) -> {
             val viewModel: BookmarkViewModel = hiltViewModel(navBackStackEntry!!)
             val uiState by viewModel.uiState.collectAsState()
@@ -50,26 +50,7 @@ fun RenderBottomBar(
         }
 
         currentDestination.isInRoute(
-            AppRoute.RouteName.HISTORY_LIST
-        ) -> {
-            NavigationBottomBar(
-                modifier = modifier,
-                currentDestination = currentDestination,
-                onClick = { route ->
-                    navController.navigate(route) {
-                        popUpTo(navController.graph.startDestinationId) {
-                            saveState = true
-                        }
-                        launchSingleTop = true
-                        restoreState = true
-                    }
-                }
-            )
-        }
-
-        currentDestination.isInRoute(
             AppRoute.RouteName.BBS_SERVICE_GROUP,
-            AppRoute.RouteName.TABS
         ) -> {
             val viewModel: ServiceListViewModel = hiltViewModel(navBackStackEntry!!)
             val uiState by viewModel.uiState.collectAsState()
@@ -97,6 +78,26 @@ fun RenderBottomBar(
             }
         }
 
+        currentDestination.isInRoute(
+            AppRoute.RouteName.OTHERS,
+            AppRoute.RouteName.TABS,
+        ) -> {
+            NavigationBottomBar(
+                modifier = modifier,
+                currentDestination = currentDestination,
+                onClick = { route ->
+                    navController.navigate(route) {
+                        popUpTo(navController.graph.startDestinationId) {
+                            saveState = true
+                        }
+                        launchSingleTop = true
+                        restoreState = true
+                    }
+                }
+            )
+        }
+
         else -> {}
     }
 }
+

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/more/MoreScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/more/MoreScreen.kt
@@ -1,0 +1,62 @@
+package com.websarva.wings.android.bbsviewer.ui.more
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.websarva.wings.android.bbsviewer.R
+import com.websarva.wings.android.bbsviewer.ui.topbar.HomeTopAppBarScreen
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MoreScreen(
+    onBoardListClick: () -> Unit,
+    onHistoryClick: () -> Unit,
+    onSettingsClick: () -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            HomeTopAppBarScreen(
+                title = stringResource(R.string.more),
+                scrollBehavior = null
+            )
+        }
+    ) { innerPadding ->
+        LazyColumn(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize()
+        ) {
+            item {
+                ListItem(
+                    modifier = Modifier.clickable(onClick = onBoardListClick),
+                    headlineContent = { Text(text = stringResource(R.string.boardList)) }
+                )
+                HorizontalDivider()
+            }
+            item {
+                ListItem(
+                    modifier = Modifier.clickable(onClick = onHistoryClick),
+                    headlineContent = { Text(text = stringResource(R.string.history)) }
+                )
+                HorizontalDivider()
+            }
+            item {
+                ListItem(
+                    modifier = Modifier.clickable(onClick = onSettingsClick),
+                    headlineContent = { Text(text = stringResource(R.string.settings)) }
+                )
+                HorizontalDivider()
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/websarva/wings/android/bbsviewer/ui/navigation/AppNavGraph.kt
@@ -11,10 +11,12 @@ import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.navigation
 import androidx.navigation.toRoute
 import com.websarva.wings.android.bbsviewer.ui.board.BoardScaffold
 import com.websarva.wings.android.bbsviewer.ui.bookmarklist.BookmarkListScaffold
 import com.websarva.wings.android.bbsviewer.ui.history.HistoryListScaffold
+import com.websarva.wings.android.bbsviewer.ui.more.MoreScreen
 import com.websarva.wings.android.bbsviewer.ui.settings.SettingsViewModel
 import com.websarva.wings.android.bbsviewer.ui.tabs.TabsScaffold
 import com.websarva.wings.android.bbsviewer.ui.tabs.TabsViewModel
@@ -52,20 +54,47 @@ fun AppNavGraph(
                 openDrawer = openDrawer
             )
         }
-        //履歴一覧
-        composable<AppRoute.HistoryList> {
-            HistoryListScaffold(
+        //その他
+        navigation<AppRoute.Others>(
+            startDestination = AppRoute.OthersHome,
+            enterTransition = { defaultEnterTransition() },
+            exitTransition = { defaultExitTransition() },
+            popEnterTransition = { defaultPopEnterTransition() },
+            popExitTransition = { defaultPopExitTransition() }
+        ) {
+            composable<AppRoute.OthersHome> {
+                MoreScreen(
+                    onBoardListClick = {
+                        navController.navigate(AppRoute.ServiceList) { launchSingleTop = true }
+                    },
+                    onHistoryClick = {
+                        navController.navigate(AppRoute.HistoryList) { launchSingleTop = true }
+                    },
+                    onSettingsClick = {
+                        navController.navigate(AppRoute.SettingsHome) { launchSingleTop = true }
+                    }
+                )
+            }
+            //履歴一覧
+            composable<AppRoute.HistoryList> {
+                HistoryListScaffold(
+                    navController = navController,
+                    topBarState = topBarState,
+                    parentPadding = parentPadding
+                )
+            }
+            //掲示板一覧
+            addRegisteredBBSNavigation(
+                parentPadding = parentPadding,
                 navController = navController,
-                topBarState = topBarState,
-                parentPadding = parentPadding
+                openDrawer = openDrawer
+            )
+            //設定画面
+            addSettingsRoute(
+                viewModel = settingsViewModel,
+                navController = navController
             )
         }
-        //掲示板一覧
-        addRegisteredBBSNavigation(
-            parentPadding = parentPadding,
-            navController = navController,
-            openDrawer = openDrawer
-        )
         //スレッド一覧
         composable<AppRoute.Board>(
             enterTransition = { defaultEnterTransition() },
@@ -106,11 +135,6 @@ fun AppNavGraph(
                 navController = navController
             )
         }
-        //設定画面
-        addSettingsRoute(
-            viewModel = settingsViewModel,
-            navController = navController
-        )
         //画像ビューア
         composable<AppRoute.ImageViewer> { backStackEntry ->
             val imageViewerRoute: AppRoute.ImageViewer = backStackEntry.toRoute()
@@ -186,6 +210,12 @@ sealed class AppRoute {
     data object Tabs : AppRoute()
 
     @Serializable
+    data object Others : AppRoute()
+
+    @Serializable
+    data object OthersHome : AppRoute()
+
+    @Serializable
     data class ImageViewer(val imageUrl: String) : AppRoute()
 
     data object RouteName {
@@ -203,5 +233,7 @@ sealed class AppRoute {
         const val SETTINGS_THREAD = "SettingsThread"
         const val TABS = "Tabs"
         const val HISTORY_LIST = "HistoryList"
+        const val OTHERS = "Others"
+        const val OTHERS_HOME = "OthersHome"
     }
 }


### PR DESCRIPTION
## Summary
- add more screen to access board list, history, and settings
- replace bottom bar items with others tab
- update navigation graph and bottom bar handling

## Testing
- `./gradlew :app:testDebugUnitTest`
- `./gradlew :app:lintDebug` *(fails: Call requires API level 26, or core library desugaring)*

------
https://chatgpt.com/codex/tasks/task_e_68aaeb26ed2483328fff6923c1ac4f98