### PR TITLE
feat: add thread read state handling

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/AppDatabase.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/AppDatabase.kt
@@ -58,7 +58,7 @@ import com.websarva.wings.android.slevo.data.datasource.local.entity.history.Pos
         BoardFetchMetaEntity::class,
         PostHistoryEntity::class
     ],
-    version = 3,
+    version = 4,
     exportSchema = true
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -130,6 +130,20 @@ abstract class AppDatabase : RoomDatabase() {
                         "threadHistoryId INTEGER NOT NULL, " +
                         "accessedAt INTEGER NOT NULL, " +
                         "PRIMARY KEY(threadHistoryId, accessedAt))"
+                )
+            }
+        }
+
+        val MIGRATION_3_4 = object : androidx.room.migration.Migration(3, 4) {
+            override fun migrate(database: androidx.sqlite.db.SupportSQLiteDatabase) {
+                database.execSQL(
+                    "ALTER TABLE thread_histories ADD COLUMN prevResCount INTEGER NOT NULL DEFAULT 0"
+                )
+                database.execSQL(
+                    "ALTER TABLE thread_histories ADD COLUMN lastReadResNo INTEGER NOT NULL DEFAULT 0"
+                )
+                database.execSQL(
+                    "ALTER TABLE thread_histories ADD COLUMN firstNewResNo INTEGER"
                 )
             }
         }

--- a/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/dao/OpenThreadTabDao.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/dao/OpenThreadTabDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Query
 import androidx.room.Upsert
 import com.websarva.wings.android.slevo.data.datasource.local.entity.OpenThreadTabEntity
 import kotlinx.coroutines.flow.Flow
