### PR TITLE
feat: add new arrival bar to thread screen

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/components/NewArrivalBar.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/components/NewArrivalBar.kt
@@ -1,7 +1,7 @@
 package com.websarva.wings.android.slevo.ui.thread.components
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.HorizontalDivider
@@ -11,26 +11,34 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.websarva.wings.android.slevo.R
 
 @Composable
 fun NewArrivalBar() {
-    Box(
+    Column(
         modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 8.dp)
+            .fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        HorizontalDivider(modifier = Modifier.align(Alignment.Center))
         Text(
             text = stringResource(id = R.string.new_responses),
             modifier = Modifier
-                .align(Alignment.Center)
-                .background(MaterialTheme.colorScheme.background)
-                .padding(horizontal = 8.dp),
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.primary)
+                .padding(vertical = 4.dp),
             style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurface
+            color = MaterialTheme.colorScheme.onPrimary,
+            textAlign = TextAlign.Center
         )
+        HorizontalDivider()
     }
 }
 
+@Preview(showBackground = true)
+@Composable
+fun NewArrivalBarPreview() {
+    NewArrivalBar()
+}

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/components/NewArrivalBar.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/components/NewArrivalBar.kt
@@ -1,0 +1,36 @@
+package com.websarva.wings.android.slevo.ui.thread.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.websarva.wings.android.slevo.R
+
+@Composable
+fun NewArrivalBar() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp)
+    ) {
+        HorizontalDivider(modifier = Modifier.align(Alignment.Center))
+        Text(
+            text = stringResource(id = R.string.new_responses),
+            modifier = Modifier
+                .align(Alignment.Center)
+                .background(MaterialTheme.colorScheme.background)
+                .padding(horizontal = 8.dp),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+    }
+}
+

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -139,11 +139,15 @@ fun ThreadScaffold(
                 }
             }
 
+            val firstNewResNo = tabsUiState.openThreadTabs.find {
+                it.key == uiState.threadInfo.key && it.boardUrl == uiState.boardInfo.url
+            }?.firstNewResNo
             ThreadScreen(
                 modifier = modifier,
                 uiState = uiState,
                 listState = listState,
                 navController = navController,
+                firstNewResNo = firstNewResNo,
                 onBottomRefresh = { viewModel.reloadThread() },
                 onLastRead = { resNum ->
                     tabsViewModel.updateThreadLastRead(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,6 +68,7 @@
     <string name="all_boards">すべての板</string>
     <string name="search_board_hint">板名またはURLで検索</string>
     <string name="new_label">new</string>
+    <string name="new_responses">新着</string>
 
     <string name="default_thread_sort_order">レスのデフォルトの並び順</string>
 


### PR DESCRIPTION
## Summary
- show a "新着" bar between first unread responses in thread view
- add `NewArrivalBar` composable and string resource
- wire first new response number from tab info to `ThreadScreen`

## Testing
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_68af0b4d2a088332bd47b4647131f83e