### PR TITLE
fix: restore last tab after resume

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/RouteScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/RouteScaffold.kt
@@ -63,6 +63,7 @@ fun <TabInfo : Any, UiState : BaseUiState<UiState>, ViewModel : BaseViewModel<Ui
     bottomBar: @Composable (viewModel: ViewModel, uiState: UiState, scrollBehavior: BottomAppBarScrollBehavior?) -> Unit,
     content: @Composable (viewModel: ViewModel, uiState: UiState, listState: LazyListState, modifier: Modifier, navController: NavHostController) -> Unit,
     scrollBehavior: TopAppBarScrollBehavior,
+    lastTabId: Any? = null,
     bottomBarScrollBehavior: (@Composable (LazyListState) -> BottomAppBarScrollBehavior)? = null,
     optionalSheetContent: @Composable (viewModel: ViewModel, uiState: UiState) -> Unit = { _, _ -> }
 ) {
@@ -82,8 +83,10 @@ fun <TabInfo : Any, UiState : BaseUiState<UiState>, ViewModel : BaseViewModel<Ui
 
     if (currentTabInfo != null) {
         // 初期ページの決定。routeやタブ数が変わったら再計算される。
-        val initialPage = remember(route, tabs.size) {
-            tabs.indexOfFirst(currentRoutePredicate).coerceAtLeast(0)
+        val initialPage = remember(route, tabs.size, lastTabId) {
+            lastTabId?.let { id ->
+                tabs.indexOfFirst { getKey(it) == id }.takeIf { it != -1 }
+            } ?: tabs.indexOfFirst(currentRoutePredicate).coerceAtLeast(0)
         }
 
         // Pagerの状態。ページ数はタブ数に応じて動的に提供される。

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabsUiState.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabsUiState.kt
@@ -1,5 +1,7 @@
 package com.websarva.wings.android.slevo.ui.tabs
 
+import com.websarva.wings.android.slevo.data.model.ThreadId
+
 /**
  * タブ画面全体のUI状態を表すデータクラス
  */
@@ -10,6 +12,8 @@ data class TabsUiState(
     val threadLoaded: Boolean = false,
     val isRefreshing: Boolean = false,
     val newResCounts: Map<String, Int> = emptyMap(),
+    val lastBoardId: Long? = null,
+    val lastThreadId: ThreadId? = null,
 ) {
     // isLoadingを他の状態から計算する算出プロパティとして定義
     val isLoading: Boolean

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -104,7 +104,7 @@ fun ThreadScaffold(
         openTabs = tabsUiState.openThreadTabs,
         currentRoutePredicate = { routeThreadId != null && it.id == routeThreadId },
         getViewModel = { tab -> tabsViewModel.getOrCreateThreadViewModel(tab.id.value) },
-        getKey = { it.id },
+        getKey = { it.id.value },
         getScrollIndex = { it.firstVisibleItemIndex },
         getScrollOffset = { it.firstVisibleItemScrollOffset },
         initializeViewModel = { viewModel, tab ->
@@ -122,7 +122,7 @@ fun ThreadScaffold(
             viewModel.updateThreadScrollPosition(tab.id, index, offset)
         },
         scrollBehavior = scrollBehavior,
-        lastTabId = if (restoreLastTab) tabsUiState.lastThreadId else null,
+        lastTabId = if (restoreLastTab) tabsUiState.lastThreadId?.value else null,
         bottomBarScrollBehavior = { listState -> rememberBottomBarShowOnBottomBehavior(listState) },
         topBar = { viewModel, uiState, _, scrollBehavior ->
             if (uiState.isSearchMode) {


### PR DESCRIPTION
## Summary
- rememberSaveable でタブ復元フラグを保持し、NavBackStackEntry のライフサイクルを監視
- RouteScaffold に lastTabId を渡して ON_RESUME 後にのみ前回タブを復元
- TabsUiState へ lastBoardId / lastThreadId を追加

## Testing
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_68c058aae4148332868fbf67b90b47c6