### PR TITLE
Add More tab to bottom navigation

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/bottombar/NavigationBottomBar.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/bottombar/NavigationBottomBar.kt
@@ -3,6 +3,7 @@ package com.websarva.wings.android.slevo.ui.bottombar
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.height
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.MoreHoriz
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.Tab
@@ -42,6 +43,12 @@ fun NavigationBottomBar(
             name = stringResource(R.string.bookmark),
             icon = Icons.Default.Star,
             parentRoute = AppRoute.BookmarkList
+        ),
+        TopLevelRoute(
+            route = AppRoute.ServiceList,
+            name = stringResource(R.string.boardList),
+            icon = Icons.AutoMirrored.Filled.List,
+            parentRoute = AppRoute.BbsServiceGroup
         ),
         TopLevelRoute(
             route = AppRoute.More,

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/bottombar/RenderBottomBar.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/bottombar/RenderBottomBar.kt
@@ -68,24 +68,6 @@ fun RenderBottomBar(
         }
 
         currentDestination.isInRoute(
-            AppRoute.RouteName.HISTORY_LIST
-        ) -> {
-            NavigationBottomBar(
-                modifier = modifier,
-                currentDestination = currentDestination,
-                onClick = { route ->
-                    navController.navigate(route) {
-                        popUpTo(navController.graph.startDestinationId) {
-                            saveState = true
-                        }
-                        launchSingleTop = true
-                        restoreState = true
-                    }
-                }
-            )
-        }
-
-        currentDestination.isInRoute(
             AppRoute.RouteName.BBS_SERVICE_GROUP,
             AppRoute.RouteName.TABS
         ) -> {

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/more/MoreScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/more/MoreScreen.kt
@@ -23,24 +23,12 @@ fun MoreScreen(
     onSettingsClick: () -> Unit,
 ) {
     Scaffold(
-        topBar = {
-            HomeTopAppBarScreen(
-                title = stringResource(R.string.more)
-            )
-        }
     ) { innerPadding ->
         LazyColumn(
             modifier = Modifier
                 .padding(innerPadding)
                 .fillMaxSize()
         ) {
-            item {
-                ListItem(
-                    modifier = Modifier.clickable(onClick = onBoardListClick),
-                    headlineContent = { Text(stringResource(R.string.boardList)) }
-                )
-                HorizontalDivider()
-            }
             item {
                 ListItem(
                     modifier = Modifier.clickable(onClick = onHistoryClick),

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/AppNavGraph.kt
@@ -54,7 +54,12 @@ fun AppNavGraph(
             )
         }
         //履歴一覧
-        composable<AppRoute.HistoryList> {
+        composable<AppRoute.HistoryList>(
+            enterTransition = { defaultEnterTransition() },
+            exitTransition = { defaultExitTransition() },
+            popEnterTransition = { defaultPopEnterTransition() },
+            popExitTransition = { defaultPopExitTransition() }
+        ) {
             HistoryListScaffold(
                 navController = navController,
                 topBarState = topBarState,


### PR DESCRIPTION
## Summary
- ナビゲーションバーにその他タブを追加し、履歴・板一覧・設定を移動
- その他画面から各画面へ遷移できるリストを追加

## Testing
- `./gradlew :app:testDebugUnitTest`
- `./gradlew :app:lintDebug` *(途中で停止)*

------
https://chatgpt.com/codex/tasks/task_e_68ab216cbe94833294c8c20673ef7348