### PR TITLE
Show thread bottom bar at end of scroll

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -35,6 +36,7 @@ import com.websarva.wings.android.slevo.ui.util.isThreeButtonNavigation
 import com.websarva.wings.android.slevo.ui.util.parseBoardUrl
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
+import kotlinx.coroutines.flow.distinctUntilChanged
 
 @OptIn(ExperimentalMaterial3Api::class)
 @RequiresApi(Build.VERSION_CODES.O)
@@ -150,6 +152,16 @@ fun ThreadScaffold(
                 tabInfo?.let {
                     viewModel.setNewArrivalInfo(it.firstNewResNo, it.prevResCount)
                 }
+            }
+
+            LaunchedEffect(listState) {
+                snapshotFlow { !listState.canScrollForward }
+                    .distinctUntilChanged()
+                    .collect { atBottom ->
+                        if (atBottom) {
+                            bottomBarScrollBehavior.state.heightOffset = 0f
+                        }
+                    }
             }
             ThreadScreen(
                 modifier = modifier,

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
@@ -165,6 +166,7 @@ fun ThreadScreen(
                     .weight(1f)
                     .nestedScroll(nestedScrollConnection),
                 state = listState,
+                contentPadding = PaddingValues(bottom = 96.dp),
             ) {
                 if (visiblePosts.isNotEmpty()) {
                     val firstIndent = if (uiState.sortType == ThreadSortType.TREE) {


### PR DESCRIPTION
## Summary
- スレッド末尾でのボトムバー表示処理を安定化
- 投稿リストにボトムバー分の下パディングを追加しちらつきを軽減

## Testing
- `./gradlew :app:testDebugUnitTest --stacktrace --no-daemon --console=plain` (TabsRepositoryTest > concurrentUpdatesAreMerged FAILED: java.net.SocketException)

------
https://chatgpt.com/codex/tasks/task_e_68b928ae7b20833285afe2bd3a1cb2a6