### PR TITLE
fix: handle nullable first unread response

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/AppDatabase.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/AppDatabase.kt
@@ -58,7 +58,7 @@ import com.websarva.wings.android.slevo.data.datasource.local.entity.history.Pos
         BoardFetchMetaEntity::class,
         PostHistoryEntity::class
     ],
-    version = 3,
+    version = 4,
     exportSchema = true
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -93,6 +93,45 @@ abstract class AppDatabase : RoomDatabase() {
                 database.execSQL(
                     "ALTER TABLE open_thread_tabs ADD COLUMN firstNewResNo INTEGER NOT NULL DEFAULT 0"
                 )
+            }
+        }
+
+        val MIGRATION_3_4 = object : androidx.room.migration.Migration(3, 4) {
+            override fun migrate(database: androidx.sqlite.db.SupportSQLiteDatabase) {
+                database.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS new_open_thread_tabs (
+                        threadKey TEXT NOT NULL,
+                        boardUrl TEXT NOT NULL,
+                        boardId INTEGER NOT NULL,
+                        boardName TEXT NOT NULL,
+                        title TEXT NOT NULL,
+                        resCount INTEGER NOT NULL,
+                        lastReadResNo INTEGER NOT NULL,
+                        firstNewResNo INTEGER,
+                        sortOrder INTEGER NOT NULL,
+                        firstVisibleItemIndex INTEGER NOT NULL,
+                        firstVisibleItemScrollOffset INTEGER NOT NULL,
+                        PRIMARY KEY(threadKey, boardUrl)
+                    )
+                    """.trimIndent()
+                )
+                database.execSQL(
+                    """
+                    INSERT INTO new_open_thread_tabs (
+                        threadKey, boardUrl, boardId, boardName, title,
+                        resCount, lastReadResNo, firstNewResNo, sortOrder,
+                        firstVisibleItemIndex, firstVisibleItemScrollOffset
+                    )
+                    SELECT threadKey, boardUrl, boardId, boardName, title,
+                        resCount, lastReadResNo,
+                        CASE WHEN firstNewResNo = 0 THEN NULL ELSE firstNewResNo END,
+                        sortOrder, firstVisibleItemIndex, firstVisibleItemScrollOffset
+                    FROM open_thread_tabs
+                    """.trimIndent()
+                )
+                database.execSQL("DROP TABLE open_thread_tabs")
+                database.execSQL("ALTER TABLE new_open_thread_tabs RENAME TO open_thread_tabs")
             }
         }
     }

--- a/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/entity/TabEntities.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/entity/TabEntities.kt
@@ -26,7 +26,7 @@ data class OpenThreadTabEntity(
     val title: String,
     val resCount: Int = 0,
     val lastReadResNo: Int = 0,
-    val firstNewResNo: Int = 0,
+    val firstNewResNo: Int? = null,
     val sortOrder: Int,
     val firstVisibleItemIndex: Int = 0,
     val firstVisibleItemScrollOffset: Int = 0

--- a/app/src/main/java/com/websarva/wings/android/slevo/di/DatabaseModule.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/di/DatabaseModule.kt
@@ -53,7 +53,7 @@ object DatabaseModule {
             AppDatabase::class.java,
             "slevo_database"
         )
-            .addMigrations(AppDatabase.MIGRATION_1_2, AppDatabase.MIGRATION_2_3)
+            .addMigrations(AppDatabase.MIGRATION_1_2, AppDatabase.MIGRATION_2_3, AppDatabase.MIGRATION_3_4)
             .addCallback(callback)
             .build()
     }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabsViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabsViewModel.kt
@@ -229,11 +229,12 @@ class TabsViewModel @Inject constructor(
         _uiState.update { state ->
             val updated = state.openThreadTabs.map { tab ->
                 if (tab.key == key && tab.boardUrl == boardUrl) {
-                    val newFirst = if (tab.firstNewResNo <= tab.lastReadResNo) {
+                    val candidate = if (tab.firstNewResNo == null || tab.firstNewResNo <= tab.lastReadResNo) {
                         tab.lastReadResNo + 1
                     } else {
                         tab.firstNewResNo
                     }
+                    val newFirst = if (candidate > resCount) null else candidate
                     tab.copy(title = title, resCount = resCount, firstNewResNo = newFirst)
                 } else {
                     tab
@@ -276,7 +277,13 @@ class TabsViewModel @Inject constructor(
         _uiState.update { state ->
             val updated = state.openThreadTabs.map { tab ->
                 if (tab.key == tabKey && tab.boardUrl == boardUrl && lastReadResNo > tab.lastReadResNo) {
-                    tab.copy(lastReadResNo = lastReadResNo)
+                    val candidate = if (tab.firstNewResNo == null || tab.firstNewResNo <= lastReadResNo) {
+                        lastReadResNo + 1
+                    } else {
+                        tab.firstNewResNo
+                    }
+                    val newFirst = if (candidate > tab.resCount) null else candidate
+                    tab.copy(lastReadResNo = lastReadResNo, firstNewResNo = newFirst)
                 } else {
                     tab
                 }
@@ -328,11 +335,12 @@ class TabsViewModel @Inject constructor(
                 if (diff > 0) {
                     resultMap[tab.key + tab.boardUrl] = diff
                 }
-                val newFirst = if (tab.firstNewResNo <= tab.lastReadResNo) {
+                val candidate = if (tab.firstNewResNo == null || tab.firstNewResNo <= tab.lastReadResNo) {
                     tab.lastReadResNo + 1
                 } else {
                     tab.firstNewResNo
                 }
+                val newFirst = if (candidate > size) null else candidate
                 tab.copy(resCount = size, firstNewResNo = newFirst)
             }
             _uiState.update { state ->

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/ThreadTabInfo.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/ThreadTabInfo.kt
@@ -8,7 +8,7 @@ data class ThreadTabInfo(
     val boardId: Long,
     val resCount: Int = 0,
     val lastReadResNo: Int = 0,
-    val firstNewResNo: Int = 0,
+    val firstNewResNo: Int? = null,
     val firstVisibleItemIndex: Int = 0, // スクロール位置（インデックス）
     val firstVisibleItemScrollOffset: Int = 0, // スクロール位置（オフセット）
     val bookmarkColorName: String? = null

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
@@ -87,27 +87,17 @@ fun ThreadScreen(
     val popupStack = remember { androidx.compose.runtime.mutableStateListOf<PopupInfo>() }
     val ngNumbers = uiState.ngPostNumbers
 
-    LaunchedEffect(listState, visiblePosts, uiState.sortType) {
+    LaunchedEffect(listState, posts) {
         snapshotFlow { listState.isScrollInProgress }
             .collect { scrolling ->
                 if (!scrolling) {
                     delay(500)
-                    if (!listState.isScrollInProgress) {
-                        val layoutInfo = listState.layoutInfo
-                        val half = layoutInfo.viewportEndOffset / 2
-                        val lastRead = layoutInfo.visibleItemsInfo
-                            .filter { it.offset < half }
-                            .mapNotNull { info ->
-                                val idx = info.index - 1
-                                if (idx in visiblePosts.indices) {
-                                    val num = visiblePosts[idx].first
-                                    if (uiState.sortType != ThreadSortType.TREE || (uiState.treeDepthMap[num]
-                                            ?: 0) == 0
-                                    ) num else null
-                                } else null
-                            }
-                            .maxOrNull()
-                        lastRead?.let { onLastRead(it) }
+                    if (
+                        !listState.isScrollInProgress &&
+                        !listState.canScrollForward &&
+                        posts.isNotEmpty()
+                    ) {
+                        onLastRead(posts.size)
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- allow `firstNewResNo` to be nullable and add migration
- update read tracking to set last read at thread bottom
- adjust logic to null out invalid `firstNewResNo`
- fix scroll handler to update last read only when at thread end

## Testing
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_68af06a3a76483328c62f543654df130