### PR TITLE
refactor: centralize board URL lookup

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/dao/bbs/BoardDao.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/dao/bbs/BoardDao.kt
@@ -22,6 +22,10 @@ interface BoardDao {
     @Query("SELECT boardId FROM boards WHERE url = :url LIMIT 1")
     suspend fun findBoardIdByUrl(url: String): Long
 
+    /** boardUrl から BoardEntity を取得 */
+    @Query("SELECT * FROM boards WHERE url = :boardUrl LIMIT 1")
+    suspend fun findBoardByUrl(boardUrl: String): BoardEntity?
+
     @Query("DELETE FROM boards WHERE serviceId = :serviceId")
     suspend fun clearForService(serviceId: Long)
 

--- a/app/src/main/java/com/websarva/wings/android/slevo/data/repository/BoardRepository.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/repository/BoardRepository.kt
@@ -189,6 +189,14 @@ class BoardRepository @Inject constructor(
     }
 
     /**
+     * boardUrl から既存の板情報を取得する。
+     * @param boardUrl 検索対象のURL
+     * @return 該当する [BoardEntity] があれば返す
+     */
+    suspend fun findBoardByUrl(boardUrl: String): BoardEntity? =
+        boardDao.findBoardByUrl(boardUrl)
+
+    /**
      * 指定した板情報をDBに登録し、そのIDを返す。
      * 既存の場合はIDのみ返す。
      * @param boardInfo 板情報

--- a/app/src/main/java/com/websarva/wings/android/slevo/data/repository/BookmarkBoardRepository.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/repository/BookmarkBoardRepository.kt
@@ -88,9 +88,6 @@ class BookmarkBoardRepository @Inject constructor(
         return boardDao.getBoardWithBookmarkAndGroupByUrlFlow(boardUrl)
     }
 
-    suspend fun findBoardByUrl(boardUrl: String): BoardEntity? =
-        boardDao.findBoardByUrl(boardUrl)
-
     fun observeAllBoards(): Flow<List<BoardEntity>> =
         boardEntityDao.getAllBoards()
 }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabsViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabsViewModel.kt
@@ -159,7 +159,7 @@ class TabsViewModel @Inject constructor(
     ): BoardInfo {
         boardId?.takeIf { it != 0L }?.let { return BoardInfo(it, boardName, boardUrl) }
 
-        bookmarkBoardRepo.findBoardByUrl(boardUrl)?.let { entity ->
+        boardRepository.findBoardByUrl(boardUrl)?.let { entity ->
             return BoardInfo(entity.boardId, entity.name, entity.url)
         }
 


### PR DESCRIPTION
## Summary
- add `findBoardByUrl` to `BoardRepository` and DAO
- drop public `findBoardByUrl` from `BookmarkBoardRepository`
- use `BoardRepository.findBoardByUrl` in `TabsViewModel.resolveBoardInfo`

## Testing
- `./gradlew :app:testDebugUnitTest`
- `./gradlew :app:lintDebug` *(fails: MainActivity must extend android.app.Activity)*

------
https://chatgpt.com/codex/tasks/task_e_68bbdc2ce3fc8332ab15fa2826379e0d