### PR TITLE
Handle invalid board URL when resolving board info

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
@@ -53,14 +53,16 @@ fun BoardScaffold(
             boardUrl = boardRoute.boardUrl,
             boardName = boardRoute.boardName
         )
-        tabsViewModel.openBoardTab(
-            BoardTabInfo(
-                boardId = info.boardId,
-                boardName = info.name,
-                boardUrl = info.url,
-                serviceName = parseServiceName(info.url)
+        info?.let {
+            tabsViewModel.openBoardTab(
+                BoardTabInfo(
+                    boardId = it.boardId,
+                    boardName = it.name,
+                    boardUrl = it.url,
+                    serviceName = parseServiceName(it.url)
+                )
             )
-        )
+        }
     }
 
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topBarState)

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabsViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabsViewModel.kt
@@ -150,20 +150,20 @@ class TabsViewModel @Inject constructor(
      * 指定された板ID・URL・板名からBoardInfoを解決する。
      * - boardIdが有効ならそれを優先。
      * - BoardEntityからURL一致の板情報を検索。
-     * - それ以外は板名を取得・登録してIDを確定。
+     * - それ以外は板名を取得し、取得できない場合は無効として返す。
      */
     suspend fun resolveBoardInfo(
         boardId: Long?,
         boardUrl: String,
         boardName: String
-    ): BoardInfo {
+    ): BoardInfo? {
         boardId?.takeIf { it != 0L }?.let { return BoardInfo(it, boardName, boardUrl) }
 
         boardRepository.findBoardByUrl(boardUrl)?.let { entity ->
             return BoardInfo(entity.boardId, entity.name, entity.url)
         }
 
-        val name = boardRepository.fetchBoardName("${boardUrl}SETTING.TXT") ?: boardName
+        val name = boardRepository.fetchBoardName("${boardUrl}SETTING.TXT") ?: return null
         val id = boardRepository.ensureBoard(BoardInfo(0L, name, boardUrl))
         return BoardInfo(id, name, boardUrl)
     }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -53,12 +53,14 @@ fun ThreadScaffold(
             boardUrl = threadRoute.boardUrl,
             boardName = threadRoute.boardName
         )
-        val vm = tabsViewModel.getOrCreateThreadViewModel(threadRoute.threadKey + info.url)
-        vm.initializeThread(
-            threadKey = threadRoute.threadKey,
-            boardInfo = info,
-            threadTitle = threadRoute.threadTitle
-        )
+        info?.let {
+            val vm = tabsViewModel.getOrCreateThreadViewModel(threadRoute.threadKey + it.url)
+            vm.initializeThread(
+                threadKey = threadRoute.threadKey,
+                boardInfo = it,
+                threadTitle = threadRoute.threadTitle
+            )
+        }
     }
 
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(topBarState)


### PR DESCRIPTION
## Summary
- avoid saving boards when `fetchBoardName` returns null
- skip opening board or thread when board URL is invalid

## Testing
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_68be43e5f3bc8332ab20c8869da1994b