### PR TITLE
fix: restore last opened tab after navigation

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
@@ -72,6 +72,10 @@ fun BoardScaffold(
 
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topBarState)
 
+    val initialPage = tabsUiState.lastOpenedBoardId?.let { id ->
+        tabsUiState.openBoardTabs.indexOfFirst { it.boardId == id }.takeIf { it >= 0 }
+    } ?: tabsUiState.openBoardTabs.indexOfFirst { it.boardUrl == boardRoute.boardUrl }.coerceAtLeast(0)
+
     RouteScaffold(
         route = boardRoute,
         tabsViewModel = tabsViewModel,
@@ -96,6 +100,8 @@ fun BoardScaffold(
             tabsViewModel.updateBoardScrollPosition(tab.boardUrl, index, offset)
         },
         scrollBehavior = scrollBehavior,
+        initialPage = initialPage,
+        onPageChanged = { tab -> tabsViewModel.setLastOpenedBoard(tab.boardId) },
         topBar = { viewModel, uiState, drawer, scrollBehavior ->
             val bookmarkState = uiState.singleBookmarkState
             val bookmarkIconColor =

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabsUiState.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabsUiState.kt
@@ -1,5 +1,7 @@
 package com.websarva.wings.android.slevo.ui.tabs
 
+import com.websarva.wings.android.slevo.data.model.ThreadId
+
 /**
  * タブ画面全体のUI状態を表すデータクラス
  */
@@ -10,6 +12,8 @@ data class TabsUiState(
     val threadLoaded: Boolean = false,
     val isRefreshing: Boolean = false,
     val newResCounts: Map<String, Int> = emptyMap(),
+    val lastOpenedBoardId: Long? = null,
+    val lastOpenedThreadId: ThreadId? = null,
 ) {
     // isLoadingを他の状態から計算する算出プロパティとして定義
     val isLoading: Boolean

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabsViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabsViewModel.kt
@@ -129,6 +129,14 @@ class TabsViewModel @Inject constructor(
         viewModelScope.launch { tabsRepository.setLastSelectedPage(page) }
     }
 
+    fun setLastOpenedBoard(boardId: Long) {
+        _uiState.update { it.copy(lastOpenedBoardId = boardId) }
+    }
+
+    fun setLastOpenedThread(threadId: ThreadId) {
+        _uiState.update { it.copy(lastOpenedThreadId = threadId) }
+    }
+
     /**
      * 板タブを開く。すでに存在する場合は最新情報で上書きする。
      */
@@ -146,7 +154,7 @@ class TabsViewModel @Inject constructor(
             } else {
                 currentBoards + boardTabInfo
             }
-            state.copy(openBoardTabs = updated)
+            state.copy(openBoardTabs = updated, lastOpenedBoardId = boardTabInfo.boardId)
         }
         viewModelScope.launch { tabsRepository.saveOpenBoardTabs(_uiState.value.openBoardTabs) }
     }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -71,9 +71,14 @@ fun ThreadScaffold(
             boardInfo = info,
             threadTitle = threadRoute.threadTitle
         )
+        routeThreadId?.let { tabsViewModel.setLastOpenedThread(it) }
     }
 
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(topBarState)
+
+    val initialPage = tabsUiState.lastOpenedThreadId?.let { id ->
+        tabsUiState.openThreadTabs.indexOfFirst { it.id == id }.takeIf { it >= 0 }
+    } ?: tabsUiState.openThreadTabs.indexOfFirst { routeThreadId != null && it.id == routeThreadId }.coerceAtLeast(0)
 
     RouteScaffold(
         route = threadRoute,
@@ -102,6 +107,8 @@ fun ThreadScaffold(
         },
         scrollBehavior = scrollBehavior,
         bottomBarScrollBehavior = { listState -> rememberBottomBarShowOnBottomBehavior(listState) },
+        initialPage = initialPage,
+        onPageChanged = { tab -> tabsViewModel.setLastOpenedThread(tab.id) },
         topBar = { viewModel, uiState, _, scrollBehavior ->
             if (uiState.isSearchMode) {
                 SearchTopAppBar(


### PR DESCRIPTION
## Summary
- keep last visited board/thread tab IDs in `TabsUiState`
- restore the pager to last opened tab when returning to board/thread screens
- update pager state on page changes to track selected tab

## Testing
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_68c04b23693c833283471fdcf9037ba6