### PR TITLE
fix: retain selected tab page

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardPagerViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardPagerViewModel.kt
@@ -1,0 +1,18 @@
+package com.websarva.wings.android.slevo.ui.board
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class BoardPagerViewModel @Inject constructor() : ViewModel() {
+    private val _currentPage = MutableStateFlow(-1)
+    val currentPage: StateFlow<Int> = _currentPage.asStateFlow()
+
+    fun setCurrentPage(page: Int) {
+        _currentPage.value = page
+    }
+}

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -48,6 +49,8 @@ fun BoardScaffold(
 ) {
     val tabsUiState by tabsViewModel.uiState.collectAsState()
     val context = LocalContext.current
+    val pagerViewModel: BoardPagerViewModel = hiltViewModel()
+    val currentPage by pagerViewModel.currentPage.collectAsState()
 
     LaunchedEffect(boardRoute) {
         val info = tabsViewModel.resolveBoardInfo(
@@ -95,6 +98,8 @@ fun BoardScaffold(
         updateScrollPosition = { _, tab, index, offset ->
             tabsViewModel.updateBoardScrollPosition(tab.boardUrl, index, offset)
         },
+        currentPage = currentPage,
+        onPageChange = { pagerViewModel.setCurrentPage(it) },
         scrollBehavior = scrollBehavior,
         topBar = { viewModel, uiState, drawer, scrollBehavior ->
             val bookmarkState = uiState.singleBookmarkState

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/RouteScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/RouteScaffold.kt
@@ -59,6 +59,8 @@ fun <TabInfo : Any, UiState : BaseUiState<UiState>, ViewModel : BaseViewModel<Ui
     getScrollOffset: (TabInfo) -> Int,
     initializeViewModel: (viewModel: ViewModel, tabInfo: TabInfo) -> Unit,
     updateScrollPosition: (viewModel: ViewModel, tab: TabInfo, index: Int, offset: Int) -> Unit,
+    currentPage: Int,
+    onPageChange: (Int) -> Unit,
     topBar: @Composable (viewModel: ViewModel, uiState: UiState, openDrawer: () -> Unit, scrollBehavior: TopAppBarScrollBehavior) -> Unit,
     bottomBar: @Composable (viewModel: ViewModel, uiState: UiState, scrollBehavior: BottomAppBarScrollBehavior?) -> Unit,
     content: @Composable (viewModel: ViewModel, uiState: UiState, listState: LazyListState, modifier: Modifier, navController: NavHostController) -> Unit,
@@ -82,8 +84,12 @@ fun <TabInfo : Any, UiState : BaseUiState<UiState>, ViewModel : BaseViewModel<Ui
 
     if (currentTabInfo != null) {
         // 初期ページの決定。routeやタブ数が変わったら再計算される。
-        val initialPage = remember(route, tabs.size) {
-            tabs.indexOfFirst(currentRoutePredicate).coerceAtLeast(0)
+        val initialPage = remember(route, tabs.size, currentPage) {
+            if (currentPage >= 0) {
+                currentPage.coerceIn(0, tabs.size - 1)
+            } else {
+                tabs.indexOfFirst(currentRoutePredicate).coerceAtLeast(0)
+            }
         }
 
         // Pagerの状態。ページ数はタブ数に応じて動的に提供される。
@@ -95,6 +101,10 @@ fun <TabInfo : Any, UiState : BaseUiState<UiState>, ViewModel : BaseViewModel<Ui
             if (pagerState.currentPage != initialPage) {
                 pagerState.scrollToPage(initialPage)
             }
+        }
+
+        LaunchedEffect(pagerState.currentPage) {
+            onPageChange(pagerState.currentPage)
         }
 
         // 共通で使うボトムシートの状態

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -49,6 +50,8 @@ fun ThreadScaffold(
 ) {
     val tabsUiState by tabsViewModel.uiState.collectAsState()
     val context = LocalContext.current
+    val pagerViewModel: ThreadPagerViewModel = hiltViewModel()
+    val currentPage by pagerViewModel.currentPage.collectAsState()
 
     val routeThreadId = parseBoardUrl(threadRoute.boardUrl)?.let { (host, board) ->
         ThreadId.of(host, board, threadRoute.threadKey)
@@ -100,6 +103,8 @@ fun ThreadScaffold(
         updateScrollPosition = { viewModel, tab, index, offset ->
             viewModel.updateThreadScrollPosition(tab.id, index, offset)
         },
+        currentPage = currentPage,
+        onPageChange = { pagerViewModel.setCurrentPage(it) },
         scrollBehavior = scrollBehavior,
         bottomBarScrollBehavior = { listState -> rememberBottomBarShowOnBottomBehavior(listState) },
         topBar = { viewModel, uiState, _, scrollBehavior ->

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/viewmodel/ThreadPagerViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/viewmodel/ThreadPagerViewModel.kt
@@ -1,0 +1,18 @@
+package com.websarva.wings.android.slevo.ui.thread.viewmodel
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class ThreadPagerViewModel @Inject constructor() : ViewModel() {
+    private val _currentPage = MutableStateFlow(-1)
+    val currentPage: StateFlow<Int> = _currentPage.asStateFlow()
+
+    fun setCurrentPage(page: Int) {
+        _currentPage.value = page
+    }
+}


### PR DESCRIPTION
## Summary
- keep tab pager position when returning to board and thread screens
- add pager view models to remember current page

## Testing
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_68c11a5c383c83328b7538a3147645e3