### PR TITLE
feat: adjust tree view for new replies

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/item/PostItem.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/item/PostItem.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.pointerInput
@@ -78,6 +79,7 @@ fun PostItem(
     indentLevel: Int = 0,
     replyFromNumbers: List<Int> = emptyList(),
     isMyPost: Boolean = false,
+    dimmed: Boolean = false,
     onReplyFromClick: ((List<Int>) -> Unit)? = null,
     onReplyClick: ((Int) -> Unit)? = null,
     onIdClick: ((String) -> Unit)? = null,
@@ -102,6 +104,7 @@ fun PostItem(
         modifier = modifier
             .fillMaxWidth()
             .padding(start = 16.dp * indentLevel)
+            .alpha(if (dimmed) 0.6f else 1f)
             .drawBehind {
                 if (indentLevel > 0) {
                     val strokeWidth = 1.dp.toPx()

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -139,15 +139,18 @@ fun ThreadScaffold(
                 }
             }
 
-            val firstNewResNo = tabsUiState.openThreadTabs.find {
+            val tabInfo = tabsUiState.openThreadTabs.find {
                 it.key == uiState.threadInfo.key && it.boardUrl == uiState.boardInfo.url
-            }?.firstNewResNo
+            }
+            val firstNewResNo = tabInfo?.firstNewResNo
+            val prevResCount = tabInfo?.prevResCount ?: 0
             ThreadScreen(
                 modifier = modifier,
                 uiState = uiState,
                 listState = listState,
                 navController = navController,
                 firstNewResNo = firstNewResNo,
+                prevResCount = prevResCount,
                 onBottomRefresh = { viewModel.reloadThread() },
                 onLastRead = { resNum ->
                     tabsViewModel.updateThreadLastRead(

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
@@ -59,6 +59,13 @@ import androidx.compose.runtime.snapshotFlow
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
 
+private data class DisplayPost(
+    val num: Int,
+    val post: ReplyInfo,
+    val dimmed: Boolean,
+    val isAfter: Boolean
+)
+
 @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
 @Composable
 fun ThreadScreen(
@@ -67,6 +74,7 @@ fun ThreadScreen(
     listState: LazyListState = rememberLazyListState(),
     navController: NavHostController,
     firstNewResNo: Int? = null,
+    prevResCount: Int = 0,
     onBottomRefresh: () -> Unit = {},
     onLastRead: (Int) -> Unit = {},
 ) {
@@ -76,17 +84,59 @@ fun ThreadScreen(
     } else {
         (1..posts.size).toList()
     }
-    val orderedPosts = order.mapNotNull { num ->
-        posts.getOrNull(num - 1)?.let { num to it }
+
+    val orderedPosts = if (uiState.sortType == ThreadSortType.TREE && firstNewResNo != null) {
+        val parentMap = mutableMapOf<Int, Int>()
+        val stack = mutableListOf<Int>()
+        order.forEach { num ->
+            val depth = uiState.treeDepthMap[num] ?: 0
+            while (stack.size > depth) stack.removeLast()
+            parentMap[num] = stack.lastOrNull() ?: 0
+            stack.add(num)
+        }
+        val before = mutableListOf<DisplayPost>()
+        val after = mutableListOf<DisplayPost>()
+        val insertedParents = mutableSetOf<Int>()
+        order.forEach { num ->
+            val parent = parentMap[num] ?: 0
+            val post = posts.getOrNull(num - 1) ?: return@forEach
+            if (num < firstNewResNo) {
+                before.add(DisplayPost(num, post, false, false))
+            } else {
+                val parentOld = parent in 1 until firstNewResNo
+                if (parentOld && num <= prevResCount) {
+                    before.add(DisplayPost(num, post, false, false))
+                } else {
+                    if (parentOld) {
+                        if (insertedParents.add(parent)) {
+                            posts.getOrNull(parent - 1)?.let { p ->
+                                after.add(DisplayPost(parent, p, true, true))
+                            }
+                        }
+                    }
+                    after.add(DisplayPost(num, post, false, true))
+                }
+            }
+        }
+        before + after
+    } else {
+        order.mapNotNull { num ->
+            posts.getOrNull(num - 1)?.let { post ->
+                val isAfter = firstNewResNo != null && num >= firstNewResNo
+                DisplayPost(num, post, false, isAfter)
+            }
+        }
     }
+
     val filteredPosts = if (uiState.searchQuery.isNotBlank()) {
-        orderedPosts.filter { it.second.content.contains(uiState.searchQuery, ignoreCase = true) }
+        orderedPosts.filter { it.post.content.contains(uiState.searchQuery, ignoreCase = true) }
     } else {
         orderedPosts
     }
-    val visiblePosts = filteredPosts.filterNot { it.first in uiState.ngPostNumbers }
-    val displayPosts = visiblePosts.map { it.second }
-    val replyCounts = visiblePosts.map { (num, _) -> uiState.replySourceMap[num]?.size ?: 0 }
+    val visiblePosts = filteredPosts.filterNot { it.num in uiState.ngPostNumbers }
+    val displayPosts = visiblePosts.map { it.post }
+    val replyCounts = visiblePosts.map { p -> uiState.replySourceMap[p.num]?.size ?: 0 }
+    val firstAfterIndex = visiblePosts.indexOfFirst { it.isAfter }
     val popupStack = remember { androidx.compose.runtime.mutableStateListOf<PopupInfo>() }
     val ngNumbers = uiState.ngPostNumbers
 
@@ -106,7 +156,7 @@ fun ThreadScreen(
                                 .mapNotNull { info ->
                                     val idx = info.index - 1
                                     if (idx in visiblePosts.indices) {
-                                        val num = visiblePosts[idx].first
+                                        val num = visiblePosts[idx].num
                                         if (uiState.sortType != ThreadSortType.TREE || (uiState.treeDepthMap[num]
                                                 ?: 0) == 0
                                         ) num else null
@@ -163,7 +213,7 @@ fun ThreadScreen(
             ) {
                 if (visiblePosts.isNotEmpty()) {
                     val firstIndent = if (uiState.sortType == ThreadSortType.TREE) {
-                        uiState.treeDepthMap[visiblePosts.first().first] ?: 0
+                        uiState.treeDepthMap[visiblePosts.first().num] ?: 0
                     } else {
                         0
                     }
@@ -172,7 +222,9 @@ fun ThreadScreen(
                     }
                 }
 
-                itemsIndexed(visiblePosts) { idx, (postNum, post) ->
+                itemsIndexed(visiblePosts) { idx, display ->
+                    val postNum = display.num
+                    val post = display.post
                     val index = postNum - 1
                     val indent = if (uiState.sortType == ThreadSortType.TREE) {
                         uiState.treeDepthMap[postNum] ?: 0
@@ -181,7 +233,7 @@ fun ThreadScreen(
                     }
                     val nextIndent = if (idx + 1 < visiblePosts.size) {
                         if (uiState.sortType == ThreadSortType.TREE) {
-                            uiState.treeDepthMap[visiblePosts[idx + 1].first] ?: 0
+                            uiState.treeDepthMap[visiblePosts[idx + 1].num] ?: 0
                         } else {
                             0
                         }
@@ -190,7 +242,7 @@ fun ThreadScreen(
                     }
                     var itemOffset by remember { mutableStateOf(IntOffset.Zero) }
                     Column {
-                        if (firstNewResNo != null && postNum == firstNewResNo) {
+                        if (firstAfterIndex != -1 && idx == firstAfterIndex) {
                             NewArrivalBar()
                         }
                         PostItem(
@@ -208,6 +260,7 @@ fun ThreadScreen(
                             indentLevel = indent,
                             replyFromNumbers = uiState.replySourceMap[postNum] ?: emptyList(),
                             isMyPost = postNum in uiState.myPostNumbers,
+                            dimmed = display.dimmed,
                             onReplyFromClick = { nums ->
                                 val offset = if (popupStack.isEmpty()) {
                                     itemOffset


### PR DESCRIPTION
## Summary
- refine thread tree sorting to keep old posts above new replies
- dim parent posts repeated below the new arrival bar
- plumb previous count to determine placement in tree view

## Testing
- `./gradlew :app:testDebugUnitTest`
- `./gradlew :app:lintDebug` *(fails: MainActivity must extend android.app.Activity)*

------
https://chatgpt.com/codex/tasks/task_e_68b1987c2b648332a429e924495d68bb