### PR TITLE
fix: apply nav bar padding only for 3-button mode

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -29,6 +29,7 @@ import com.websarva.wings.android.slevo.ui.thread.dialog.ResponseWebViewDialog
 import com.websarva.wings.android.slevo.ui.thread.state.ThreadSortType
 import com.websarva.wings.android.slevo.ui.thread.viewmodel.PostViewModel
 import com.websarva.wings.android.slevo.ui.topbar.SearchTopAppBar
+import com.websarva.wings.android.slevo.ui.util.isThreeButtonNavigation
 import com.websarva.wings.android.slevo.ui.util.parseBoardUrl
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
@@ -103,14 +104,7 @@ fun ThreadScaffold(
         },
         bottomBar = { viewModel, uiState ->
             val context = LocalContext.current
-            val isThreeButtonBar = remember {
-                val id = context.resources.getIdentifier(
-                    "config_navBarInteractionMode",
-                    "integer",
-                    "android"
-                )
-                id > 0 && context.resources.getInteger(id) == 0
-            }
+            val isThreeButtonBar = remember { isThreeButtonNavigation(context) }
             ThreadBottomBar(
                 modifier = if (isThreeButtonBar) {
                     Modifier.navigationBarsPadding()

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/util/SystemUiUtils.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/util/SystemUiUtils.kt
@@ -1,0 +1,12 @@
+package com.websarva.wings.android.slevo.ui.util
+
+import android.content.Context
+
+fun isThreeButtonNavigation(context: Context): Boolean {
+    val id = context.resources.getIdentifier(
+        "config_navBarInteractionMode",
+        "integer",
+        "android"
+    )
+    return id > 0 && context.resources.getInteger(id) == 0
+}


### PR DESCRIPTION
## Summary
- apply navigationBarsPadding only when device uses 3-button navigation

## Testing
- `./gradlew :app:testDebugUnitTest`
- `./gradlew :app:lintDebug` *(fails: MainActivity must extend android.app.Activity)*


------
https://chatgpt.com/codex/tasks/task_e_68b7f9f7bdb88332a89a31f0698b315b