### PR TITLE
Refine tree post ordering for new replies

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
@@ -101,10 +101,10 @@ fun ThreadScreen(
                                 .mapNotNull { info ->
                                     val idx = info.index - 1
                                     if (idx in visiblePosts.indices) {
-                                        val num = visiblePosts[idx].num
-                                        if (uiState.sortType != ThreadSortType.TREE || (uiState.treeDepthMap[num]
-                                                ?: 0) == 0
-                                        ) num else null
+                                        val display = visiblePosts[idx]
+                                        if (uiState.sortType != ThreadSortType.TREE || display.indent == 0) {
+                                            display.num
+                                        } else null
                                     } else null
                                 }
                                 .maxOrNull()
@@ -158,7 +158,7 @@ fun ThreadScreen(
             ) {
                 if (visiblePosts.isNotEmpty()) {
                     val firstIndent = if (uiState.sortType == ThreadSortType.TREE) {
-                        uiState.treeDepthMap[visiblePosts.first().num] ?: 0
+                        visiblePosts.first().indent
                     } else {
                         0
                     }
@@ -175,13 +175,13 @@ fun ThreadScreen(
                     val post = display.post
                     val index = postNum - 1
                     val indent = if (uiState.sortType == ThreadSortType.TREE) {
-                        uiState.treeDepthMap[postNum] ?: 0
+                        display.indent
                     } else {
                         0
                     }
                     val nextIndent = if (idx + 1 < visiblePosts.size) {
                         if (uiState.sortType == ThreadSortType.TREE) {
-                            uiState.treeDepthMap[visiblePosts[idx + 1].num] ?: 0
+                            visiblePosts[idx + 1].indent
                         } else {
                             0
                         }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/state/DisplayPost.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/state/DisplayPost.kt
@@ -7,5 +7,6 @@ data class DisplayPost(
     val num: Int,
     val post: ReplyInfo,
     val dimmed: Boolean,
-    val isAfter: Boolean
+    val isAfter: Boolean,
+    val indent: Int
 )


### PR DESCRIPTION
## Summary
- split posts into `before`/`after` in number order before tree sorting
- show dimmed parent at root when new reply belongs to old thread
- carry indent info in `DisplayPost` and render via `ThreadScreen`

## Testing
- `./gradlew :app:testDebugUnitTest`
- `./gradlew :app:lintDebug` *(fails: MainActivity must extend android.app.Activity)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a1a4b3408332bf25f11beb4f7338