### PR TITLE
feat: add markers to momentum bar

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/components/MomentumBar.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/components/MomentumBar.kt
@@ -47,7 +47,9 @@ fun MomentumBar(
     val replyColors = replyCounts.map { count ->
         if (count >= 5) replyCountColor(count) else Color.Unspecified
     }
-    val markerColor = MaterialTheme.colorScheme.primary
+
+    val arrivalMarkerColor = MaterialTheme.colorScheme.tertiary
+    val myPostMarkerColor = MaterialTheme.colorScheme.primary
 
     var barHeight by remember { mutableStateOf(0) }
     val scope = rememberCoroutineScope()
@@ -197,7 +199,7 @@ fun MomentumBar(
                         lineTo(x - half, y)
                         close()
                     }
-                    drawPath(path = path, color = markerColor)
+                    drawPath(path = path, color = myPostMarkerColor)
                 }
             }
 
@@ -206,7 +208,7 @@ fun MomentumBar(
                 val y = firstAfterIndex * postHeight
                 val strokeWidth = 1.dp.toPx()
                 drawLine(
-                    color = markerColor,
+                    color = arrivalMarkerColor,
                     start = Offset(0f, y),
                     end = Offset(canvasWidth, y),
                     strokeWidth = strokeWidth

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/components/MomentumBar.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/components/MomentumBar.kt
@@ -33,7 +33,9 @@ fun MomentumBar(
     modifier: Modifier = Modifier,
     posts: List<ReplyInfo>,
     replyCounts: List<Int>,
-    lazyListState: LazyListState
+    lazyListState: LazyListState,
+    firstAfterIndex: Int = -1,
+    myPostNumbers: Set<Int> = emptySet()
 ) {
     val barColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.6f)
     val indicatorColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.2f)
@@ -45,6 +47,7 @@ fun MomentumBar(
     val replyColors = replyCounts.map { count ->
         if (count >= 5) replyCountColor(count) else Color.Unspecified
     }
+    val markerColor = MaterialTheme.colorScheme.primary
 
     var barHeight by remember { mutableStateOf(0) }
     val scope = rememberCoroutineScope()
@@ -178,6 +181,37 @@ fun MomentumBar(
                     drawPath(path = path, color = color)
                 }
             }
+
+            // 書き込みマーク（自分の投稿）
+            val diamondSize = 8.dp.toPx()
+            myPostNumbers.forEach { num ->
+                val index = num - 1
+                if (index in posts.indices) {
+                    val y = index * postHeight + postHeight / 2f
+                    val x = canvasWidth / 2f
+                    val half = diamondSize / 2f
+                    val path = Path().apply {
+                        moveTo(x, y - half)
+                        lineTo(x + half, y)
+                        lineTo(x, y + half)
+                        lineTo(x - half, y)
+                        close()
+                    }
+                    drawPath(path = path, color = markerColor)
+                }
+            }
+
+            // 新着マーク
+            if (firstAfterIndex in 0..posts.size) {
+                val y = firstAfterIndex * postHeight
+                val strokeWidth = 1.dp.toPx()
+                drawLine(
+                    color = markerColor,
+                    start = Offset(0f, y),
+                    end = Offset(canvasWidth, y),
+                    strokeWidth = strokeWidth
+                )
+            }
         }
     }
 }
@@ -206,5 +240,12 @@ fun MomentumBarPreview() {
     }
     val listState = rememberLazyListState()
     val counts = List(dummyPosts.size) { index -> if (index % 7 == 0) 5 else 0 }
-    MomentumBar(posts = dummyPosts, replyCounts = counts, lazyListState = listState)
+    val myPosts = setOf(3, 15, 25)
+    MomentumBar(
+        posts = dummyPosts,
+        replyCounts = counts,
+        lazyListState = listState,
+        firstAfterIndex = 10,
+        myPostNumbers = myPosts
+    )
 }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/components/NewArrivalBar.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/components/NewArrivalBar.kt
@@ -27,7 +27,7 @@ fun NewArrivalBar() {
             text = stringResource(id = R.string.new_responses),
             modifier = Modifier
                 .fillMaxWidth()
-                .background(MaterialTheme.colorScheme.primary)
+                .background(MaterialTheme.colorScheme.tertiary)
                 .padding(vertical = 4.dp),
             style = MaterialTheme.typography.labelMedium,
             color = MaterialTheme.colorScheme.onPrimary,

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
@@ -289,7 +289,9 @@ fun ThreadScreen(
                     .fillMaxHeight(),
                 posts = displayPosts,
                 replyCounts = replyCounts,
-                lazyListState = listState
+                lazyListState = listState,
+                firstAfterIndex = firstAfterIndex,
+                myPostNumbers = uiState.myPostNumbers
             )
         }
 


### PR DESCRIPTION
## Summary
- show diamond markers for own posts in momentum bar
- display horizontal line for new arrivals on momentum bar

## Testing
- `./gradlew :app:testDebugUnitTest`
- `./gradlew :app:lintDebug` *(fails: MainActivity must extend android.app.Activity)*

------
https://chatgpt.com/codex/tasks/task_e_68b704abd1908332bd2a41716c76fc2e