### PR TITLE
feat: track first new thread response

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/AppDatabase.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/AppDatabase.kt
@@ -58,7 +58,7 @@ import com.websarva.wings.android.slevo.data.datasource.local.entity.history.Pos
         BoardFetchMetaEntity::class,
         PostHistoryEntity::class
     ],
-    version = 2,
+    version = 3,
     exportSchema = true
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -84,6 +84,14 @@ abstract class AppDatabase : RoomDatabase() {
             override fun migrate(database: androidx.sqlite.db.SupportSQLiteDatabase) {
                 database.execSQL(
                     "ALTER TABLE open_thread_tabs ADD COLUMN lastReadResNo INTEGER NOT NULL DEFAULT 0"
+                )
+            }
+        }
+
+        val MIGRATION_2_3 = object : androidx.room.migration.Migration(2, 3) {
+            override fun migrate(database: androidx.sqlite.db.SupportSQLiteDatabase) {
+                database.execSQL(
+                    "ALTER TABLE open_thread_tabs ADD COLUMN firstNewResNo INTEGER NOT NULL DEFAULT 0"
                 )
             }
         }

--- a/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/entity/TabEntities.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/entity/TabEntities.kt
@@ -26,6 +26,7 @@ data class OpenThreadTabEntity(
     val title: String,
     val resCount: Int = 0,
     val lastReadResNo: Int = 0,
+    val firstNewResNo: Int = 0,
     val sortOrder: Int,
     val firstVisibleItemIndex: Int = 0,
     val firstVisibleItemScrollOffset: Int = 0

--- a/app/src/main/java/com/websarva/wings/android/slevo/data/repository/TabsRepository.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/repository/TabsRepository.kt
@@ -62,6 +62,7 @@ class TabsRepository @Inject constructor(
                     boardId = entity.boardId,
                     resCount = entity.resCount,
                     lastReadResNo = entity.lastReadResNo,
+                    firstNewResNo = entity.firstNewResNo,
                     firstVisibleItemIndex = entity.firstVisibleItemIndex,
                     firstVisibleItemScrollOffset = entity.firstVisibleItemScrollOffset
                 )
@@ -80,6 +81,7 @@ class TabsRepository @Inject constructor(
                     title = info.title,
                     resCount = info.resCount,
                     lastReadResNo = info.lastReadResNo,
+                    firstNewResNo = info.firstNewResNo,
                     sortOrder = index,
                     firstVisibleItemIndex = info.firstVisibleItemIndex,
                     firstVisibleItemScrollOffset = info.firstVisibleItemScrollOffset

--- a/app/src/main/java/com/websarva/wings/android/slevo/di/DatabaseModule.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/di/DatabaseModule.kt
@@ -53,7 +53,7 @@ object DatabaseModule {
             AppDatabase::class.java,
             "slevo_database"
         )
-            .addMigrations(AppDatabase.MIGRATION_1_2)
+            .addMigrations(AppDatabase.MIGRATION_1_2, AppDatabase.MIGRATION_2_3)
             .addCallback(callback)
             .build()
     }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabsViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabsViewModel.kt
@@ -229,7 +229,16 @@ class TabsViewModel @Inject constructor(
         _uiState.update { state ->
             val updated = state.openThreadTabs.map { tab ->
                 if (tab.key == key && tab.boardUrl == boardUrl) {
-                    tab.copy(title = title, resCount = resCount)
+                    val newFirst = if (resCount > tab.resCount) {
+                        if (tab.firstNewResNo <= tab.lastReadResNo) {
+                            tab.lastReadResNo + 1
+                        } else {
+                            tab.firstNewResNo
+                        }
+                    } else {
+                        tab.firstNewResNo
+                    }
+                    tab.copy(title = title, resCount = resCount, firstNewResNo = newFirst)
                 } else {
                     tab
                 }
@@ -316,17 +325,32 @@ class TabsViewModel @Inject constructor(
             _uiState.update { it.copy(isRefreshing = true) }
             val currentTabs = _uiState.value.openThreadTabs
             val resultMap = mutableMapOf<String, Int>()
-            currentTabs.forEach { tab ->
+            val updatedTabs = currentTabs.map { tab ->
                 val res = datRepository.getThread(tab.boardUrl, tab.key)
                 val size = res?.first?.size ?: tab.resCount
                 val diff = size - tab.resCount
                 if (diff > 0) {
                     resultMap[tab.key + tab.boardUrl] = diff
                 }
+                val newFirst = if (diff > 0) {
+                    if (tab.firstNewResNo <= tab.lastReadResNo) {
+                        tab.lastReadResNo + 1
+                    } else {
+                        tab.firstNewResNo
+                    }
+                } else {
+                    tab.firstNewResNo
+                }
+                tab.copy(firstNewResNo = newFirst)
             }
             _uiState.update { state ->
-                state.copy(newResCounts = resultMap, isRefreshing = false)
+                state.copy(
+                    openThreadTabs = updatedTabs,
+                    newResCounts = resultMap,
+                    isRefreshing = false
+                )
             }
+            tabsRepository.saveOpenThreadTabs(_uiState.value.openThreadTabs)
         }
     }
 

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/ThreadTabInfo.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/ThreadTabInfo.kt
@@ -8,6 +8,7 @@ data class ThreadTabInfo(
     val boardId: Long,
     val resCount: Int = 0,
     val lastReadResNo: Int = 0,
+    val firstNewResNo: Int = 0,
     val firstVisibleItemIndex: Int = 0, // スクロール位置（インデックス）
     val firstVisibleItemScrollOffset: Int = 0, // スクロール位置（オフセット）
     val bookmarkColorName: String? = null


### PR DESCRIPTION
## Summary
- store first unread response number per thread tab
- update firstNewResNo when new posts arrive
- add Room migration for firstNewResNo

## Testing
- `./gradlew :app:testDebugUnitTest` *(fails: Observed package id 'build-tools;35.0.0' in inconsistent location)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9c6172e48332b478faa0d506be0c