### PR TITLE
fix: retain tab position on board and thread

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
@@ -25,6 +25,7 @@ import androidx.navigation.NavHostController
 import com.websarva.wings.android.slevo.data.model.BoardInfo
 import com.websarva.wings.android.slevo.ui.navigation.AppRoute
 import com.websarva.wings.android.slevo.ui.navigation.RouteScaffold
+import com.websarva.wings.android.slevo.ui.navigation.RoutePagerViewModel
 import com.websarva.wings.android.slevo.ui.tabs.BoardTabInfo
 import com.websarva.wings.android.slevo.ui.tabs.TabListViewModel
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -48,6 +49,8 @@ fun BoardScaffold(
     topBarState: TopAppBarState
 ) {
     val tabsUiState by tabListViewModel.uiState.collectAsState()
+    val pagerViewModel: RoutePagerViewModel = hiltViewModel()
+    val pagerUiState by pagerViewModel.uiState.collectAsState()
     val context = LocalContext.current
 
     LaunchedEffect(boardRoute) {
@@ -97,6 +100,8 @@ fun BoardScaffold(
             tabListViewModel.updateBoardScrollPosition(tab.boardUrl, index, offset)
         },
         scrollBehavior = scrollBehavior,
+        currentPage = pagerUiState.currentPage,
+        onPageChange = { pagerViewModel.setCurrentPage(it) },
         topBar = { viewModel, uiState, drawer, scrollBehavior ->
             val bookmarkState = uiState.singleBookmarkState
             val bookmarkIconColor =

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/RoutePagerViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/RoutePagerViewModel.kt
@@ -1,0 +1,30 @@
+package com.websarva.wings.android.slevo.ui.navigation
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import javax.inject.Inject
+
+/**
+ * 画面全体で利用するページインデックスを保持する ViewModel。
+ * 初期値は -1 とし、未設定であることを示す。
+ */
+@HiltViewModel
+class RoutePagerViewModel @Inject constructor() : ViewModel() {
+    private val _uiState = MutableStateFlow(RoutePagerUiState())
+    val uiState: StateFlow<RoutePagerUiState> = _uiState.asStateFlow()
+
+    fun setCurrentPage(page: Int) {
+        _uiState.update { it.copy(currentPage = page) }
+    }
+}
+
+/**
+ * Pager 用の UiState。currentPage が -1 の場合は未設定として扱う。
+ */
+data class RoutePagerUiState(
+    val currentPage: Int = -1
+)

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -23,6 +23,7 @@ import com.websarva.wings.android.slevo.ui.common.PostDialog
 import com.websarva.wings.android.slevo.ui.common.PostingDialog
 import com.websarva.wings.android.slevo.ui.navigation.AppRoute
 import com.websarva.wings.android.slevo.ui.navigation.RouteScaffold
+import com.websarva.wings.android.slevo.ui.navigation.RoutePagerViewModel
 import com.websarva.wings.android.slevo.ui.tabs.TabListViewModel
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.websarva.wings.android.slevo.ui.thread.components.ThreadBottomBar
@@ -48,6 +49,8 @@ fun ThreadScaffold(
     topBarState: TopAppBarState,
 ) {
     val tabsUiState by tabListViewModel.uiState.collectAsState()
+    val pagerViewModel: RoutePagerViewModel = hiltViewModel()
+    val pagerUiState by pagerViewModel.uiState.collectAsState()
     val context = LocalContext.current
 
     val viewModel: ThreadViewModel = hiltViewModel(key = threadRoute.threadKey + threadRoute.boardUrl)
@@ -98,7 +101,8 @@ fun ThreadScaffold(
             viewModel.updateThreadScrollPosition(tab.key, tab.boardUrl, index, offset)
         },
         scrollBehavior = scrollBehavior,
-        bottomBarScrollBehavior = { listState -> rememberBottomBarShowOnBottomBehavior(listState) },
+        currentPage = pagerUiState.currentPage,
+        onPageChange = { pagerViewModel.setCurrentPage(it) },
         topBar = { viewModel, uiState, _, scrollBehavior ->
             if (uiState.isSearchMode) {
                 SearchTopAppBar(
@@ -172,6 +176,7 @@ fun ThreadScaffold(
                 onReplyToPost = { viewModel.showReplyDialog(it) }
             )
         },
+        bottomBarScrollBehavior = { listState -> rememberBottomBarShowOnBottomBehavior(listState) },
         optionalSheetContent = { viewModel, uiState ->
             val postUiState by viewModel.postUiState.collectAsState()
             val threadInfoSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)


### PR DESCRIPTION
## Summary
- keep pager index in RoutePagerViewModel to avoid resetting tabs after navigation
- integrate pager state with board and thread scaffolds via RouteScaffold

## Testing
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_68c110e4f8dc8332908d64d61b6f00b4