### PR TITLE
fix: block interactions beneath reply popup

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/dialog/ReplyPopup.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/dialog/ReplyPopup.kt
@@ -27,6 +27,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import com.websarva.wings.android.slevo.ui.thread.item.PostItem
 import com.websarva.wings.android.slevo.ui.thread.state.ReplyInfo
+import com.websarva.wings.android.slevo.ui.util.consumeAllPointerEvents
 
 data class PopupInfo(
     val posts: List<ReplyInfo>,
@@ -55,6 +56,7 @@ fun ReplyPopup(
 
     val lastIndex = popupStack.lastIndex
     popupStack.forEachIndexed { index, info ->
+        val isTop = index == lastIndex
         Popup(
             popupPositionProvider = object : PopupPositionProvider {
                 override fun calculatePosition(
@@ -76,10 +78,11 @@ fun ReplyPopup(
                     .onGloballyPositioned { coords ->
                         val size = coords.size
                         if (size != info.size) {
-                        popupStack[index] = info.copy(size = size)
+                            popupStack[index] = info.copy(size = size)
+                        }
                     }
-                }
                     .border(width = 2.dp, color = MaterialTheme.colorScheme.primary)
+                    .let { if (isTop) it else it.consumeAllPointerEvents() }
             ) {
                 val maxHeight = LocalConfiguration.current.screenHeightDp.dp * 0.75f
                 Column(

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
@@ -51,6 +51,7 @@ import com.websarva.wings.android.slevo.ui.thread.item.PostItem
 import com.websarva.wings.android.slevo.ui.thread.state.ReplyInfo
 import com.websarva.wings.android.slevo.ui.thread.state.ThreadSortType
 import com.websarva.wings.android.slevo.ui.thread.state.ThreadUiState
+import com.websarva.wings.android.slevo.ui.util.consumeAllPointerEvents
 import kotlin.math.min
 
 @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
@@ -151,10 +152,12 @@ fun ThreadScreen(
                     }
                     var itemOffset by remember { mutableStateOf(IntOffset.Zero) }
                     PostItem(
-                        modifier = Modifier.onGloballyPositioned { coords ->
-                            val pos = coords.positionInWindow()
-                            itemOffset = IntOffset(pos.x.toInt(), pos.y.toInt())
-                        },
+                        modifier = Modifier
+                            .onGloballyPositioned { coords ->
+                                val pos = coords.positionInWindow()
+                                itemOffset = IntOffset(pos.x.toInt(), pos.y.toInt())
+                            }
+                            .let { if (popupStack.isEmpty()) it else it.consumeAllPointerEvents() },
                         post = post,
                         postNum = postNum,
                         idIndex = uiState.idIndexList.getOrElse(index) { 1 },

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/util/PointerUtils.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/util/PointerUtils.kt
@@ -1,0 +1,9 @@
+package com.websarva.wings.android.slevo.ui.util
+
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+
+fun Modifier.consumeAllPointerEvents(): Modifier = pointerInput(Unit) {
+    detectTapGestures(onPress = { awaitRelease() })
+}


### PR DESCRIPTION
## Summary
- non-top reply popups now absorb pointer events
- thread posts disabled while any reply popup is shown

## Testing
- `./gradlew :app:testDebugUnitTest`
- `./gradlew :app:lintDebug` *(fails: MainActivity must extend android.app.Activity)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9ec3cd588332a8e43a2c0a95db68