### PR TITLE
refactor: separate tab list viewmodel

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/MainActivity.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/MainActivity.kt
@@ -14,7 +14,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowInsetsControllerCompat
 import com.websarva.wings.android.slevo.ui.AppScaffold
-import com.websarva.wings.android.slevo.ui.tabs.TabsViewModel
+import com.websarva.wings.android.slevo.ui.tabs.TabListViewModel
 import com.websarva.wings.android.slevo.ui.settings.SettingsViewModel
 import com.websarva.wings.android.slevo.ui.theme.SlevoTheme
 import dagger.hilt.android.AndroidEntryPoint
@@ -22,7 +22,7 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     private val settingsViewModel: SettingsViewModel by viewModels()
-    private val tabsViewModel: TabsViewModel by viewModels()
+    private val tabListViewModel: TabListViewModel by viewModels()
 
     @RequiresApi(Build.VERSION_CODES.O)
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -46,7 +46,7 @@ class MainActivity : ComponentActivity() {
             SlevoTheme(darkTheme = uiState.isDark) {
                 AppScaffold(
                     settingsViewModel = settingsViewModel,
-                    tabsViewModel = tabsViewModel
+                    tabListViewModel = tabListViewModel
                 )
             }
         }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/AppScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/AppScaffold.kt
@@ -22,7 +22,7 @@ import androidx.navigation.compose.rememberNavController
 import com.websarva.wings.android.slevo.ui.bottombar.RenderBottomBar
 import com.websarva.wings.android.slevo.ui.navigation.AppNavGraph
 import com.websarva.wings.android.slevo.ui.settings.SettingsViewModel
-import com.websarva.wings.android.slevo.ui.tabs.TabsViewModel
+import com.websarva.wings.android.slevo.ui.tabs.TabListViewModel
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -32,7 +32,7 @@ fun AppScaffold(
     modifier: Modifier = Modifier,
     navController: NavHostController = rememberNavController(),
     settingsViewModel: SettingsViewModel,
-    tabsViewModel: TabsViewModel
+    tabListViewModel: TabListViewModel
 ) {
     val navBackStackEntry by navController.currentBackStackEntryAsState()
 
@@ -69,7 +69,7 @@ fun AppScaffold(
             topBarState = topBarState,
             settingsViewModel = settingsViewModel,
             openDrawer = openDrawer,
-            tabsViewModel = tabsViewModel
+            tabListViewModel = tabListViewModel
         )
     }
 

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
@@ -26,7 +26,8 @@ import com.websarva.wings.android.slevo.data.model.BoardInfo
 import com.websarva.wings.android.slevo.ui.navigation.AppRoute
 import com.websarva.wings.android.slevo.ui.navigation.RouteScaffold
 import com.websarva.wings.android.slevo.ui.tabs.BoardTabInfo
-import com.websarva.wings.android.slevo.ui.tabs.TabsViewModel
+import com.websarva.wings.android.slevo.ui.tabs.TabListViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.websarva.wings.android.slevo.ui.util.parseServiceName
 import com.websarva.wings.android.slevo.ui.util.parseBoardUrl
 import com.websarva.wings.android.slevo.ui.topbar.SearchTopAppBar
