### PR TITLE
Handle Broken MonaTicket by clearing cookies and retrying post

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/data/repository/PostRepository.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/repository/PostRepository.kt
@@ -1,8 +1,8 @@
 package com.websarva.wings.android.slevo.data.repository
 
-import android.util.Log
 import com.websarva.wings.android.slevo.data.datasource.remote.PostRemoteDataSource
 import com.websarva.wings.android.slevo.data.util.PostParser
+import com.websarva.wings.android.slevo.di.PersistentCookieJar
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import timber.log.Timber
@@ -13,16 +13,26 @@ sealed class PostResult {
     data class Success(val resNum: Int? = null) : PostResult() // 書き込み成功（レス番号付き）
     data class Confirm(val confirmationData: ConfirmationData) : PostResult() // 書き込み確認画面
     data class Error(val html: String, val message: String) : PostResult() // その他のエラー（WebView表示用）
+    object Retry : PostResult() // MonaTicket エラー時の再試行
 }
 
 class PostRepository @Inject constructor(
-    private val remoteDataSource: PostRemoteDataSource // DIでDataSourceを受け取る
+    private val remoteDataSource: PostRemoteDataSource, // DIでDataSourceを受け取る
+    private val cookieJar: PersistentCookieJar,
 ) {
-    private suspend fun handlePostResponse(response: okhttp3.Response?): PostResult {
+    private suspend fun handlePostResponse(
+        host: String,
+        response: okhttp3.Response?,
+    ): PostResult {
         if (response == null) {
             return PostResult.Error("", "ネットワークエラーが発生しました。")
         }
         return response.use {
+            val errorHeader = it.header("x-chx-error")
+            if (errorHeader == "0000 Confirmation[Broken MonaTicket]") {
+                cookieJar.clearCookiesFor(host)
+                return PostResult.Retry
+            }
             val html = it.body?.string() ?: return PostResult.Error("", "空のレスポンスです。")
             if (!it.isSuccessful) {
                 return PostResult.Error(html, "サーバーエラー: ${it.code}")
@@ -44,8 +54,13 @@ class PostRepository @Inject constructor(
         message: String
     ): PostResult = withContext(Dispatchers.IO) {
         try {
-            val response = remoteDataSource.postFirstPhase(host, board, threadKey, name, mail, message)
-            handlePostResponse(response)
+            var response = remoteDataSource.postFirstPhase(host, board, threadKey, name, mail, message)
+            var result = handlePostResponse(host, response)
+            if (result is PostResult.Retry) {
+                response = remoteDataSource.postFirstPhase(host, board, threadKey, name, mail, message)
+                result = handlePostResponse(host, response)
+            }
+            result
         } catch (e: Exception) {
             Timber.e(e, "初回投稿リクエスト失敗")
             PostResult.Error("", e.message ?: "不明なエラー")
@@ -60,7 +75,7 @@ class PostRepository @Inject constructor(
     ): PostResult = withContext(Dispatchers.IO) {
         try {
             val response = remoteDataSource.postSecondPhase(host, board, threadKey, confirmationData)
-            handlePostResponse(response)
+            handlePostResponse(host, response)
         } catch (e: Exception) {
             Timber.e(e, "2回目投稿リクエスト失敗")
             PostResult.Error("", e.message ?: "不明なエラー")

--- a/app/src/main/java/com/websarva/wings/android/slevo/di/PersistentCookieJar.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/di/PersistentCookieJar.kt
@@ -71,4 +71,18 @@ class PersistentCookieJar @Inject constructor(
             localDataSource.saveCookies(cache.values.flatten())
         }
     }
+
+    /**
+     * 指定したドメインに関連するクッキーを削除する。
+     */
+    fun clearCookiesFor(domain: String) {
+        // キャッシュに登録されているドメインのうち、指定ドメインで終わるものを削除
+        val targets = cache.keys.filter { domain.endsWith(it) }
+        targets.forEach { cache.remove(it) }
+
+        // DataStoreからも削除された状態を保存
+        scope.launch {
+            localDataSource.saveCookies(cache.values.flatten())
+        }
+    }
 }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardViewModel.kt
@@ -327,6 +327,11 @@ class BoardViewModel @AssistedInject constructor(
                         it.copy(showErrorWebView = true, errorHtmlContent = result.html)
                     }
                 }
+                is PostResult.Retry -> {
+                    _uiState.update {
+                        it.copy(showErrorWebView = true, errorHtmlContent = "Broken MonaTicket")
+                    }
+                }
             }
         }
     }
@@ -356,6 +361,11 @@ class BoardViewModel @AssistedInject constructor(
                             postConfirmation = result.confirmationData,
                             isConfirmationScreen = true
                         )
+                    }
+                }
+                is PostResult.Retry -> {
+                    _uiState.update {
+                        it.copy(showErrorWebView = true, errorHtmlContent = "Broken MonaTicket")
                     }
                 }
             }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/viewmodel/ThreadViewModelPost.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/viewmodel/ThreadViewModelPost.kt
@@ -83,6 +83,12 @@ fun ThreadViewModel.postFirstPhase(
                     it.copy(showErrorWebView = true, errorHtmlContent = result.html)
                 }
             }
+            is PostResult.Retry -> {
+                // 2回目の試行でも失敗した場合はエラーとして扱う
+                _postUiState.update {
+                    it.copy(showErrorWebView = true, errorHtmlContent = "Broken MonaTicket")
+                }
+            }
         }
     }
 }
@@ -112,6 +118,10 @@ fun ThreadViewModel.postTo5chSecondPhase(
                 _postUiState.update {
                     it.copy(postConfirmation = result.confirmationData, isConfirmationScreen = true)
                 }
+            }
+            is PostResult.Retry -> {
+                val state = postUiState.value.postFormState
+                postFirstPhase(host, board, threadKey, state.name, state.mail, state.message, onSuccess)
             }
         }
     }


### PR DESCRIPTION
## Summary
- clear cookies for domain when `x-chx-error: 0000 Confirmation[Broken MonaTicket]` header is returned
- retry posting after cookie reset to recover from Broken MonaTicket

## Testing
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_68baf17a08348332ba4d7ee75f1d376a