### PR TITLE
fix: update last read on bottom refresh

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
@@ -124,7 +124,7 @@ fun ThreadScreen(
     val refreshThresholdPx = with(density) { 80.dp.toPx() }
     var overscroll by remember { mutableFloatStateOf(0f) }
     var triggerRefresh by remember { mutableStateOf(false) }
-    val nestedScrollConnection = remember(listState) {
+    val nestedScrollConnection = remember(listState, posts.size) {
         object : NestedScrollConnection {
             override fun onPostScroll(
                 consumed: Offset,
@@ -143,6 +143,7 @@ fun ThreadScreen(
 
             override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
                 if (triggerRefresh) {
+                    onLastRead(posts.size)
                     onBottomRefresh()
                 }
                 overscroll = 0f


### PR DESCRIPTION
## Summary
- update last read position when refreshing a thread by swiping at the bottom

## Testing
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_68af35c0af808332abfbdcd726d77524