### PR TITLE
fix: show bottom bar on overscroll

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -160,7 +160,8 @@ fun ThreadScaffold(
                         uiState.boardInfo.url,
                         resNum
                     )
-                }
+                },
+                bottomBarScrollBehavior = bottomBarScrollBehavior
             )
         },
         optionalSheetContent = { viewModel, uiState ->

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
@@ -127,21 +127,6 @@ fun ThreadScreen(
     val nestedScrollConnection = remember(listState, posts.size, bottomBarScrollBehavior) {
         object : NestedScrollConnection {
             override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
-                return if (overscroll > 0f && available.y > 0f) {
-                    val consume = min(overscroll, available.y)
-                    overscroll -= consume
-                    triggerRefresh = overscroll >= refreshThresholdPx
-                    Offset(0f, consume)
-                } else {
-                    Offset.Zero
-                }
-            }
-
-            override fun onPostScroll(
-                consumed: Offset,
-                available: Offset,
-                source: NestedScrollSource
-            ): Offset {
                 if (!listState.canScrollForward && available.y < 0f) {
                     val delta = -available.y
                     var remaining = delta
@@ -156,8 +141,21 @@ fun ThreadScreen(
                     }
                     return available
                 }
-                return Offset.Zero
+                return if (overscroll > 0f && available.y > 0f) {
+                    val consume = min(overscroll, available.y)
+                    overscroll -= consume
+                    triggerRefresh = overscroll >= refreshThresholdPx
+                    Offset(0f, consume)
+                } else {
+                    Offset.Zero
+                }
             }
+
+            override fun onPostScroll(
+                consumed: Offset,
+                available: Offset,
+                source: NestedScrollSource
+            ): Offset = Offset.Zero
 
             override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
                 if (triggerRefresh) {

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
@@ -143,11 +143,16 @@ fun ThreadScreen(
                 source: NestedScrollSource
             ): Offset {
                 if (!listState.canScrollForward && available.y < 0f) {
-                    overscroll -= available.y
-                    triggerRefresh = overscroll >= refreshThresholdPx
+                    val delta = -available.y
+                    var remaining = delta
                     bottomBarScrollBehavior?.state?.let { state ->
-                        val newOffset = state.heightOffset + (-available.y)
-                        state.heightOffset = newOffset.coerceAtMost(0f)
+                        val oldOffset = state.heightOffset
+                        state.heightOffset = (oldOffset + delta).coerceAtMost(0f)
+                        remaining -= state.heightOffset - oldOffset
+                    }
+                    if (remaining > 0f) {
+                        overscroll += remaining
+                        triggerRefresh = overscroll >= refreshThresholdPx
                     }
                     return available
                 }


### PR DESCRIPTION
## Summary
- reveal bottom bar when overscrolling past thread end
- pass bottom bar scroll behavior to thread screen

## Testing
- `./gradlew :app:testDebugUnitTest`
- `./gradlew :app:lintDebug` *(fails: MainActivity must extend android.app.Activity)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a305e234833280d4fa72751c03a8