### PR TITLE
feat: add about screen with open source licenses

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,6 +14,8 @@ plugins {
     id("com.google.devtools.ksp")
 }
 
+apply(plugin = "com.google.android.gms.oss-licenses-plugin")
+
 // local.propertiesからAPIキーを読み込む
 val properties = Properties()
 val localPropertiesFile = rootProject.file("local.properties")
@@ -71,6 +73,7 @@ dependencies {
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
     implementation(libs.androidx.navigation.compose)
+    implementation("androidx.appcompat:appcompat:1.7.0")
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
@@ -78,6 +81,8 @@ dependencies {
     androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
+
+    implementation("com.google.android.gms:play-services-oss-licenses:17.0.1")
 
     //okhttp
     implementation(libs.okhttp3.okhttp)

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/about/AboutScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/about/AboutScreen.kt
@@ -1,0 +1,68 @@
+package com.websarva.wings.android.slevo.ui.about
+
+import android.content.Intent
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.res.stringResource
+import com.google.android.gms.oss.licenses.OssLicensesMenuActivity
+import com.websarva.wings.android.slevo.BuildConfig
+import com.websarva.wings.android.slevo.R
+import com.websarva.wings.android.slevo.ui.topbar.SmallTopAppBarScreen
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AboutScreen(
+    onNavigateUp: () -> Unit,
+) {
+    val context = LocalContext.current
+    val uriHandler = LocalUriHandler.current
+    Scaffold(
+        topBar = {
+            SmallTopAppBarScreen(
+                title = stringResource(R.string.about_app),
+                onNavigateUp = onNavigateUp
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize()
+        ) {
+            ListItem(
+                headlineContent = { Text(stringResource(R.string.app_name)) },
+                supportingContent = {
+                    Text(stringResource(R.string.version_label, BuildConfig.VERSION_NAME))
+                }
+            )
+            ListItem(
+                modifier = Modifier.clickable {
+                    uriHandler.openUri(context.getString(R.string.github_url))
+                },
+                headlineContent = { Text(stringResource(R.string.github)) },
+                supportingContent = { Text(stringResource(R.string.github_url)) }
+            )
+            ListItem(
+                modifier = Modifier.clickable {
+                    OssLicensesMenuActivity.setActivityTitle(
+                        context.getString(R.string.open_source_licenses)
+                    )
+                    context.startActivity(
+                        Intent(context, OssLicensesMenuActivity::class.java)
+                    )
+                },
+                headlineContent = { Text(stringResource(R.string.open_source_licenses)) }
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/more/MoreScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/more/MoreScreen.kt
@@ -21,6 +21,7 @@ fun MoreScreen(
     onBoardListClick: () -> Unit,
     onHistoryClick: () -> Unit,
     onSettingsClick: () -> Unit,
+    onAboutClick: () -> Unit,
 ) {
     Scaffold(
     ) { innerPadding ->
@@ -40,6 +41,13 @@ fun MoreScreen(
                 ListItem(
                     modifier = Modifier.clickable(onClick = onSettingsClick),
                     headlineContent = { Text(stringResource(R.string.settings)) }
+                )
+                HorizontalDivider()
+            }
+            item {
+                ListItem(
+                    modifier = Modifier.clickable(onClick = onAboutClick),
+                    headlineContent = { Text(stringResource(R.string.about_app)) }
                 )
             }
         }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/AppNavGraph.kt
@@ -16,6 +16,7 @@ import com.websarva.wings.android.slevo.ui.board.BoardScaffold
 import com.websarva.wings.android.slevo.ui.bookmarklist.BookmarkListScaffold
 import com.websarva.wings.android.slevo.ui.history.HistoryListScaffold
 import com.websarva.wings.android.slevo.ui.more.MoreScreen
+import com.websarva.wings.android.slevo.ui.about.AboutScreen
 import com.websarva.wings.android.slevo.ui.settings.SettingsViewModel
 import com.websarva.wings.android.slevo.ui.tabs.TabsScaffold
 import com.websarva.wings.android.slevo.ui.tabs.TabsViewModel
@@ -122,7 +123,19 @@ fun AppNavGraph(
             MoreScreen(
                 onBoardListClick = { navController.navigate(AppRoute.ServiceList) },
                 onHistoryClick = { navController.navigate(AppRoute.HistoryList) },
-                onSettingsClick = { navController.navigate(AppRoute.SettingsHome) }
+                onSettingsClick = { navController.navigate(AppRoute.SettingsHome) },
+                onAboutClick = { navController.navigate(AppRoute.About) }
+            )
+        }
+        //このアプリについて
+        composable<AppRoute.About>(
+            enterTransition = { defaultEnterTransition() },
+            exitTransition = { defaultExitTransition() },
+            popEnterTransition = { defaultPopEnterTransition() },
+            popExitTransition = { defaultPopExitTransition() }
+        ) {
+            AboutScreen(
+                onNavigateUp = { navController.navigateUp() }
             )
         }
         //画像ビューア
@@ -203,6 +216,9 @@ sealed class AppRoute {
     data object More : AppRoute()
 
     @Serializable
+    data object About : AppRoute()
+
+    @Serializable
     data class ImageViewer(val imageUrl: String) : AppRoute()
 
     data object RouteName {
@@ -220,6 +236,7 @@ sealed class AppRoute {
         const val SETTINGS_THREAD = "SettingsThread"
         const val TABS = "Tabs"
         const val MORE = "More"
+        const val ABOUT = "About"
         const val HISTORY_LIST = "HistoryList"
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,4 +70,9 @@
     <string name="new_label">new</string>
 
     <string name="default_thread_sort_order">レスのデフォルトの並び順</string>
+    <string name="about_app">このアプリについて</string>
+    <string name="open_source_licenses">オープンソースライセンス</string>
+    <string name="version_label">バージョン %1$s</string>
+    <string name="github">GitHub</string>
+    <string name="github_url">https://github.com/tsu-nera/Slevo</string>
 </resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,13 @@ plugins {
     id("com.google.dagger.hilt.android") version "2.51.1" apply false
 
     id("com.google.devtools.ksp") version "2.1.20-1.0.32" apply false
+
+}
+
+buildscript {
+    dependencies {
+        classpath("com.google.android.gms:oss-licenses-plugin:0.10.7")
+    }
 }
 
 allprojects {


### PR DESCRIPTION
## Summary
- その他画面に「このアプリについて」項目を追加
- アプリ名・バージョン・GitHubリンク・オープンソースライセンスを表示する画面を実装
- OSSライセンス表示のための依存関係を追加

## Testing
- `./gradlew :app:assembleDebug`
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_68ab2ddc32f883328ba666a04c83a0a5