### PR TITLE
fix: レスのポップアップ外クリック時に最上位のみ閉じるように修正

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/dialog/ReplyPopup.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/dialog/ReplyPopup.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupPositionProvider
+import androidx.compose.ui.window.PopupProperties
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import com.websarva.wings.android.slevo.ui.thread.item.PostItem
@@ -49,6 +50,7 @@ fun ReplyPopup(
     onClose: () -> Unit
 ) {
     popupStack.forEachIndexed { index, info ->
+        val isTopMost = index == popupStack.lastIndex
         Popup(
             popupPositionProvider = object : PopupPositionProvider {
                 override fun calculatePosition(
@@ -63,7 +65,11 @@ fun ReplyPopup(
                     )
                 }
             },
-            onDismissRequest = onClose
+            onDismissRequest = { if (isTopMost) onClose() },
+            properties = PopupProperties(
+                dismissOnClickOutside = isTopMost,
+                dismissOnBackPress = isTopMost,
+            ),
         ) {
             Card(
                 modifier = Modifier


### PR DESCRIPTION
## Summary
- ポップアップ外クリックで最上位のみ閉じるようにPopupのプロパティを調整

## Testing
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_68adc76b218883328f6658c9df1e0c11