### PR TITLE
feat: add open source license screen

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/about/AboutScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/about/AboutScreen.kt
@@ -1,15 +1,18 @@
 package com.websarva.wings.android.slevo.ui.about
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.ListItem
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
-import com.mikepenz.aboutlibraries.ui.compose.android.rememberLibraries
-import com.mikepenz.aboutlibraries.ui.compose.m3.LibrariesContainer
 import com.websarva.wings.android.slevo.BuildConfig
 import com.websarva.wings.android.slevo.R
 import com.websarva.wings.android.slevo.ui.topbar.SmallTopAppBarScreen
@@ -17,11 +20,12 @@ import com.websarva.wings.android.slevo.ui.topbar.SmallTopAppBarScreen
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AboutScreen(
-    onNavigateUp: () -> Unit
+    onNavigateUp: () -> Unit,
+    onOpenSourceLicenseClick: () -> Unit
 ) {
-    val context = LocalContext.current
     val versionName = BuildConfig.VERSION_NAME
     val githubUrl = stringResource(R.string.github_url)
+    val uriHandler = LocalUriHandler.current
 
     Scaffold(
         topBar = {
@@ -31,8 +35,38 @@ fun AboutScreen(
             )
         }
     ) { innerPadding ->
-
-        val libraries by rememberLibraries(R.raw.aboutlibraries)
-        LibrariesContainer(libraries, Modifier.fillMaxSize())
+        LazyColumn(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize()
+        ) {
+            item {
+                ListItem(
+                    headlineContent = { Text(stringResource(R.string.app_name)) }
+                )
+                HorizontalDivider()
+            }
+            item {
+                ListItem(
+                    headlineContent = { Text(stringResource(R.string.version_name_label, versionName)) }
+                )
+                HorizontalDivider()
+            }
+            item {
+                ListItem(
+                    modifier = Modifier.clickable { uriHandler.openUri(githubUrl) },
+                    headlineContent = { Text(stringResource(R.string.github)) },
+                    supportingContent = { Text(githubUrl) }
+                )
+                HorizontalDivider()
+            }
+            item {
+                ListItem(
+                    modifier = Modifier.clickable(onClick = onOpenSourceLicenseClick),
+                    headlineContent = { Text(stringResource(R.string.open_source_licenses)) }
+                )
+            }
+        }
     }
 }
+

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/about/OpenSourceLicenseScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/about/OpenSourceLicenseScreen.kt
@@ -1,0 +1,38 @@
+package com.websarva.wings.android.slevo.ui.about
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.mikepenz.aboutlibraries.ui.compose.android.rememberLibraries
+import com.mikepenz.aboutlibraries.ui.compose.m3.LibrariesContainer
+import com.websarva.wings.android.slevo.R
+import com.websarva.wings.android.slevo.ui.topbar.SmallTopAppBarScreen
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun OpenSourceLicenseScreen(
+    onNavigateUp: () -> Unit
+) {
+    Scaffold(
+        topBar = {
+            SmallTopAppBarScreen(
+                title = stringResource(R.string.open_source_licenses),
+                onNavigateUp = onNavigateUp
+            )
+        }
+    ) { innerPadding ->
+        val libraries by rememberLibraries(R.raw.aboutlibraries)
+        LibrariesContainer(
+            libraries = libraries,
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize()
+        )
+    }
+}
+

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/AppNavGraph.kt
@@ -17,6 +17,7 @@ import com.websarva.wings.android.slevo.ui.bookmarklist.BookmarkListScaffold
 import com.websarva.wings.android.slevo.ui.history.HistoryListScaffold
 import com.websarva.wings.android.slevo.ui.more.MoreScreen
 import com.websarva.wings.android.slevo.ui.about.AboutScreen
+import com.websarva.wings.android.slevo.ui.about.OpenSourceLicenseScreen
 import com.websarva.wings.android.slevo.ui.settings.SettingsViewModel
 import com.websarva.wings.android.slevo.ui.tabs.TabsScaffold
 import com.websarva.wings.android.slevo.ui.tabs.TabsViewModel
@@ -135,6 +136,18 @@ fun AppNavGraph(
             popExitTransition = { defaultPopExitTransition() }
         ) {
             AboutScreen(
+                onNavigateUp = { navController.navigateUp() },
+                onOpenSourceLicenseClick = { navController.navigate(AppRoute.OpenSourceLicense) }
+            )
+        }
+        //オープンソースライセンス
+        composable<AppRoute.OpenSourceLicense>(
+            enterTransition = { defaultEnterTransition() },
+            exitTransition = { defaultExitTransition() },
+            popEnterTransition = { defaultPopEnterTransition() },
+            popExitTransition = { defaultPopExitTransition() }
+        ) {
+            OpenSourceLicenseScreen(
                 onNavigateUp = { navController.navigateUp() }
             )
         }
@@ -221,6 +234,9 @@ sealed class AppRoute {
     @Serializable
     data object About : AppRoute()
 
+    @Serializable
+    data object OpenSourceLicense : AppRoute()
+
     data object RouteName {
         const val BOOKMARK_LIST = "BookmarkList"
         const val BBS_SERVICE_GROUP = "BbsServiceGroup"
@@ -238,5 +254,6 @@ sealed class AppRoute {
         const val MORE = "More"
         const val HISTORY_LIST = "HistoryList"
         const val ABOUT = "About"
+        const val OPEN_SOURCE_LICENSE = "OpenSourceLicense"
     }
 }


### PR DESCRIPTION
## Summary
- show app name, version, GitHub link and license entry on About screen
- display open source licenses on a dedicated screen
- wire new license screen into navigation

## Testing
- `./gradlew :app:lintDebug :app:testDebugUnitTest` *(fails: Observed package id 'build-tools;35.0.0' in inconsistent location)*

------
https://chatgpt.com/codex/tasks/task_e_68abdb34fa788332ad23c0c4677f11f2