+import com.websarva.wings.android.slevo.data.model.ThreadId
 
 @Dao
 interface OpenThreadTabDao {
@@ -22,4 +23,16 @@ interface OpenThreadTabDao {
 
     @Query("DELETE FROM open_thread_tabs")
     suspend fun deleteAll()
+
+    @Query(
+        "UPDATE open_thread_tabs SET prevResCount = :prevResCount, " +
+            "lastReadResNo = :lastReadResNo, firstNewResNo = :firstNewResNo " +
+            "WHERE threadId = :threadId"
+    )
+    suspend fun updateReadState(
+        threadId: ThreadId,
+        prevResCount: Int,
+        lastReadResNo: Int,
+        firstNewResNo: Int?
+    )
 }

--- a/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/dao/history/ThreadHistoryDao.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/dao/history/ThreadHistoryDao.kt
@@ -66,4 +66,16 @@ interface ThreadHistoryDao {
 
     @Query("DELETE FROM thread_histories WHERE threadId = :threadId")
     suspend fun delete(threadId: ThreadId)
+
+    @Query(
+        "UPDATE thread_histories SET prevResCount = :prevResCount, " +
+            "lastReadResNo = :lastReadResNo, firstNewResNo = :firstNewResNo " +
+            "WHERE threadId = :threadId"
+    )
+    suspend fun updateReadState(
+        threadId: ThreadId,
+        prevResCount: Int,
+        lastReadResNo: Int,
+        firstNewResNo: Int?
+    )
 }

--- a/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/entity/TabEntities.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/entity/TabEntities.kt
@@ -1,8 +1,10 @@
 package com.websarva.wings.android.slevo.data.datasource.local.entity
 
+import androidx.room.Embedded
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.websarva.wings.android.slevo.data.model.ThreadId
+import com.websarva.wings.android.slevo.data.datasource.local.entity.ThreadReadState
 
 @Entity(tableName = "open_board_tabs")
 data class OpenBoardTabEntity(
@@ -23,9 +25,7 @@ data class OpenThreadTabEntity(
     val boardName: String,
     val title: String,
     val resCount: Int = 0,
-    val prevResCount: Int = 0,
-    val lastReadResNo: Int = 0,
-    val firstNewResNo: Int? = null,
+    @Embedded val readState: ThreadReadState = ThreadReadState(),
     val sortOrder: Int,
     val firstVisibleItemIndex: Int = 0,
     val firstVisibleItemScrollOffset: Int = 0

--- a/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/entity/ThreadReadState.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/entity/ThreadReadState.kt
@@ -1,0 +1,7 @@
+package com.websarva.wings.android.slevo.data.datasource.local.entity
+
+data class ThreadReadState(
+    val prevResCount: Int = 0,
+    val lastReadResNo: Int = 0,
+    val firstNewResNo: Int? = null
+)

--- a/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/entity/history/ThreadHistoryEntity.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/entity/history/ThreadHistoryEntity.kt
@@ -1,9 +1,11 @@
 package com.websarva.wings.android.slevo.data.datasource.local.entity.history
 
+import androidx.room.Embedded
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
 import com.websarva.wings.android.slevo.data.model.ThreadId
+import com.websarva.wings.android.slevo.data.datasource.local.entity.ThreadReadState
 
 @Entity(
     tableName = "thread_histories",
@@ -16,5 +18,6 @@ data class ThreadHistoryEntity(
     val boardId: Long,
     val boardName: String,
     val title: String,
-    val resCount: Int = 0
+    val resCount: Int = 0,
+    @Embedded val readState: ThreadReadState = ThreadReadState()
 )

--- a/app/src/main/java/com/websarva/wings/android/slevo/data/repository/TabsRepository.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/repository/TabsRepository.kt
@@ -9,6 +9,7 @@ import com.websarva.wings.android.slevo.data.datasource.local.AppDatabase
 import com.websarva.wings.android.slevo.data.model.ThreadId
 import com.websarva.wings.android.slevo.ui.tabs.BoardTabInfo
 import com.websarva.wings.android.slevo.ui.tabs.ThreadTabInfo
+import com.websarva.wings.android.slevo.data.datasource.local.entity.ThreadReadState
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -79,9 +80,9 @@ class TabsRepository @Inject constructor(
                     boardUrl = entity.boardUrl,
                     boardId = entity.boardId,
                     resCount = entity.resCount,
-                    prevResCount = entity.prevResCount,
-                    lastReadResNo = entity.lastReadResNo,
-                    firstNewResNo = entity.firstNewResNo,
+                    prevResCount = entity.readState.prevResCount,
+                    lastReadResNo = entity.readState.lastReadResNo,
+                    firstNewResNo = entity.readState.firstNewResNo,
                     firstVisibleItemIndex = entity.firstVisibleItemIndex,
                     firstVisibleItemScrollOffset = entity.firstVisibleItemScrollOffset
                 )
@@ -101,9 +102,11 @@ class TabsRepository @Inject constructor(
                     boardName = info.boardName,
                     title = info.title,
                     resCount = info.resCount,
-                    prevResCount = info.prevResCount,
-                    lastReadResNo = info.lastReadResNo,
-                    firstNewResNo = info.firstNewResNo,
+                    readState = ThreadReadState(
+                        prevResCount = info.prevResCount,
+                        lastReadResNo = info.lastReadResNo,
+                        firstNewResNo = info.firstNewResNo
+                    ),
                     sortOrder = index,
                     firstVisibleItemIndex = info.firstVisibleItemIndex,
                     firstVisibleItemScrollOffset = info.firstVisibleItemScrollOffset

--- a/app/src/main/java/com/websarva/wings/android/slevo/data/repository/ThreadHistoryRepository.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/repository/ThreadHistoryRepository.kt
@@ -3,6 +3,7 @@ package com.websarva.wings.android.slevo.data.repository
 import com.websarva.wings.android.slevo.data.datasource.local.dao.history.ThreadHistoryDao
 import com.websarva.wings.android.slevo.data.datasource.local.entity.history.ThreadHistoryAccessEntity
 import com.websarva.wings.android.slevo.data.datasource.local.entity.history.ThreadHistoryEntity
+import com.websarva.wings.android.slevo.data.datasource.local.entity.ThreadReadState
 import com.websarva.wings.android.slevo.data.model.BoardInfo
 import com.websarva.wings.android.slevo.data.model.ThreadId
 import com.websarva.wings.android.slevo.data.model.ThreadInfo
@@ -44,7 +45,8 @@ class ThreadHistoryRepository @Inject constructor(
             boardId = boardInfo.boardId,
             boardName = boardInfo.name,
             title = threadInfo.title,
-            resCount = resCount
+            resCount = resCount,
+            readState = existing?.readState ?: ThreadReadState()
         )
         val id = if (existing == null) {
             dao.insert(history)

--- a/app/src/main/java/com/websarva/wings/android/slevo/data/repository/ThreadReadStateRepository.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/repository/ThreadReadStateRepository.kt
@@ -1,0 +1,37 @@
+package com.websarva.wings.android.slevo.data.repository
+
+import androidx.room.withTransaction
+import com.websarva.wings.android.slevo.data.datasource.local.AppDatabase
+import com.websarva.wings.android.slevo.data.datasource.local.dao.OpenThreadTabDao
+import com.websarva.wings.android.slevo.data.datasource.local.dao.history.ThreadHistoryDao
+import com.websarva.wings.android.slevo.data.datasource.local.entity.ThreadReadState
+import com.websarva.wings.android.slevo.data.model.ThreadId
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ThreadReadStateRepository @Inject constructor(
+    private val threadHistoryDao: ThreadHistoryDao,
+    private val openThreadTabDao: OpenThreadTabDao,
+    private val db: AppDatabase,
+) {
+    suspend fun saveReadState(threadId: ThreadId, readState: ThreadReadState) =
+        withContext(Dispatchers.IO) {
+            db.withTransaction {
+                openThreadTabDao.updateReadState(
+                    threadId,
+                    readState.prevResCount,
+                    readState.lastReadResNo,
+                    readState.firstNewResNo
+                )
+                threadHistoryDao.updateReadState(
+                    threadId,
+                    readState.prevResCount,
+                    readState.lastReadResNo,
+                    readState.firstNewResNo
+                )
+            }
+        }
+}

--- a/app/src/main/java/com/websarva/wings/android/slevo/di/DatabaseModule.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/di/DatabaseModule.kt
@@ -57,7 +57,8 @@ object DatabaseModule {
         )
             .addMigrations(
                 AppDatabase.MIGRATION_1_2,
-                AppDatabase.MIGRATION_2_3
+                AppDatabase.MIGRATION_2_3,
+                AppDatabase.MIGRATION_3_4
             )
             .addCallback(callback)
             .apply {


### PR DESCRIPTION
## Summary
- track thread read state in dedicated data class
- embed read state into thread history and open thread tab entities
- add repository and migrations to persist read state across tables

## Testing
- `./gradlew :app:lintDebug` *(fails: MainActivity must extend android.app.Activity)*
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_68c020e4753083329a6ad3269ec374f1