### PR TITLE
feat: track last read response

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/AppDatabase.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/AppDatabase.kt
@@ -58,7 +58,7 @@ import com.websarva.wings.android.slevo.data.datasource.local.entity.history.Pos
         BoardFetchMetaEntity::class,
         PostHistoryEntity::class
     ],
-    version = 1,
+    version = 2,
     exportSchema = true
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -78,4 +78,14 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun boardVisitDao(): BoardVisitDao
     abstract fun boardFetchMetaDao(): BoardFetchMetaDao
     abstract fun postHistoryDao(): PostHistoryDao
+
+    companion object {
+        val MIGRATION_1_2 = object : androidx.room.migration.Migration(1, 2) {
+            override fun migrate(database: androidx.sqlite.db.SupportSQLiteDatabase) {
+                database.execSQL(
+                    "ALTER TABLE open_thread_tabs ADD COLUMN lastReadResNo INTEGER NOT NULL DEFAULT 0"
+                )
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/entity/TabEntities.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/entity/TabEntities.kt
@@ -25,6 +25,7 @@ data class OpenThreadTabEntity(
     val boardName: String,
     val title: String,
     val resCount: Int = 0,
+    val lastReadResNo: Int = 0,
     val sortOrder: Int,
     val firstVisibleItemIndex: Int = 0,
     val firstVisibleItemScrollOffset: Int = 0

--- a/app/src/main/java/com/websarva/wings/android/slevo/data/repository/TabsRepository.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/repository/TabsRepository.kt
@@ -61,6 +61,7 @@ class TabsRepository @Inject constructor(
                     boardUrl = entity.boardUrl,
                     boardId = entity.boardId,
                     resCount = entity.resCount,
+                    lastReadResNo = entity.lastReadResNo,
                     firstVisibleItemIndex = entity.firstVisibleItemIndex,
                     firstVisibleItemScrollOffset = entity.firstVisibleItemScrollOffset
                 )
@@ -78,6 +79,7 @@ class TabsRepository @Inject constructor(
                     boardName = info.boardName,
                     title = info.title,
                     resCount = info.resCount,
+                    lastReadResNo = info.lastReadResNo,
                     sortOrder = index,
                     firstVisibleItemIndex = info.firstVisibleItemIndex,
                     firstVisibleItemScrollOffset = info.firstVisibleItemScrollOffset

--- a/app/src/main/java/com/websarva/wings/android/slevo/di/DatabaseModule.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/di/DatabaseModule.kt
@@ -53,6 +53,7 @@ object DatabaseModule {
             AppDatabase::class.java,
             "slevo_database"
         )
+            .addMigrations(AppDatabase.MIGRATION_1_2)
             .addCallback(callback)
             .build()
     }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabsViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabsViewModel.kt
@@ -265,6 +265,23 @@ class TabsViewModel @Inject constructor(
     }
 
     /**
+     * 最後に読んだレス番号を保存する。
+     */
+    fun updateThreadLastRead(tabKey: String, boardUrl: String, lastReadResNo: Int) {
+        _uiState.update { state ->
+            val updated = state.openThreadTabs.map { tab ->
+                if (tab.key == tabKey && tab.boardUrl == boardUrl && lastReadResNo > tab.lastReadResNo) {
+                    tab.copy(lastReadResNo = lastReadResNo)
+                } else {
+                    tab
+                }
+            }
+            state.copy(openThreadTabs = updated)
+        }
+        viewModelScope.launch { tabsRepository.saveOpenThreadTabs(_uiState.value.openThreadTabs) }
+    }
+
+    /**
      * 板タブのスクロール位置を保存する。
      */
     fun updateBoardScrollPosition(

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/ThreadTabInfo.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/ThreadTabInfo.kt
@@ -7,6 +7,7 @@ data class ThreadTabInfo(
     val boardUrl: String,
     val boardId: Long,
     val resCount: Int = 0,
+    val lastReadResNo: Int = 0,
     val firstVisibleItemIndex: Int = 0, // スクロール位置（インデックス）
     val firstVisibleItemScrollOffset: Int = 0, // スクロール位置（オフセット）
     val bookmarkColorName: String? = null

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -139,7 +139,14 @@ fun ThreadScaffold(
                 uiState = uiState,
                 listState = listState,
                 navController = navController,
-                onBottomRefresh = { viewModel.reloadThread() }
+                onBottomRefresh = { viewModel.reloadThread() },
+                onLastRead = { resNum ->
+                    tabsViewModel.updateThreadLastRead(
+                        uiState.threadInfo.key,
+                        uiState.boardInfo.url,
+                        resNum
+                    )
+                }
             )
         },
         optionalSheetContent = { viewModel, uiState ->


### PR DESCRIPTION
## Summary
- save highest visible post in upper half as last read when idle for 500ms
- persist last read number in thread tabs with Room migration

## Testing
- `./gradlew :app:testDebugUnitTest` *(fails: Observed package id 'build-tools;35.0.0' in inconsistent location)*

------
https://chatgpt.com/codex/tasks/task_e_68ae6439283083329ed4ff1bd5886118