### PR TITLE
fix: retry post when MonaTicket is broken

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/data/repository/PostRepository.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/repository/PostRepository.kt
@@ -48,7 +48,7 @@ class PostRepository @Inject constructor(
             val response = remoteDataSource.postFirstPhase(host, board, threadKey, name, mail, message)
             if (response?.header("x-chx-error") == "0000 Confirmation[Broken MonaTicket]") {
                 response.close()
-                cookieJar.clear(host)
+                cookieJar.clearMonaTicket(host)
                 val retry = remoteDataSource.postFirstPhase(host, board, threadKey, name, mail, message)
                 handlePostResponse(retry)
             } else {

--- a/app/src/main/java/com/websarva/wings/android/slevo/di/PersistentCookieJar.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/di/PersistentCookieJar.kt
@@ -71,4 +71,15 @@ class PersistentCookieJar @Inject constructor(
             localDataSource.saveCookies(cache.values.flatten())
         }
     }
+
+    /**
+     * 指定したホストに関連するクッキーを削除する
+     */
+    fun clear(host: String) {
+        val targets = cache.keys.filter { host.endsWith(it) }
+        targets.forEach { cache.remove(it) }
+        scope.launch {
+            localDataSource.saveCookies(cache.values.flatten())
+        }
+    }
 }

--- a/app/src/main/java/com/websarva/wings/android/slevo/di/PersistentCookieJar.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/di/PersistentCookieJar.kt
@@ -73,11 +73,29 @@ class PersistentCookieJar @Inject constructor(
     }
 
     /**
-     * 指定したホストに関連するクッキーを削除する
+     * 指定したホストに関連するすべてのクッキーを削除する
      */
     fun clear(host: String) {
         val targets = cache.keys.filter { host.endsWith(it) }
         targets.forEach { cache.remove(it) }
+        scope.launch {
+            localDataSource.saveCookies(cache.values.flatten())
+        }
+    }
+
+    /**
+     * 指定したホストの MonaTicket クッキーのみを削除する
+     */
+    fun clearMonaTicket(host: String) {
+        val targets = cache.keys.filter { host.endsWith(it) }
+        targets.forEach { domain ->
+            val remaining = cache[domain]?.filterNot { it.name == "MonaTicket" }
+            if (remaining.isNullOrEmpty()) {
+                cache.remove(domain)
+            } else {
+                cache[domain] = remaining
+            }
+        }
         scope.launch {
             localDataSource.saveCookies(cache.values.flatten())
         }


### PR DESCRIPTION
## Summary
- retry posting from the first phase when server responds with `x-chx-error: 0000 Confirmation[Broken MonaTicket]`
- add cookie jar helper to clear cookies for a host

## Testing
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_68baf17a08348332ba4d7ee75f1d376a