### PR TITLE
refactor: move thread display logic to ViewModel

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -138,13 +138,14 @@ fun ThreadScaffold(
             }
             val firstNewResNo = tabInfo?.firstNewResNo
             val prevResCount = tabInfo?.prevResCount ?: 0
+            LaunchedEffect(firstNewResNo, prevResCount) {
+                viewModel.setNewArrivalInfo(firstNewResNo, prevResCount)
+            }
             ThreadScreen(
                 modifier = modifier,
                 uiState = uiState,
                 listState = listState,
                 navController = navController,
-                firstNewResNo = firstNewResNo,
-                prevResCount = prevResCount,
                 onBottomRefresh = { viewModel.reloadThread() },
                 onLastRead = { resNum ->
                     viewModel.updateThreadLastRead(

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
@@ -54,17 +54,11 @@ import com.websarva.wings.android.slevo.ui.thread.item.PostItem
 import com.websarva.wings.android.slevo.ui.thread.state.ReplyInfo
 import com.websarva.wings.android.slevo.ui.thread.state.ThreadSortType
 import com.websarva.wings.android.slevo.ui.thread.state.ThreadUiState
+import com.websarva.wings.android.slevo.ui.thread.state.DisplayPost
 import kotlin.math.min
 import androidx.compose.runtime.snapshotFlow
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
-
-private data class DisplayPost(
-    val num: Int,
-    val post: ReplyInfo,
-    val dimmed: Boolean,
-    val isAfter: Boolean
-)
 
 @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
 @Composable
@@ -73,70 +67,14 @@ fun ThreadScreen(
     uiState: ThreadUiState,
     listState: LazyListState = rememberLazyListState(),
     navController: NavHostController,
-    firstNewResNo: Int? = null,
-    prevResCount: Int = 0,
     onBottomRefresh: () -> Unit = {},
     onLastRead: (Int) -> Unit = {},
 ) {
     val posts = uiState.posts ?: emptyList()
-    val order = if (uiState.sortType == ThreadSortType.TREE) {
-        uiState.treeOrder
-    } else {
-        (1..posts.size).toList()
-    }
-
-    val orderedPosts = if (uiState.sortType == ThreadSortType.TREE && firstNewResNo != null) {
-        val parentMap = mutableMapOf<Int, Int>()
-        val stack = mutableListOf<Int>()
-        order.forEach { num ->
-            val depth = uiState.treeDepthMap[num] ?: 0
-            while (stack.size > depth) stack.removeLast()
-            parentMap[num] = stack.lastOrNull() ?: 0
-            stack.add(num)
-        }
-        val before = mutableListOf<DisplayPost>()
-        val after = mutableListOf<DisplayPost>()
-        val insertedParents = mutableSetOf<Int>()
-        order.forEach { num ->
-            val parent = parentMap[num] ?: 0
-            val post = posts.getOrNull(num - 1) ?: return@forEach
-            if (num < firstNewResNo) {
-                before.add(DisplayPost(num, post, false, false))
-            } else {
-                val parentOld = parent in 1 until firstNewResNo
-                if (parentOld && num <= prevResCount) {
-                    before.add(DisplayPost(num, post, false, false))
-                } else {
-                    if (parentOld) {
-                        if (insertedParents.add(parent)) {
-                            posts.getOrNull(parent - 1)?.let { p ->
-                                after.add(DisplayPost(parent, p, true, true))
-                            }
-                        }
-                    }
-                    after.add(DisplayPost(num, post, false, true))
-                }
-            }
-        }
-        before + after
-    } else {
-        order.mapNotNull { num ->
-            posts.getOrNull(num - 1)?.let { post ->
-                val isAfter = firstNewResNo != null && num >= firstNewResNo
-                DisplayPost(num, post, false, isAfter)
-            }
-        }
-    }
-
-    val filteredPosts = if (uiState.searchQuery.isNotBlank()) {
-        orderedPosts.filter { it.post.content.contains(uiState.searchQuery, ignoreCase = true) }
-    } else {
-        orderedPosts
-    }
-    val visiblePosts = filteredPosts.filterNot { it.num in uiState.ngPostNumbers }
+    val visiblePosts = uiState.visiblePosts
     val displayPosts = visiblePosts.map { it.post }
-    val replyCounts = visiblePosts.map { p -> uiState.replySourceMap[p.num]?.size ?: 0 }
-    val firstAfterIndex = visiblePosts.indexOfFirst { it.isAfter }
+    val replyCounts = uiState.replyCounts
+    val firstAfterIndex = uiState.firstAfterIndex
     val popupStack = remember { androidx.compose.runtime.mutableStateListOf<PopupInfo>() }
     val ngNumbers = uiState.ngPostNumbers
 

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/state/DisplayPost.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/state/DisplayPost.kt
@@ -1,0 +1,11 @@
+package com.websarva.wings.android.slevo.ui.thread.state
+
+/**
+ * UI表示用の投稿情報
+ */
+data class DisplayPost(
+    val num: Int,
+    val post: ReplyInfo,
+    val dimmed: Boolean,
+    val isAfter: Boolean
+)

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/state/PostUiState.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/state/PostUiState.kt
@@ -1,0 +1,26 @@
+package com.websarva.wings.android.slevo.ui.thread.state
+
+import com.websarva.wings.android.slevo.data.repository.ConfirmationData
+
+/**
+ * 投稿機能用のUI状態を保持するデータクラス
+ */
+data class PostUiState(
+    val postDialog: Boolean = false,
+    val postFormState: PostFormState = PostFormState(),
+    val isPosting: Boolean = false,
+    val postConfirmation: ConfirmationData? = null,
+    val isConfirmationScreen: Boolean = false,
+    val showErrorWebView: Boolean = false,
+    val errorHtmlContent: String = "",
+    val postResultMessage: String? = null,
+)
+
+/**
+ * 投稿フォームの入力状態
+ */
+data class PostFormState(
+    val name: String = "",
+    val mail: String = "",
+    val message: String = "",
+)

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/state/ThreadUiState.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/state/ThreadUiState.kt
@@ -2,7 +2,6 @@ package com.websarva.wings.android.slevo.ui.thread.state
 
 import com.websarva.wings.android.slevo.data.model.BoardInfo
 import com.websarva.wings.android.slevo.data.model.ThreadInfo
-import com.websarva.wings.android.slevo.data.repository.ConfirmationData
 import com.websarva.wings.android.slevo.ui.common.BaseUiState
 import com.websarva.wings.android.slevo.ui.common.bookmark.SingleBookmarkState
 
@@ -16,17 +15,9 @@ data class ThreadUiState(
     val posts: List<ReplyInfo>? = null,
     val loadProgress: Float = 0f,
     val boardInfo: BoardInfo = BoardInfo(0, "", ""),
-    val postDialog: Boolean = false,
-    val postFormState: PostFormState = PostFormState(),
-    val isPosting: Boolean = false,
-    val postConfirmation: ConfirmationData? = null,
-    val isConfirmationScreen: Boolean = false,
     val singleBookmarkState: SingleBookmarkState = SingleBookmarkState(),
     override val isLoading: Boolean = false,
     override val showTabListSheet: Boolean = false,
-    val showErrorWebView: Boolean = false,
-    val errorHtmlContent: String = "",
-    val postResultMessage: String? = null,
     val myPostNumbers: Set<Int> = emptySet(),
     // UI描画用の派生情報（ViewModelで算出）
     val idCountMap: Map<String, Int> = emptyMap(),
@@ -73,10 +64,3 @@ data class ReplyInfo(
         const val HAS_OTHER_URL = 1 shl 2
     }
 }
-
-data class PostFormState(
-    val name: String = "",
-    val mail: String = "",
-    val message: String = ""
-)
-

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/state/ThreadUiState.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/state/ThreadUiState.kt
@@ -38,6 +38,11 @@ data class ThreadUiState(
     val sortType: ThreadSortType = ThreadSortType.NUMBER,
     val treeOrder: List<Int> = emptyList(),
     val treeDepthMap: Map<Int, Int> = emptyMap(),
+    val firstNewResNo: Int? = null,
+    val prevResCount: Int = 0,
+    val visiblePosts: List<DisplayPost> = emptyList(),
+    val replyCounts: List<Int> = emptyList(),
+    val firstAfterIndex: Int = -1,
 ) : BaseUiState<ThreadUiState> {
     override fun copyState(
         isLoading: Boolean,

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/viewmodel/PostViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/viewmodel/PostViewModel.kt
@@ -1,0 +1,176 @@
+package com.websarva.wings.android.slevo.ui.thread.viewmodel
+
+import android.content.Context
+import android.net.Uri
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.websarva.wings.android.slevo.data.repository.ConfirmationData
+import com.websarva.wings.android.slevo.data.repository.ImageUploadRepository
+import com.websarva.wings.android.slevo.data.repository.PostRepository
+import com.websarva.wings.android.slevo.data.repository.PostResult
+import com.websarva.wings.android.slevo.ui.thread.state.PostUiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+@HiltViewModel
+class PostViewModel @Inject constructor(
+    private val postRepository: PostRepository,
+    private val imageUploadRepository: ImageUploadRepository,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(PostUiState())
+    val uiState: StateFlow<PostUiState> = _uiState.asStateFlow()
+
+    fun showPostDialog() {
+        _uiState.update { it.copy(postDialog = true) }
+    }
+
+    fun hidePostDialog() {
+        _uiState.update { it.copy(postDialog = false) }
+    }
+
+    fun hideConfirmationScreen() {
+        _uiState.update { it.copy(isConfirmationScreen = false) }
+    }
+
+    fun updatePostName(name: String) {
+        _uiState.update { it.copy(postFormState = it.postFormState.copy(name = name)) }
+    }
+
+    fun updatePostMail(mail: String) {
+        _uiState.update { it.copy(postFormState = it.postFormState.copy(mail = mail)) }
+    }
+
+    fun updatePostMessage(message: String) {
+        _uiState.update { it.copy(postFormState = it.postFormState.copy(message = message)) }
+    }
+
+    fun hideErrorWebView() {
+        _uiState.update { it.copy(showErrorWebView = false, errorHtmlContent = "") }
+    }
+
+    fun postFirstPhase(
+        host: String,
+        board: String,
+        threadKey: String,
+        name: String,
+        mail: String,
+        message: String,
+        onSuccess: (Int?) -> Unit,
+    ) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isPosting = true, postDialog = false) }
+            val result =
+                postRepository.postTo5chFirstPhase(host, board, threadKey, name, mail, message)
+
+            _uiState.update { it.copy(isPosting = false) }
+
+            when (result) {
+                is PostResult.Success -> {
+                    _uiState.update {
+                        it.copy(
+                            postResultMessage = "書き込みに成功しました。",
+                        )
+                    }
+                    onSuccess(result.resNum)
+                }
+
+                is PostResult.Confirm -> {
+                    _uiState.update {
+                        it.copy(
+                            postConfirmation = result.confirmationData,
+                            isConfirmationScreen = true,
+                        )
+                    }
+                }
+
+                is PostResult.Error -> {
+                    _uiState.update {
+                        it.copy(
+                            showErrorWebView = true,
+                            errorHtmlContent = result.html,
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    fun postTo5chSecondPhase(
+        host: String,
+        board: String,
+        threadKey: String,
+        confirmationData: ConfirmationData,
+        onSuccess: (Int?) -> Unit,
+    ) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isPosting = true, isConfirmationScreen = false) }
+            val result = postRepository.postTo5chSecondPhase(
+                host,
+                board,
+                threadKey,
+                confirmationData,
+            )
+
+            _uiState.update { it.copy(isPosting = false) }
+
+            when (result) {
+                is PostResult.Success -> {
+                    _uiState.update {
+                        it.copy(
+                            postResultMessage = "書き込みに成功しました。",
+                        )
+                    }
+                    onSuccess(result.resNum)
+                }
+
+                is PostResult.Error -> {
+                    _uiState.update {
+                        it.copy(
+                            showErrorWebView = true,
+                            errorHtmlContent = result.html,
+                        )
+                    }
+                }
+
+                is PostResult.Confirm -> {
+                    _uiState.update {
+                        it.copy(
+                            postConfirmation = result.confirmationData,
+                            isConfirmationScreen = true,
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    fun uploadImage(context: Context, uri: Uri) {
+        viewModelScope.launch {
+            val bytes = withContext(Dispatchers.IO) {
+                context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
+            }
+            bytes?.let {
+                val url = imageUploadRepository.uploadImage(it)
+                if (url != null) {
+                    val msg = uiState.value.postFormState.message
+                    _uiState.update { current ->
+                        current.copy(
+                            postFormState = current.postFormState.copy(message = msg + "\n" + url),
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    fun clearPostResultMessage() {
+        _uiState.update { it.copy(postResultMessage = null) }
+    }
+}


### PR DESCRIPTION
## Summary
- move post display calculations from ThreadScreen to ThreadViewModel
- add DisplayPost model and uiState fields for visible posts and counts
- update scaffold to provide new arrival info via ViewModel

## Testing
- `./gradlew :app:lintDebug` *(fails: MainActivity must extend android.app.Activity)*
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_68b566d5a16c8332a3cd11017c9e3bea