### PR TITLE
feat: persist thread read state in history

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/dao/OpenThreadTabDao.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/dao/OpenThreadTabDao.kt
@@ -2,14 +2,17 @@ package com.websarva.wings.android.slevo.data.datasource.local.dao
 
 import androidx.room.Dao
 import androidx.room.Query
+import androidx.room.Transaction
 import androidx.room.Upsert
 import com.websarva.wings.android.slevo.data.datasource.local.entity.OpenThreadTabEntity
+import com.websarva.wings.android.slevo.data.datasource.local.entity.OpenThreadTabWithHistory
 import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface OpenThreadTabDao {
+    @Transaction
     @Query("SELECT * FROM open_thread_tabs ORDER BY sortOrder ASC")
-    fun observeOpenThreadTabs(): Flow<List<OpenThreadTabEntity>>
+    fun observeOpenThreadTabs(): Flow<List<OpenThreadTabWithHistory>>
 
     @Query("SELECT * FROM open_thread_tabs")
     suspend fun getAll(): List<OpenThreadTabEntity>
@@ -18,8 +21,7 @@ interface OpenThreadTabDao {
     suspend fun upsertAll(tabs: List<OpenThreadTabEntity>)
 
     @Query(
-        "DELETE FROM open_thread_tabs " +
-            "WHERE (threadKey || ':' || boardUrl) NOT IN (:ids)"
+        "DELETE FROM open_thread_tabs WHERE threadId NOT IN (:ids)"
     )
     suspend fun deleteNotIn(ids: List<String>)
 

--- a/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/dao/history/ThreadHistoryDao.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/dao/history/ThreadHistoryDao.kt
@@ -6,8 +6,10 @@ import androidx.room.Insert
 import androidx.room.Query
 import androidx.room.Transaction
 import androidx.room.Update
+import androidx.room.Upsert
 import com.websarva.wings.android.slevo.data.datasource.local.entity.history.ThreadHistoryAccessEntity
 import com.websarva.wings.android.slevo.data.datasource.local.entity.history.ThreadHistoryEntity
+import com.websarva.wings.android.slevo.data.model.ThreadId
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -30,39 +32,35 @@ interface ThreadHistoryDao {
     )
     fun observeHistories(): Flow<List<HistoryWithLastAccess>>
 
-    @Query("SELECT * FROM thread_histories WHERE threadKey = :threadKey AND boardUrl = :boardUrl LIMIT 1")
-    suspend fun find(threadKey: String, boardUrl: String): ThreadHistoryEntity?
+    @Query("SELECT * FROM thread_histories WHERE threadId = :threadId LIMIT 1")
+    suspend fun find(threadId: ThreadId): ThreadHistoryEntity?
     @Query("SELECT threadKey, resCount FROM thread_histories WHERE boardUrl = :boardUrl")
     suspend fun findByBoard(boardUrl: String): List<HistorySimple>
 
     @Query("SELECT threadKey, resCount FROM thread_histories WHERE boardUrl = :boardUrl")
     fun observeByBoard(boardUrl: String): Flow<List<HistorySimple>>
 
-
-    @Insert
-    suspend fun insert(history: ThreadHistoryEntity): Long
-
-    @Update
-    suspend fun update(history: ThreadHistoryEntity)
+    @Upsert
+    suspend fun upsert(history: ThreadHistoryEntity): Long
 
     @Insert
     suspend fun insertAccess(access: ThreadHistoryAccessEntity)
 
     @Query(
-        "SELECT accessedAt FROM thread_history_accesses WHERE threadHistoryId = :threadId " +
+        "SELECT accessedAt FROM thread_history_accesses WHERE threadHistoryId = :historyId " +
             "ORDER BY accessedAt DESC LIMIT 1"
     )
-    suspend fun getLastAccess(threadId: Long): Long?
+    suspend fun getLastAccess(historyId: Long): Long?
 
     @Query(
-        "SELECT * FROM thread_history_accesses WHERE threadHistoryId = :threadId " +
+        "SELECT * FROM thread_history_accesses WHERE threadHistoryId = :historyId " +
             "ORDER BY accessedAt DESC LIMIT 1"
     )
-    suspend fun getLastAccessEntity(threadId: Long): ThreadHistoryAccessEntity?
+    suspend fun getLastAccessEntity(historyId: Long): ThreadHistoryAccessEntity?
 
     @Update
     suspend fun updateAccess(access: ThreadHistoryAccessEntity)
 
-    @Query("DELETE FROM thread_histories WHERE threadKey = :threadKey AND boardUrl = :boardUrl")
-    suspend fun delete(threadKey: String, boardUrl: String)
+    @Query("DELETE FROM thread_histories WHERE threadId = :threadId")
+    suspend fun delete(threadId: ThreadId)
 }

--- a/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/entity/OpenThreadTabWithHistory.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/entity/OpenThreadTabWithHistory.kt
@@ -1,0 +1,17 @@
+package com.websarva.wings.android.slevo.data.datasource.local.entity
+
+import androidx.room.Embedded
+import androidx.room.Relation
+import com.websarva.wings.android.slevo.data.datasource.local.entity.history.ThreadHistoryEntity
+
+/**
+ * OpenThreadTabEntity と ThreadHistoryEntity を結合したデータクラス
+ */
+data class OpenThreadTabWithHistory(
+    @Embedded val tab: OpenThreadTabEntity,
+    @Relation(
+        parentColumn = "threadId",
+        entityColumn = "threadId"
+    )
+    val history: ThreadHistoryEntity
+)

--- a/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/entity/TabEntities.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/entity/TabEntities.kt
@@ -2,6 +2,7 @@ package com.websarva.wings.android.slevo.data.datasource.local.entity
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import com.websarva.wings.android.slevo.data.model.ThreadId
 
 @Entity(tableName = "open_board_tabs")
 data class OpenBoardTabEntity(
@@ -15,19 +16,10 @@ data class OpenBoardTabEntity(
 )
 
 @Entity(
-    tableName = "open_thread_tabs",
-    primaryKeys = ["threadKey", "boardUrl"]
+    tableName = "open_thread_tabs"
 )
 data class OpenThreadTabEntity(
-    val threadKey: String,
-    val boardUrl: String,
-    val boardId: Long,
-    val boardName: String,
-    val title: String,
-    val resCount: Int = 0,
-    val prevResCount: Int = 0,
-    val lastReadResNo: Int = 0,
-    val firstNewResNo: Int? = null,
+    @PrimaryKey val threadId: ThreadId,
     val sortOrder: Int,
     val firstVisibleItemIndex: Int = 0,
     val firstVisibleItemScrollOffset: Int = 0

--- a/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/entity/history/ThreadHistoryEntity.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/entity/history/ThreadHistoryEntity.kt
@@ -3,17 +3,25 @@ package com.websarva.wings.android.slevo.data.datasource.local.entity.history
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import com.websarva.wings.android.slevo.data.model.ThreadId
 
 @Entity(
     tableName = "thread_histories",
-    indices = [Index(value = ["threadKey", "boardUrl"], unique = true)]
+    indices = [
+        Index(value = ["threadKey", "boardUrl"], unique = true),
+        Index(value = ["threadId"], unique = true)
+    ]
 )
 data class ThreadHistoryEntity(
     @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val threadId: ThreadId,
     val threadKey: String,
     val boardUrl: String,
     val boardId: Long,
     val boardName: String,
     val title: String,
-    val resCount: Int = 0
+    val resCount: Int = 0,
+    val prevResCount: Int = 0,
+    val lastReadResNo: Int = 0,
+    val firstNewResNo: Int? = null
 )

--- a/app/src/main/java/com/websarva/wings/android/slevo/data/model/ThreadId.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/model/ThreadId.kt
@@ -1,0 +1,9 @@
+package com.websarva.wings.android.slevo.data.model
+
+@JvmInline
+value class ThreadId(val value: String) {
+    companion object {
+        fun of(host: String, board: String, threadKey: String) =
+            ThreadId("$host/$board/$threadKey")
+    }
+}

--- a/app/src/main/java/com/websarva/wings/android/slevo/di/DatabaseModule.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/di/DatabaseModule.kt
@@ -56,7 +56,8 @@ object DatabaseModule {
             name
         )
             .addMigrations(
-                AppDatabase.MIGRATION_1_2
+                AppDatabase.MIGRATION_1_2,
+                AppDatabase.MIGRATION_2_3
             )
             .addCallback(callback)
             .apply {


### PR DESCRIPTION
## Summary
- move prevResCount, lastReadResNo, and firstNewResNo into ThreadHistoryEntity
- link open thread tabs to thread history via ThreadId
- add migration for new schema

## Testing
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_68bfeaca4ecc83328d08dadda16f2221