### PR TITLE
Handle invalid board URLs when resolving board info

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
@@ -1,6 +1,7 @@
 package com.websarva.wings.android.slevo.ui.board
 
 import android.os.Build
+import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.height
@@ -46,6 +47,7 @@ fun BoardScaffold(
     topBarState: TopAppBarState
 ) {
     val tabsUiState by tabsViewModel.uiState.collectAsState()
+    val context = LocalContext.current
 
     LaunchedEffect(boardRoute) {
         val info = tabsViewModel.resolveBoardInfo(
@@ -53,6 +55,11 @@ fun BoardScaffold(
             boardUrl = boardRoute.boardUrl,
             boardName = boardRoute.boardName
         )
+        if (info == null) {
+            Toast.makeText(context, R.string.invalid_board_url, Toast.LENGTH_SHORT).show()
+            navController.navigateUp()
+            return@LaunchedEffect
+        }
         tabsViewModel.openBoardTab(
             BoardTabInfo(
                 boardId = info.boardId,

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabsViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabsViewModel.kt
@@ -156,14 +156,14 @@ class TabsViewModel @Inject constructor(
         boardId: Long?,
         boardUrl: String,
         boardName: String
-    ): BoardInfo {
+    ): BoardInfo? {
         boardId?.takeIf { it != 0L }?.let { return BoardInfo(it, boardName, boardUrl) }
 
         boardRepository.findBoardByUrl(boardUrl)?.let { entity ->
             return BoardInfo(entity.boardId, entity.name, entity.url)
         }
 
-        val name = boardRepository.fetchBoardName("${boardUrl}SETTING.TXT") ?: boardName
+        val name = boardRepository.fetchBoardName("${boardUrl}SETTING.TXT") ?: return null
         val id = boardRepository.ensureBoard(BoardInfo(0L, name, boardUrl))
         return BoardInfo(id, name, boardUrl)
     }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -1,6 +1,7 @@
 package com.websarva.wings.android.slevo.ui.thread.screen
 
 import android.os.Build
+import android.widget.Toast
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -46,6 +47,7 @@ fun ThreadScaffold(
     topBarState: TopAppBarState,
 ) {
     val tabsUiState by tabsViewModel.uiState.collectAsState()
+    val context = LocalContext.current
 
     LaunchedEffect(threadRoute) {
         val info = tabsViewModel.resolveBoardInfo(
@@ -53,6 +55,11 @@ fun ThreadScaffold(
             boardUrl = threadRoute.boardUrl,
             boardName = threadRoute.boardName
         )
+        if (info == null) {
+            Toast.makeText(context, R.string.invalid_board_url, Toast.LENGTH_SHORT).show()
+            navController.navigateUp()
+            return@LaunchedEffect
+        }
         val vm = tabsViewModel.getOrCreateThreadViewModel(threadRoute.threadKey + info.url)
         vm.initializeThread(
             threadKey = threadRoute.threadKey,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,6 +47,7 @@
     <string name="title">タイトル</string>
     <string name="open_url">URLを開く</string>
     <string name="enter_url">板またはスレッドのURLを入力してください</string>
+    <string name="invalid_board_url">無効な板URLです</string>
     <string name="open">開く</string>
     <string name="select_image">画像を選択</string>
     <string name="history">履歴</string>


### PR DESCRIPTION
## Summary
- Avoid saving board info when `fetchBoardName` returns null
- Return `null` from `resolveBoardInfo` for invalid board URLs
- Show toast and navigate back when board info resolution fails

## Testing
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_68be43e5f3bc8332ab20c8869da1994b