### PR TITLE
fix: restore last opened tab after recomposition

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
@@ -68,6 +68,7 @@ fun BoardScaffold(
                 serviceName = parseServiceName(info.url)
             )
         )
+        tabsViewModel.updateLastBoardTab(info.boardId)
     }
 
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topBarState)
@@ -81,6 +82,8 @@ fun BoardScaffold(
         currentRoutePredicate = { it.boardUrl == boardRoute.boardUrl },
         getViewModel = { tab -> tabsViewModel.getOrCreateBoardViewModel(tab.boardUrl) },
         getKey = { it.boardUrl },
+        getId = { it.boardId },
+        lastTabId = tabsUiState.lastBoardId,
         getScrollIndex = { it.firstVisibleItemIndex },
         getScrollOffset = { it.firstVisibleItemScrollOffset },
         initializeViewModel = { viewModel, tab ->
@@ -95,6 +98,7 @@ fun BoardScaffold(
         updateScrollPosition = { _, tab, index, offset ->
             tabsViewModel.updateBoardScrollPosition(tab.boardUrl, index, offset)
         },
+        onPageChanged = { tabsViewModel.updateLastBoardTab(it.boardId) },
         scrollBehavior = scrollBehavior,
         topBar = { viewModel, uiState, drawer, scrollBehavior ->
             val bookmarkState = uiState.singleBookmarkState

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
@@ -14,6 +14,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -48,6 +51,7 @@ fun BoardScaffold(
 ) {
     val tabsUiState by tabsViewModel.uiState.collectAsState()
     val context = LocalContext.current
+    var restoreLastTab by remember(boardRoute) { mutableStateOf(false) }
 
     LaunchedEffect(boardRoute) {
         val info = tabsViewModel.resolveBoardInfo(
@@ -69,6 +73,7 @@ fun BoardScaffold(
             )
         )
         tabsViewModel.updateLastBoardTab(info.boardId)
+        restoreLastTab = true
     }
 
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topBarState)
@@ -83,7 +88,7 @@ fun BoardScaffold(
         getViewModel = { tab -> tabsViewModel.getOrCreateBoardViewModel(tab.boardUrl) },
         getKey = { it.boardUrl },
         getId = { it.boardId },
-        lastTabId = tabsUiState.lastBoardId,
+        lastTabId = if (restoreLastTab) tabsUiState.lastBoardId else null,
         getScrollIndex = { it.firstVisibleItemIndex },
         getScrollOffset = { it.firstVisibleItemScrollOffset },
         initializeViewModel = { viewModel, tab ->

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabsUiState.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabsUiState.kt
@@ -10,6 +10,8 @@ data class TabsUiState(
     val threadLoaded: Boolean = false,
     val isRefreshing: Boolean = false,
     val newResCounts: Map<String, Int> = emptyMap(),
+    val lastBoardId: Long? = null,
+    val lastThreadId: String? = null,
 ) {
     // isLoadingを他の状態から計算する算出プロパティとして定義
     val isLoading: Boolean

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabsViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabsViewModel.kt
@@ -103,6 +103,14 @@ class TabsViewModel @Inject constructor(
         }
     }
 
+    fun updateLastBoardTab(boardId: Long) {
+        _uiState.update { it.copy(lastBoardId = boardId) }
+    }
+
+    fun updateLastThreadTab(threadId: ThreadId) {
+        _uiState.update { it.copy(lastThreadId = threadId.value) }
+    }
+
     /**
      * 指定キーの [ThreadViewModel] を取得。
      * 存在しない場合は Factory から生成して登録する。
@@ -146,7 +154,7 @@ class TabsViewModel @Inject constructor(
             } else {
                 currentBoards + boardTabInfo
             }
-            state.copy(openBoardTabs = updated)
+            state.copy(openBoardTabs = updated, lastBoardId = boardTabInfo.boardId)
         }
         viewModelScope.launch { tabsRepository.saveOpenBoardTabs(_uiState.value.openBoardTabs) }
     }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -11,7 +11,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -49,10 +51,10 @@ fun ThreadScaffold(
 ) {
     val tabsUiState by tabsViewModel.uiState.collectAsState()
     val context = LocalContext.current
-
     val routeThreadId = parseBoardUrl(threadRoute.boardUrl)?.let { (host, board) ->
         ThreadId.of(host, board, threadRoute.threadKey)
     }
+    var restoreLastTab by remember(threadRoute) { mutableStateOf(false) }
 
     LaunchedEffect(threadRoute) {
         val info = tabsViewModel.resolveBoardInfo(
@@ -72,6 +74,7 @@ fun ThreadScaffold(
             threadTitle = threadRoute.threadTitle
         )
         tabsViewModel.updateLastThreadTab(routeThreadId)
+        restoreLastTab = true
     }
 
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(topBarState)
@@ -86,7 +89,7 @@ fun ThreadScaffold(
         getViewModel = { tab -> tabsViewModel.getOrCreateThreadViewModel(tab.id.value) },
         getKey = { it.id.value },
         getId = { it.id.value },
-        lastTabId = tabsUiState.lastThreadId,
+        lastTabId = if (restoreLastTab) tabsUiState.lastThreadId else null,
         getScrollIndex = { it.firstVisibleItemIndex },
         getScrollOffset = { it.firstVisibleItemScrollOffset },
         initializeViewModel = { viewModel, tab ->

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -71,6 +71,7 @@ fun ThreadScaffold(
             boardInfo = info,
             threadTitle = threadRoute.threadTitle
         )
+        tabsViewModel.updateLastThreadTab(routeThreadId)
     }
 
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(topBarState)
@@ -84,6 +85,8 @@ fun ThreadScaffold(
         currentRoutePredicate = { routeThreadId != null && it.id == routeThreadId },
         getViewModel = { tab -> tabsViewModel.getOrCreateThreadViewModel(tab.id.value) },
         getKey = { it.id.value },
+        getId = { it.id.value },
+        lastTabId = tabsUiState.lastThreadId,
         getScrollIndex = { it.firstVisibleItemIndex },
         getScrollOffset = { it.firstVisibleItemScrollOffset },
         initializeViewModel = { viewModel, tab ->
@@ -100,6 +103,7 @@ fun ThreadScaffold(
         updateScrollPosition = { viewModel, tab, index, offset ->
             viewModel.updateThreadScrollPosition(tab.id, index, offset)
         },
+        onPageChanged = { tabsViewModel.updateLastThreadTab(it.id) },
         scrollBehavior = scrollBehavior,
         bottomBarScrollBehavior = { listState -> rememberBottomBarShowOnBottomBehavior(listState) },
         topBar = { viewModel, uiState, _, scrollBehavior ->


### PR DESCRIPTION
## Summary
- preserve last opened board and thread tabs
- restore pager to previous tab when returning to screen

## Testing
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_68c04b23693c833283471fdcf9037ba6