### PR TITLE
fix: cancel thread pull refresh when drag returns

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
@@ -123,6 +123,17 @@ fun ThreadScreen(
     var triggerRefresh by remember { mutableStateOf(false) }
     val nestedScrollConnection = remember(listState, posts.size) {
         object : NestedScrollConnection {
+            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                return if (overscroll > 0f && available.y > 0f) {
+                    val consume = min(overscroll, available.y)
+                    overscroll -= consume
+                    triggerRefresh = overscroll >= refreshThresholdPx
+                    Offset(0f, consume)
+                } else {
+                    Offset.Zero
+                }
+            }
+
             override fun onPostScroll(
                 consumed: Offset,
                 available: Offset,
@@ -131,9 +142,6 @@ fun ThreadScreen(
                 if (!listState.canScrollForward && available.y < 0f) {
                     overscroll -= available.y
                     triggerRefresh = overscroll >= refreshThresholdPx
-                } else if (available.y > 0f) {
-                    overscroll = 0f
-                    triggerRefresh = false
                 }
                 return Offset.Zero
             }


### PR DESCRIPTION
## Summary
- adjust thread screen overscroll tracking to cancel refresh when drag returns below threshold
- keep thread list static while drag returns below refresh threshold

## Testing
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_68b821e76bd4833290da565ecad9515f