@@ -43,14 +44,14 @@ fun BoardScaffold(
     boardRoute: AppRoute.Board,
     navController: NavHostController,
     openDrawer: () -> Unit,
-    tabsViewModel: TabsViewModel,
+    tabListViewModel: TabListViewModel,
     topBarState: TopAppBarState
 ) {
-    val tabsUiState by tabsViewModel.uiState.collectAsState()
+    val tabsUiState by tabListViewModel.uiState.collectAsState()
     val context = LocalContext.current
 
     LaunchedEffect(boardRoute) {
-        val info = tabsViewModel.resolveBoardInfo(
+        val info = tabListViewModel.resolveBoardInfo(
             boardId = boardRoute.boardId,
             boardUrl = boardRoute.boardUrl,
             boardName = boardRoute.boardName
@@ -60,7 +61,7 @@ fun BoardScaffold(
             navController.navigateUp()
             return@LaunchedEffect
         }
-        tabsViewModel.openBoardTab(
+        tabListViewModel.openBoardTab(
             BoardTabInfo(
                 boardId = info.boardId,
                 boardName = info.name,
@@ -74,12 +75,12 @@ fun BoardScaffold(
 
     RouteScaffold(
         route = boardRoute,
-        tabsViewModel = tabsViewModel,
+        tabListViewModel = tabListViewModel,
         navController = navController,
         openDrawer = openDrawer,
         openTabs = tabsUiState.openBoardTabs,
         currentRoutePredicate = { it.boardUrl == boardRoute.boardUrl },
-        getViewModel = { tab -> tabsViewModel.getOrCreateBoardViewModel(tab.boardUrl) },
+        provideViewModel = { tab -> hiltViewModel<BoardViewModel>(key = tab.boardUrl) },
         getKey = { it.boardUrl },
         getScrollIndex = { it.firstVisibleItemIndex },
         getScrollOffset = { it.firstVisibleItemScrollOffset },
@@ -93,7 +94,7 @@ fun BoardScaffold(
             )
         },
         updateScrollPosition = { _, tab, index, offset ->
-            tabsViewModel.updateBoardScrollPosition(tab.boardUrl, index, offset)
+            tabListViewModel.updateBoardScrollPosition(tab.boardUrl, index, offset)
         },
         scrollBehavior = scrollBehavior,
         topBar = { viewModel, uiState, drawer, scrollBehavior ->
@@ -143,7 +144,7 @@ fun BoardScaffold(
             LaunchedEffect(uiState.resetScroll) {
                 if (uiState.resetScroll) {
                     listState.scrollToItem(0)
-                    tabsViewModel.updateBoardScrollPosition(uiState.boardInfo.url, 0, 0)
+                    tabListViewModel.updateBoardScrollPosition(uiState.boardInfo.url, 0, 0)
                     viewModel.consumeResetScroll()
                 }
             }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardViewModel.kt
@@ -19,9 +19,8 @@ import com.websarva.wings.android.slevo.ui.common.bookmark.SingleBookmarkViewMod
 import com.websarva.wings.android.slevo.ui.common.bookmark.SingleBookmarkViewModelFactory
 import com.websarva.wings.android.slevo.ui.util.parseServiceName
 import com.websarva.wings.android.slevo.data.model.THREAD_KEY_THRESHOLD
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
@@ -30,13 +29,13 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.runBlocking
 
 @RequiresApi(Build.VERSION_CODES.O)
-class BoardViewModel @AssistedInject constructor(
+@HiltViewModel
+class BoardViewModel @Inject constructor(
     private val repository: BoardRepository,
     private val threadCreateRepository: ThreadCreateRepository,
     private val imageUploadRepository: ImageUploadRepository,
     private val historyRepository: ThreadHistoryRepository,
     private val singleBookmarkViewModelFactory: SingleBookmarkViewModelFactory,
-    @Assisted("viewModelKey") val viewModelKey: String
 ) : BaseViewModel<BoardUiState>() {
 
     // 元のスレッドリストを保持
@@ -398,11 +397,4 @@ class BoardViewModel @AssistedInject constructor(
     }
 }
 
-
-@AssistedFactory
-interface BoardViewModelFactory {
-    fun create(
-        @Assisted("viewModelKey") viewModelKey: String
-    ): BoardViewModel
-}
 

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/AppNavGraph.kt
@@ -20,7 +20,7 @@ import com.websarva.wings.android.slevo.ui.about.AboutScreen
 import com.websarva.wings.android.slevo.ui.about.OpenSourceLicenseScreen
 import com.websarva.wings.android.slevo.ui.settings.SettingsViewModel
 import com.websarva.wings.android.slevo.ui.tabs.TabsScaffold
-import com.websarva.wings.android.slevo.ui.tabs.TabsViewModel
+import com.websarva.wings.android.slevo.ui.tabs.TabListViewModel
 import com.websarva.wings.android.slevo.ui.thread.screen.ThreadScaffold
 import com.websarva.wings.android.slevo.ui.viewer.ImageViewerScreen
 import kotlinx.serialization.Serializable
@@ -36,7 +36,7 @@ fun AppNavGraph(
     topBarState: TopAppBarState,
     settingsViewModel: SettingsViewModel,
     openDrawer: () -> Unit,
-    tabsViewModel: TabsViewModel,
+    tabListViewModel: TabListViewModel,
 ) {
     NavHost(
         navController = navController,
@@ -86,7 +86,7 @@ fun AppNavGraph(
                 boardRoute = boardRoute,
                 navController = navController,
                 openDrawer = openDrawer,
-                tabsViewModel = tabsViewModel,
+                tabListViewModel = tabListViewModel,
                 topBarState = topBarState
             )
         }
@@ -101,7 +101,7 @@ fun AppNavGraph(
             ThreadScaffold(
                 threadRoute = threadRoute,
                 navController = navController,
-                tabsViewModel = tabsViewModel,
+                tabListViewModel = tabListViewModel,
                 openDrawer = openDrawer,
                 topBarState = topBarState
             )
@@ -110,7 +110,7 @@ fun AppNavGraph(
         composable<AppRoute.Tabs> {
             TabsScaffold(
                 parentPadding = parentPadding,
-                tabsViewModel = tabsViewModel,
+                tabListViewModel = tabListViewModel,
                 navController = navController
             )
         }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/RouteScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/RouteScaffold.kt
@@ -35,7 +35,7 @@ import com.websarva.wings.android.slevo.ui.common.bookmark.BookmarkBottomSheet
 import com.websarva.wings.android.slevo.ui.common.bookmark.DeleteGroupDialog
 import com.websarva.wings.android.slevo.ui.common.bookmark.SingleBookmarkState
 import com.websarva.wings.android.slevo.ui.tabs.TabsBottomSheet
-import com.websarva.wings.android.slevo.ui.tabs.TabsViewModel
+import com.websarva.wings.android.slevo.ui.tabs.TabListViewModel
 import com.websarva.wings.android.slevo.ui.thread.state.ThreadUiState
 import com.websarva.wings.android.slevo.ui.thread.viewmodel.ThreadViewModel
 import kotlinx.coroutines.FlowPreview
@@ -48,12 +48,12 @@ import timber.log.Timber
 @Composable
 fun <TabInfo : Any, UiState : BaseUiState<UiState>, ViewModel : BaseViewModel<UiState>> RouteScaffold(
     route: AppRoute,
-    tabsViewModel: TabsViewModel,
+    tabListViewModel: TabListViewModel,
     navController: NavHostController,
     openDrawer: () -> Unit,
     openTabs: List<TabInfo>,
     currentRoutePredicate: (TabInfo) -> Boolean,
-    getViewModel: (TabInfo) -> ViewModel,
+    provideViewModel: @Composable (TabInfo) -> ViewModel,
     getKey: (TabInfo) -> Any,
     getScrollIndex: (TabInfo) -> Int,
     getScrollOffset: (TabInfo) -> Int,
@@ -106,7 +106,7 @@ fun <TabInfo : Any, UiState : BaseUiState<UiState>, ViewModel : BaseViewModel<Ui
             key = { page -> getKey(tabs[page]) }
         ) { page ->
             val tab = tabs[page]
-            val viewModel = getViewModel(tab)
+            val viewModel = provideViewModel(tab)
             val uiState by viewModel.uiState.collectAsState()
             // Board / Thread 用のブックマーク状態を統一的に取得
             val bookmarkState = (uiState as? BoardUiState)?.singleBookmarkState
@@ -241,7 +241,7 @@ fun <TabInfo : Any, UiState : BaseUiState<UiState>, ViewModel : BaseViewModel<Ui
                     }
                     TabsBottomSheet(
                         sheetState = tabListSheetState,
-                        tabsViewModel = tabsViewModel,
+                        tabListViewModel = tabListViewModel,
                         navController = navController,
                         onDismissRequest = { viewModel.closeTabListSheet() },
                         initialPage = initialPage,

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabListUiState.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabListUiState.kt
@@ -3,7 +3,7 @@ package com.websarva.wings.android.slevo.ui.tabs
 /**
  * タブ画面全体のUI状態を表すデータクラス
  */
-data class TabsUiState(
+data class TabListUiState(
     val openThreadTabs: List<ThreadTabInfo> = emptyList(),
     val openBoardTabs: List<BoardTabInfo> = emptyList(),
     val boardLoaded: Boolean = false,

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabScreenContent.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabScreenContent.kt
@@ -31,14 +31,14 @@ import com.websarva.wings.android.slevo.ui.util.parseThreadUrl
 @Composable
 fun TabScreenContent(
     modifier: Modifier = Modifier,
-    tabsViewModel: TabsViewModel,
+    tabListViewModel: TabListViewModel,
     navController: NavHostController,
     closeDrawer: () -> Unit,
     initialPage: Int = 0,
     onPageChanged: (Int) -> Unit = {}
 ) {
     var showUrlDialog by remember { mutableStateOf(false) }
-    val uiState by tabsViewModel.uiState.collectAsState()
+    val uiState by tabListViewModel.uiState.collectAsState()
 
     Scaffold(
         modifier = modifier,
@@ -59,7 +59,7 @@ fun TabScreenContent(
         } else {
             TabsPagerContent(
                 modifier = Modifier.padding(innerPadding),
-                tabsViewModel = tabsViewModel,
+                tabListViewModel = tabListViewModel,
                 navController = navController,
                 closeDrawer = closeDrawer,
                 initialPage = initialPage,

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabsBottomSheet.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabsBottomSheet.kt
@@ -16,7 +16,7 @@ import androidx.navigation.NavHostController
 fun TabsBottomSheet(
     modifier: Modifier = Modifier,
     sheetState: SheetState,
-    tabsViewModel: TabsViewModel,
+    tabListViewModel: TabListViewModel,
     navController: NavHostController,
     onDismissRequest: () -> Unit,
     initialPage: Int = 0,
@@ -28,7 +28,7 @@ fun TabsBottomSheet(
     ) {
         TabScreenContent(
             modifier = Modifier.fillMaxHeight(0.8f),
-            tabsViewModel = tabsViewModel,
+            tabListViewModel = tabListViewModel,
             navController = navController,
             closeDrawer = onDismissRequest, // ボトムシートを閉じる
             initialPage = initialPage

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabsPagerContent.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabsPagerContent.kt
@@ -24,13 +24,13 @@ import kotlinx.coroutines.launch
 @Composable
 fun TabsPagerContent(
     modifier: Modifier = Modifier,
-    tabsViewModel: TabsViewModel,
+    tabListViewModel: TabListViewModel,
     navController: NavHostController,
     closeDrawer: () -> Unit,
     initialPage: Int = 0,
     onPageChanged: (Int) -> Unit = {}
 ) {
-    val uiState by tabsViewModel.uiState.collectAsState()
+    val uiState by tabListViewModel.uiState.collectAsState()
 
     val pagerState = rememberPagerState(initialPage = initialPage, pageCount = { 2 })
     val scope = rememberCoroutineScope()
@@ -56,19 +56,19 @@ fun TabsPagerContent(
             when (page) {
                 0 -> OpenBoardsList(
                     openTabs = uiState.openBoardTabs,
-                    onCloseClick = { tabsViewModel.closeBoardTab(it) },
+                    onCloseClick = { tabListViewModel.closeBoardTab(it) },
                     navController = navController,
                     closeDrawer = closeDrawer
                 )
                 else -> OpenThreadsList(
                     openTabs = uiState.openThreadTabs,
-                    onCloseClick = { tabsViewModel.closeThreadTab(it) },
+                    onCloseClick = { tabListViewModel.closeThreadTab(it) },
                     navController = navController,
                     closeDrawer = closeDrawer,
                     isRefreshing = uiState.isRefreshing,
-                    onRefresh = { tabsViewModel.refreshOpenThreads() },
+                    onRefresh = { tabListViewModel.refreshOpenThreads() },
                     newResCounts = uiState.newResCounts,
-                    onItemClick = { tabsViewModel.clearNewResCount(it.key, it.boardUrl) }
+                    onItemClick = { tabListViewModel.clearNewResCount(it.key, it.boardUrl) }
                 )
             }
         }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabsScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabsScaffold.kt
@@ -14,16 +14,16 @@ import androidx.navigation.NavHostController
 @Composable
 fun TabsScaffold(
     parentPadding: PaddingValues,
-    tabsViewModel: TabsViewModel,
+    tabListViewModel: TabListViewModel,
     navController: NavHostController
 ) {
-    val lastPage by tabsViewModel.lastSelectedPage.collectAsState()
+    val lastPage by tabListViewModel.lastSelectedPage.collectAsState()
     TabScreenContent(
         modifier = Modifier.padding(parentPadding),
-        tabsViewModel = tabsViewModel,
+        tabListViewModel = tabListViewModel,
         navController = navController,
         closeDrawer = {}, // Scaffoldの場合は何もしない
         initialPage = lastPage,
-        onPageChanged = { tabsViewModel.setLastSelectedPage(it) }
+        onPageChanged = { tabListViewModel.setLastSelectedPage(it) }
     )
 }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/viewmodel/ThreadViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/viewmodel/ThreadViewModel.kt
@@ -27,9 +27,8 @@ import com.websarva.wings.android.slevo.ui.thread.state.ReplyInfo
 import com.websarva.wings.android.slevo.ui.thread.state.ThreadSortType
 import com.websarva.wings.android.slevo.ui.thread.state.ThreadUiState
 import com.websarva.wings.android.slevo.data.util.ThreadListParser.calculateThreadDate
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -50,7 +49,8 @@ private data class PendingPost(
     val email: String,
 )
 
-class ThreadViewModel @AssistedInject constructor(
+@HiltViewModel
+class ThreadViewModel @Inject constructor(
     private val datRepository: DatRepository,
     private val boardRepository: BoardRepository,
     private val historyRepository: ThreadHistoryRepository,
@@ -61,7 +61,6 @@ class ThreadViewModel @AssistedInject constructor(
     private val tabsRepository: TabsRepository,
     internal val postRepository: PostRepository,
     internal val imageUploadRepository: ImageUploadRepository,
-    @Assisted @Suppress("unused") val viewModelKey: String,
 ) : BaseViewModel<ThreadUiState>() {
 
     override val _uiState = MutableStateFlow(ThreadUiState())
@@ -660,7 +659,3 @@ class ThreadViewModel @AssistedInject constructor(
     }
 }
 
-@AssistedFactory
-interface ThreadViewModelFactory {
-    fun create(viewModelKey: String): ThreadViewModel
-}


### PR DESCRIPTION
## Summary
- split TabsViewModel into TabListViewModel responsible for persisting open tabs
- use screen-scoped BoardViewModel and ThreadViewModel via hiltViewModel
- clean up obsolete caches and release logic

## Testing
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_68c0ec3cb3c4833284984490fe6e5ee2