### PR TITLE
fix: block interactions behind top reply popup

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/dialog/ReplyPopup.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/dialog/ReplyPopup.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
 import androidx.compose.runtime.Composable
@@ -55,6 +56,7 @@ fun ReplyPopup(
 
     val lastIndex = popupStack.lastIndex
     popupStack.forEachIndexed { index, info ->
+        val isTop = index == lastIndex
         Popup(
             popupPositionProvider = object : PopupPositionProvider {
                 override fun calculatePosition(
@@ -76,10 +78,24 @@ fun ReplyPopup(
                     .onGloballyPositioned { coords ->
                         val size = coords.size
                         if (size != info.size) {
-                        popupStack[index] = info.copy(size = size)
+                            popupStack[index] = info.copy(size = size)
+                        }
                     }
-                }
                     .border(width = 2.dp, color = MaterialTheme.colorScheme.primary)
+                    .then(
+                        if (!isTop) {
+                            Modifier.pointerInput(Unit) {
+                                awaitPointerEventScope {
+                                    while (true) {
+                                        val event = awaitPointerEvent()
+                                        event.changes.forEach { it.consume() }
+                                    }
+                                }
+                            }
+                        } else {
+                            Modifier
+                        }
+                    )
             ) {
                 val maxHeight = LocalConfiguration.current.screenHeightDp.dp * 0.75f
                 Column(

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/dialog/ReplyPopup.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/dialog/ReplyPopup.kt
@@ -87,7 +87,7 @@ fun ReplyPopup(
                             Modifier.pointerInput(Unit) {
                                 awaitPointerEventScope {
                                     while (true) {
-                                        val event = awaitPointerEvent()
+                                        val event = awaitPointerEvent(androidx.compose.ui.input.pointer.PointerEventPass.Initial)
                                         event.changes.forEach { it.consume() }
                                     }
                                 }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalContext
@@ -238,6 +239,21 @@ fun ThreadScreen(
                 posts = displayPosts,
                 replyCounts = replyCounts,
                 lazyListState = listState
+            )
+        }
+
+        if (popupStack.isNotEmpty()) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .pointerInput(Unit) {
+                        awaitPointerEventScope {
+                            while (true) {
+                                val event = awaitPointerEvent()
+                                event.changes.forEach { it.consume() }
+                            }
+                        }
+                    }
             )
         }
 

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
@@ -249,7 +249,7 @@ fun ThreadScreen(
                     .pointerInput(Unit) {
                         awaitPointerEventScope {
                             while (true) {
-                                val event = awaitPointerEvent()
+                                val event = awaitPointerEvent(androidx.compose.ui.input.pointer.PointerEventPass.Initial)
                                 event.changes.forEach { it.consume() }
                             }
                         }


### PR DESCRIPTION
## Summary
- スレッド画面でレスのポップアップ表示中に背面の要素が操作できないようにガード
- 下位のポップアップも長押しなどのイベントを受け取らないように制御

## Testing
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_68ae9ec3cd588332a8e43a2c0a95db68