### PR TITLE
feat: reveal bottom bar near thread end

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/components/ThreadBottomBar.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/components/ThreadBottomBar.kt
@@ -41,6 +41,8 @@ import com.websarva.wings.android.slevo.ui.common.bookmark.SingleBookmarkState
 import com.websarva.wings.android.slevo.ui.theme.bookmarkColor
 import com.websarva.wings.android.slevo.ui.thread.state.ThreadUiState
 
+val THREAD_BOTTOM_BAR_HEIGHT = 96.dp
+
 @OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun ThreadBottomBar(
@@ -58,7 +60,7 @@ fun ThreadBottomBar(
 ) {
     FlexibleBottomAppBar(
         modifier = modifier,
-        expandedHeight = 96.dp,
+        expandedHeight = THREAD_BOTTOM_BAR_HEIGHT,
         scrollBehavior = scrollBehavior,
     ) {
         Column(

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -24,6 +24,7 @@ import com.websarva.wings.android.slevo.ui.common.PostingDialog
 import com.websarva.wings.android.slevo.ui.navigation.AppRoute
 import com.websarva.wings.android.slevo.ui.navigation.RouteScaffold
 import com.websarva.wings.android.slevo.ui.tabs.TabsViewModel
+import com.websarva.wings.android.slevo.ui.thread.components.THREAD_BOTTOM_BAR_HEIGHT
 import com.websarva.wings.android.slevo.ui.thread.components.ThreadBottomBar
 import com.websarva.wings.android.slevo.ui.thread.components.ThreadInfoBottomSheet
 import com.websarva.wings.android.slevo.ui.thread.dialog.ResponseWebViewDialog
@@ -91,6 +92,7 @@ fun ThreadScaffold(
         },
         scrollBehavior = scrollBehavior,
         bottomBarScrollBehavior = bottomBarScrollBehavior,
+        bottomBarVisibilityThreshold = THREAD_BOTTOM_BAR_HEIGHT,
         topBar = { viewModel, uiState, _, scrollBehavior ->
             if (uiState.isSearchMode) {
                 SearchTopAppBar(


### PR DESCRIPTION
## Summary
- Show thread bottom bar when list nears its end
- Add constant for thread bottom bar height

## Testing
- `./gradlew :app:testDebugUnitTest` (fails: TabsRepositoryTest > concurrentUpdatesAreMerged)
- `./gradlew :app:lintDebug` (fails: MainActivity must extend android.app.Activity)


------
https://chatgpt.com/codex/tasks/task_e_68b94a5922008332ba94bc2ec650a062