### PR TITLE
feat: add cookie management screen

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/data/repository/CookieRepository.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/repository/CookieRepository.kt
@@ -1,0 +1,21 @@
+package com.websarva.wings.android.slevo.data.repository
+
+import com.websarva.wings.android.slevo.data.datasource.local.CookieLocalDataSource
+import com.websarva.wings.android.slevo.di.PersistentCookieJar
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.Flow
+import okhttp3.Cookie
+
+@Singleton
+class CookieRepository @Inject constructor(
+    private val local: CookieLocalDataSource,
+    private val cookieJar: PersistentCookieJar,
+) {
+    fun observeCookies(): Flow<List<Cookie>> = local.getCookies()
+
+    suspend fun remove(cookie: Cookie) {
+        cookieJar.removeCookie(cookie)
+    }
+}
+

--- a/app/src/main/java/com/websarva/wings/android/slevo/di/PersistentCookieJar.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/di/PersistentCookieJar.kt
@@ -73,6 +73,23 @@ class PersistentCookieJar @Inject constructor(
     }
 
     /**
+     * 指定したクッキーを削除する
+     */
+    fun removeCookie(target: Cookie) {
+        val domain = target.domain
+        val current = cache[domain]?.toMutableList() ?: return
+        current.removeAll { it.name == target.name && it.path == target.path }
+        if (current.isEmpty()) {
+            cache.remove(domain)
+        } else {
+            cache[domain] = current
+        }
+        scope.launch {
+            localDataSource.saveCookies(cache.values.flatten())
+        }
+    }
+
+    /**
      * 指定したホストに関連するすべてのクッキーを削除する
      */
     fun clear(host: String) {

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/AppNavGraph.kt
@@ -223,6 +223,9 @@ sealed class AppRoute {
     data object SettingsThread : AppRoute()
 
     @Serializable
+    data object SettingsCookie : AppRoute()
+
+    @Serializable
     data object Tabs : AppRoute()
 
     @Serializable
@@ -250,6 +253,7 @@ sealed class AppRoute {
         const val SETTINGS_GENERAL = "SettingsGeneral"
         const val SETTINGS_NG = "SettingsNg"
         const val SETTINGS_THREAD = "SettingsThread"
+        const val SETTINGS_COOKIE = "SettingsCookie"
         const val TABS = "Tabs"
         const val MORE = "More"
         const val HISTORY_LIST = "HistoryList"

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/SettingsRoute.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/SettingsRoute.kt
@@ -6,6 +6,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
+import com.websarva.wings.android.slevo.ui.settings.SettingsCookieScreen
 import com.websarva.wings.android.slevo.ui.settings.SettingsGeneralScreen
 import com.websarva.wings.android.slevo.ui.settings.SettingsNgScreen
 import com.websarva.wings.android.slevo.ui.settings.SettingsScreen
@@ -27,7 +28,8 @@ fun NavGraphBuilder.addSettingsRoute(
             SettingsScreen(
                 onGeneralClick = { navController.navigate(AppRoute.SettingsGeneral) },
                 onThreadClick = { navController.navigate(AppRoute.SettingsThread) },
-                onNgClick = { navController.navigate(AppRoute.SettingsNg) }
+                onNgClick = { navController.navigate(AppRoute.SettingsNg) },
+                onCookieClick = { navController.navigate(AppRoute.SettingsCookie) }
             )
         }
         composable<AppRoute.SettingsGeneral> {
@@ -45,6 +47,11 @@ fun NavGraphBuilder.addSettingsRoute(
         }
         composable<AppRoute.SettingsThread> {
             SettingsThreadScreen(
+                onNavigateUp = { navController.navigateUp() }
+            )
+        }
+        composable<AppRoute.SettingsCookie> {
+            SettingsCookieScreen(
                 onNavigateUp = { navController.navigateUp() }
             )
         }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/settings/SettingsCookieScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/settings/SettingsCookieScreen.kt
@@ -1,0 +1,67 @@
+package com.websarva.wings.android.slevo.ui.settings
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.websarva.wings.android.slevo.R
+import com.websarva.wings.android.slevo.ui.topbar.SmallTopAppBarScreen
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsCookieScreen(
+    onNavigateUp: () -> Unit,
+    viewModel: SettingsCookieViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    Scaffold(
+        topBar = {
+            SmallTopAppBarScreen(
+                title = stringResource(R.string.cookie_management),
+                onNavigateUp = onNavigateUp,
+            )
+        }
+    ) { innerPadding ->
+        LazyColumn(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize()
+        ) {
+            items(
+                items = uiState.cookies,
+                key = { it.name + it.domain + it.path }
+            ) { cookie ->
+                ListItem(
+                    headlineContent = { Text("${cookie.name}=${cookie.value}") },
+                    supportingContent = { Text(cookie.domain) },
+                    trailingContent = {
+                        IconButton(onClick = { viewModel.removeCookie(cookie) }) {
+                            Icon(
+                                imageVector = Icons.Filled.Delete,
+                                contentDescription = stringResource(R.string.delete)
+                            )
+                        }
+                    }
+                )
+                HorizontalDivider()
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/settings/SettingsCookieScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/settings/SettingsCookieScreen.kt
@@ -1,5 +1,6 @@
 package com.websarva.wings.android.slevo.ui.settings
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -48,8 +49,31 @@ fun SettingsCookieScreen(
                 key = { it.name + it.domain + it.path }
             ) { cookie ->
                 ListItem(
-                    headlineContent = { Text("${cookie.name}=${cookie.value}") },
-                    supportingContent = { Text(cookie.domain) },
+                    headlineContent = { Text(cookie.name) },
+                    supportingContent = {
+                        Column {
+                            Text(
+                                stringResource(
+                                    R.string.cookie_domain_path,
+                                    cookie.domain,
+                                    cookie.path,
+                                )
+                            )
+                            Text(
+                                stringResource(
+                                    R.string.cookie_expires,
+                                    cookie.expires,
+                                )
+                            )
+                            Text(stringResource(R.string.cookie_size, cookie.size))
+                            Text(
+                                stringResource(
+                                    R.string.cookie_value_preview,
+                                    cookie.valuePreview,
+                                )
+                            )
+                        }
+                    },
                     trailingContent = {
                         IconButton(onClick = { viewModel.removeCookie(cookie) }) {
                             Icon(

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/settings/SettingsCookieViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/settings/SettingsCookieViewModel.kt
@@ -1,0 +1,40 @@
+package com.websarva.wings.android.slevo.ui.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.websarva.wings.android.slevo.data.repository.CookieRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import okhttp3.Cookie
+
+@HiltViewModel
+class SettingsCookieViewModel @Inject constructor(
+    private val repository: CookieRepository
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(SettingsCookieUiState())
+    val uiState: StateFlow<SettingsCookieUiState> = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            repository.observeCookies().collect { cookies ->
+                _uiState.update { it.copy(cookies = cookies) }
+            }
+        }
+    }
+
+    fun removeCookie(cookie: Cookie) {
+        viewModelScope.launch {
+            repository.remove(cookie)
+        }
+    }
+}
+
+data class SettingsCookieUiState(
+    val cookies: List<Cookie> = emptyList()
+)
+

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/settings/SettingsCookieViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/settings/SettingsCookieViewModel.kt
@@ -11,6 +11,9 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import okhttp3.Cookie
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 
 @HiltViewModel
 class SettingsCookieViewModel @Inject constructor(
@@ -22,19 +25,58 @@ class SettingsCookieViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             repository.observeCookies().collect { cookies ->
-                _uiState.update { it.copy(cookies = cookies) }
+                _uiState.update { state ->
+                    state.copy(cookies = cookies.map { it.toCookieItem() })
+                }
             }
         }
     }
 
-    fun removeCookie(cookie: Cookie) {
+    fun removeCookie(item: CookieItem) {
         viewModelScope.launch {
-            repository.remove(cookie)
+            repository.remove(item.cookie)
         }
     }
 }
 
 data class SettingsCookieUiState(
-    val cookies: List<Cookie> = emptyList()
+    val cookies: List<CookieItem> = emptyList()
 )
+
+data class CookieItem(
+    val name: String,
+    val domain: String,
+    val path: String,
+    val expires: String,
+    val size: Int,
+    val valuePreview: String,
+    val cookie: Cookie,
+)
+
+private val formatter: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss")
+        .withZone(ZoneId.systemDefault())
+
+private fun Cookie.toCookieItem(): CookieItem {
+    val expiresText = if (persistent) {
+        formatter.format(Instant.ofEpochMilli(expiresAt))
+    } else {
+        "セッション"
+    }
+    val sizeBytes = name.toByteArray().size + value.toByteArray().size
+    val preview = if (value.length <= 4) {
+        value
+    } else {
+        value.take(4) + "…"
+    }
+    return CookieItem(
+        name = name,
+        domain = domain,
+        path = path,
+        expires = expiresText,
+        size = sizeBytes,
+        valuePreview = preview,
+        cookie = this,
+    )
+}
 

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/settings/SettingsScreen.kt
@@ -19,6 +19,7 @@ fun SettingsScreen(
     onGeneralClick: () -> Unit,
     onThreadClick: () -> Unit,
     onNgClick: () -> Unit,
+    onCookieClick: () -> Unit,
 ) {
     Scaffold(
         topBar = {
@@ -52,6 +53,13 @@ fun SettingsScreen(
                 ListItem(
                     modifier = Modifier.clickable(onClick = onNgClick),
                     headlineContent = { Text("NG") }
+                )
+                HorizontalDivider()
+            }
+            item {
+                ListItem(
+                    modifier = Modifier.clickable(onClick = onCookieClick),
+                    headlineContent = { Text("Cookie管理") }
                 )
                 HorizontalDivider()
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,4 +82,5 @@
     <string name="thread_date">%1$d年%2$d月%3$d日%4$s曜日 %5$02d:%6$02d</string>
     <string name="posting_in_progress">書き込み中</string>
     <string name="momentum">勢い</string>
+    <string name="cookie_management">Cookie管理</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -83,4 +83,8 @@
     <string name="posting_in_progress">書き込み中</string>
     <string name="momentum">勢い</string>
     <string name="cookie_management">Cookie管理</string>
+    <string name="cookie_domain_path">Domain / Path: %1$s / %2$s</string>
+    <string name="cookie_expires">Expires / Max-Age: %1$s</string>
+    <string name="cookie_size">Size: %1$d</string>
+    <string name="cookie_value_preview">Value: %1$s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,7 +82,7 @@
     <string name="thread_date">%1$d年%2$d月%3$d日%4$s曜日 %5$02d:%6$02d</string>
     <string name="posting_in_progress">書き込み中</string>
     <string name="momentum">勢い</string>
-    <string name="cookie_management">Cookie管理</string>
+    <string name="cookie_management">Cookieの管理</string>
     <string name="cookie_domain_path">Domain / Path: %1$s / %2$s</string>
     <string name="cookie_expires">Expires / Max-Age: %1$s</string>
     <string name="cookie_size">Size: %1$d</string>


### PR DESCRIPTION
## Summary
- add Cookie management entry in settings and route
- display stored cookies with delete button
- persist removal via PersistentCookieJar

## Testing
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_68bb0c5f5c8483329e10c96413b581cb