### PR TITLE
Show thread bottom bar at end of scroll

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -150,6 +151,15 @@ fun ThreadScaffold(
                 tabInfo?.let {
                     viewModel.setNewArrivalInfo(it.firstNewResNo, it.prevResCount)
                 }
+            }
+
+            LaunchedEffect(listState) {
+                snapshotFlow { !listState.canScrollForward }
+                    .collect { atBottom ->
+                        if (atBottom) {
+                            bottomBarScrollBehavior.state.heightOffset = 0f
+                        }
+                    }
             }
             ThreadScreen(
                 modifier = modifier,

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -34,6 +34,7 @@ import com.websarva.wings.android.slevo.ui.thread.viewmodel.PostViewModel
 import com.websarva.wings.android.slevo.ui.topbar.SearchTopAppBar
 import com.websarva.wings.android.slevo.ui.util.isThreeButtonNavigation
 import com.websarva.wings.android.slevo.ui.util.parseBoardUrl
+import kotlinx.coroutines.flow.distinctUntilChanged
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
@@ -155,9 +156,12 @@ fun ThreadScaffold(
 
             LaunchedEffect(listState) {
                 snapshotFlow { !listState.canScrollForward }
+                    .distinctUntilChanged()
                     .collect { atBottom ->
-                        if (atBottom) {
+                        if (atBottom && bottomBarScrollBehavior.state.heightOffset < 0f) {
+                            val barHeight = -bottomBarScrollBehavior.state.heightOffsetLimit
                             bottomBarScrollBehavior.state.heightOffset = 0f
+                            listState.animateScrollBy(barHeight)
                         }
                     }
             }


### PR DESCRIPTION
## Summary
- スレッドの最後までスクロールするとボトムバーが表示されるように調整

## Testing
- `./gradlew :app:testDebugUnitTest` (途中で停止。環境依存のため完走せず)


------
https://chatgpt.com/codex/tasks/task_e_68b928ae7b20833285afe2bd3a1cb2a6