### PR TITLE
feat: remember last opened tabs

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
@@ -68,6 +68,7 @@ fun BoardScaffold(
                 serviceName = parseServiceName(info.url)
             )
         )
+        tabsViewModel.setLastOpenedBoard(info.boardId)
     }
 
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topBarState)

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/OpenBoardsList.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/OpenBoardsList.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.HorizontalDivider
@@ -20,6 +21,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -35,12 +37,21 @@ import com.websarva.wings.android.slevo.ui.theme.bookmarkColor
 fun OpenBoardsList(
     modifier: Modifier = Modifier,
     openTabs: List<BoardTabInfo>,
+    lastOpenedBoardId: Long? = null,
     onCloseClick: (BoardTabInfo) -> Unit = {},
     navController: NavHostController,
     closeDrawer: () -> Unit,
 ) {
+    val listState = rememberLazyListState()
+    LaunchedEffect(lastOpenedBoardId, openTabs) {
+        val index = openTabs.indexOfFirst { it.boardId == lastOpenedBoardId }
+        if (index >= 0) {
+            listState.scrollToItem(index)
+        }
+    }
+
     Column(modifier = modifier.fillMaxSize()) {
-        LazyColumn(modifier = Modifier.weight(1f)) {
+        LazyColumn(modifier = Modifier.weight(1f), state = listState) {
             items(openTabs, key = { it.boardUrl }) { tab ->
                 val color = tab.bookmarkColorName?.let { bookmarkColor(it) }
                 Row(modifier = Modifier.height(IntrinsicSize.Min)) {

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/OpenThreadsList.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/OpenThreadsList.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.HorizontalDivider
@@ -26,6 +27,7 @@ import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -50,6 +52,7 @@ fun OpenThreadsList(
     isRefreshing: Boolean = false,
     onRefresh: () -> Unit = {},
     newResCounts: Map<String, Int> = emptyMap(),
+    lastOpenedThreadId: ThreadId? = null,
     onItemClick: (ThreadTabInfo) -> Unit = {}
 ) {
     PullToRefreshBox(
@@ -57,7 +60,15 @@ fun OpenThreadsList(
         isRefreshing = isRefreshing,
         onRefresh = onRefresh,
     ) {
-        LazyColumn(modifier = Modifier.fillMaxSize()) {
+        val listState = rememberLazyListState()
+        LaunchedEffect(lastOpenedThreadId, openTabs) {
+            val index = openTabs.indexOfFirst { it.id == lastOpenedThreadId }
+            if (index >= 0) {
+                listState.scrollToItem(index)
+            }
+        }
+
+        LazyColumn(modifier = Modifier.fillMaxSize(), state = listState) {
             items(openTabs, key = { it.id.value }) { tab ->
                 val color = tab.bookmarkColorName?.let { bookmarkColor(it) }
                 Row(modifier = Modifier.height(IntrinsicSize.Min)) {

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabsPagerContent.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabsPagerContent.kt
@@ -56,12 +56,14 @@ fun TabsPagerContent(
             when (page) {
                 0 -> OpenBoardsList(
                     openTabs = uiState.openBoardTabs,
+                    lastOpenedBoardId = uiState.lastOpenedBoardId,
                     onCloseClick = { tabsViewModel.closeBoardTab(it) },
                     navController = navController,
                     closeDrawer = closeDrawer
                 )
                 else -> OpenThreadsList(
                     openTabs = uiState.openThreadTabs,
+                    lastOpenedThreadId = uiState.lastOpenedThreadId,
                     onCloseClick = { tabsViewModel.closeThreadTab(it) },
                     navController = navController,
                     closeDrawer = closeDrawer,

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabsUiState.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabsUiState.kt
@@ -1,5 +1,7 @@
 package com.websarva.wings.android.slevo.ui.tabs
 
+import com.websarva.wings.android.slevo.data.model.ThreadId
+
 /**
  * タブ画面全体のUI状態を表すデータクラス
  */
@@ -10,6 +12,8 @@ data class TabsUiState(
     val threadLoaded: Boolean = false,
     val isRefreshing: Boolean = false,
     val newResCounts: Map<String, Int> = emptyMap(),
+    val lastOpenedBoardId: Long? = null,
+    val lastOpenedThreadId: ThreadId? = null,
 ) {
     // isLoadingを他の状態から計算する算出プロパティとして定義
     val isLoading: Boolean

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabsViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabsViewModel.kt
@@ -129,6 +129,14 @@ class TabsViewModel @Inject constructor(
         viewModelScope.launch { tabsRepository.setLastSelectedPage(page) }
     }
 
+    fun setLastOpenedBoard(boardId: Long) {
+        _uiState.update { it.copy(lastOpenedBoardId = boardId) }
+    }
+
+    fun setLastOpenedThread(threadId: ThreadId) {
+        _uiState.update { it.copy(lastOpenedThreadId = threadId) }
+    }
+
     /**
      * 板タブを開く。すでに存在する場合は最新情報で上書きする。
      */

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -71,6 +71,7 @@ fun ThreadScaffold(
             boardInfo = info,
             threadTitle = threadRoute.threadTitle
         )
+        tabsViewModel.setLastOpenedThread(routeThreadId)
     }
 
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(topBarState)


### PR DESCRIPTION
## Summary
- track last opened board and thread tabs
- scroll open tab lists to saved tab when revisiting

## Testing
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_68c02389c51083328cdd62fc4a0c8100