### PR TITLE
refactor: separate post logic into PostViewModel

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/state/PostUiState.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/state/PostUiState.kt
@@ -1,0 +1,26 @@
+package com.websarva.wings.android.slevo.ui.thread.state
+
+import com.websarva.wings.android.slevo.data.repository.ConfirmationData
+
+/**
+ * 投稿機能用のUI状態を保持するデータクラス
+ */
+data class PostUiState(
+    val postDialog: Boolean = false,
+    val postFormState: PostFormState = PostFormState(),
+    val isPosting: Boolean = false,
+    val postConfirmation: ConfirmationData? = null,
+    val isConfirmationScreen: Boolean = false,
+    val showErrorWebView: Boolean = false,
+    val errorHtmlContent: String = "",
+    val postResultMessage: String? = null,
+)
+
+/**
+ * 投稿フォームの入力状態
+ */
+data class PostFormState(
+    val name: String = "",
+    val mail: String = "",
+    val message: String = "",
+)

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/state/ThreadUiState.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/state/ThreadUiState.kt
@@ -2,7 +2,6 @@ package com.websarva.wings.android.slevo.ui.thread.state
 
 import com.websarva.wings.android.slevo.data.model.BoardInfo
 import com.websarva.wings.android.slevo.data.model.ThreadInfo
-import com.websarva.wings.android.slevo.data.repository.ConfirmationData
 import com.websarva.wings.android.slevo.ui.common.BaseUiState
 import com.websarva.wings.android.slevo.ui.common.bookmark.SingleBookmarkState
 
@@ -16,17 +15,9 @@ data class ThreadUiState(
     val posts: List<ReplyInfo>? = null,
     val loadProgress: Float = 0f,
     val boardInfo: BoardInfo = BoardInfo(0, "", ""),
-    val postDialog: Boolean = false,
-    val postFormState: PostFormState = PostFormState(),
-    val isPosting: Boolean = false,
-    val postConfirmation: ConfirmationData? = null,
-    val isConfirmationScreen: Boolean = false,
     val singleBookmarkState: SingleBookmarkState = SingleBookmarkState(),
     override val isLoading: Boolean = false,
     override val showTabListSheet: Boolean = false,
-    val showErrorWebView: Boolean = false,
-    val errorHtmlContent: String = "",
-    val postResultMessage: String? = null,
     val myPostNumbers: Set<Int> = emptySet(),
     // UI描画用の派生情報（ViewModelで算出）
     val idCountMap: Map<String, Int> = emptyMap(),
@@ -73,10 +64,3 @@ data class ReplyInfo(
         const val HAS_OTHER_URL = 1 shl 2
     }
 }
-
-data class PostFormState(
-    val name: String = "",
-    val mail: String = "",
-    val message: String = ""
-)
-

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/viewmodel/PostViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/viewmodel/PostViewModel.kt
@@ -1,0 +1,176 @@
+package com.websarva.wings.android.slevo.ui.thread.viewmodel
+
+import android.content.Context
+import android.net.Uri
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.websarva.wings.android.slevo.data.repository.ConfirmationData
+import com.websarva.wings.android.slevo.data.repository.ImageUploadRepository
+import com.websarva.wings.android.slevo.data.repository.PostRepository
+import com.websarva.wings.android.slevo.data.repository.PostResult
+import com.websarva.wings.android.slevo.ui.thread.state.PostUiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+@HiltViewModel
+class PostViewModel @Inject constructor(
+    private val postRepository: PostRepository,
+    private val imageUploadRepository: ImageUploadRepository,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(PostUiState())
+    val uiState: StateFlow<PostUiState> = _uiState.asStateFlow()
+
+    fun showPostDialog() {
+        _uiState.update { it.copy(postDialog = true) }
+    }
+
+    fun hidePostDialog() {
+        _uiState.update { it.copy(postDialog = false) }
+    }
+
+    fun hideConfirmationScreen() {
+        _uiState.update { it.copy(isConfirmationScreen = false) }
+    }
+
+    fun updatePostName(name: String) {
+        _uiState.update { it.copy(postFormState = it.postFormState.copy(name = name)) }
+    }
+
+    fun updatePostMail(mail: String) {
+        _uiState.update { it.copy(postFormState = it.postFormState.copy(mail = mail)) }
+    }
+
+    fun updatePostMessage(message: String) {
+        _uiState.update { it.copy(postFormState = it.postFormState.copy(message = message)) }
+    }
+
+    fun hideErrorWebView() {
+        _uiState.update { it.copy(showErrorWebView = false, errorHtmlContent = "") }
+    }
+
+    fun postFirstPhase(
+        host: String,
+        board: String,
+        threadKey: String,
+        name: String,
+        mail: String,
+        message: String,
+        onSuccess: (Int?) -> Unit,
+    ) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isPosting = true, postDialog = false) }
+            val result =
+                postRepository.postTo5chFirstPhase(host, board, threadKey, name, mail, message)
+
+            _uiState.update { it.copy(isPosting = false) }
+
+            when (result) {
+                is PostResult.Success -> {
+                    _uiState.update {
+                        it.copy(
+                            postResultMessage = "書き込みに成功しました。",
+                        )
+                    }
+                    onSuccess(result.resNum)
+                }
+
+                is PostResult.Confirm -> {
+                    _uiState.update {
+                        it.copy(
+                            postConfirmation = result.confirmationData,
+                            isConfirmationScreen = true,
+                        )
+                    }
+                }
+
+                is PostResult.Error -> {
+                    _uiState.update {
+                        it.copy(
+                            showErrorWebView = true,
+                            errorHtmlContent = result.html,
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    fun postTo5chSecondPhase(
+        host: String,
+        board: String,
+        threadKey: String,
+        confirmationData: ConfirmationData,
+        onSuccess: (Int?) -> Unit,
+    ) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isPosting = true, isConfirmationScreen = false) }
+            val result = postRepository.postTo5chSecondPhase(
+                host,
+                board,
+                threadKey,
+                confirmationData,
+            )
+
+            _uiState.update { it.copy(isPosting = false) }
+
+            when (result) {
+                is PostResult.Success -> {
+                    _uiState.update {
+                        it.copy(
+                            postResultMessage = "書き込みに成功しました。",
+                        )
+                    }
+                    onSuccess(result.resNum)
+                }
+
+                is PostResult.Error -> {
+                    _uiState.update {
+                        it.copy(
+                            showErrorWebView = true,
+                            errorHtmlContent = result.html,
+                        )
+                    }
+                }
+
+                is PostResult.Confirm -> {
+                    _uiState.update {
+                        it.copy(
+                            postConfirmation = result.confirmationData,
+                            isConfirmationScreen = true,
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    fun uploadImage(context: Context, uri: Uri) {
+        viewModelScope.launch {
+            val bytes = withContext(Dispatchers.IO) {
+                context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
+            }
+            bytes?.let {
+                val url = imageUploadRepository.uploadImage(it)
+                if (url != null) {
+                    val msg = uiState.value.postFormState.message
+                    _uiState.update { current ->
+                        current.copy(
+                            postFormState = current.postFormState.copy(message = msg + "\n" + url),
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    fun clearPostResultMessage() {
+        _uiState.update { it.copy(postResultMessage = null) }
+    }
+}


### PR DESCRIPTION
## Summary
- extract posting state into new PostViewModel
- delegate thread reloading via onPostSuccess
- update UI to consume PostViewModel

## Testing
- `./gradlew :app:testDebugUnitTest`

------
https://chatgpt.com/codex/tasks/task_e_68b591eebca88332ac848935b6f78418