### PR TITLE
refactor: merge migrations into version 3

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/AppDatabase.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/AppDatabase.kt
@@ -58,7 +58,7 @@ import com.websarva.wings.android.slevo.data.datasource.local.entity.history.Pos
         BoardFetchMetaEntity::class,
         PostHistoryEntity::class
     ],
-    version = 4,
+    version = 3,
     exportSchema = true
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -105,14 +105,15 @@ abstract class AppDatabase : RoomDatabase() {
                         "boardName TEXT NOT NULL, " +
                         "title TEXT NOT NULL, " +
                         "resCount INTEGER NOT NULL, " +
-                            "prevResCount INTEGER NOT NULL DEFAULT 0, " +
-                            "lastReadResNo INTEGER NOT NULL DEFAULT 0, " +
+                        "prevResCount INTEGER NOT NULL DEFAULT 0, " +
+                        "lastReadResNo INTEGER NOT NULL DEFAULT 0, " +
                         "firstNewResNo INTEGER, " +
                         "sortOrder INTEGER NOT NULL, " +
                         "firstVisibleItemIndex INTEGER NOT NULL, " +
                         "firstVisibleItemScrollOffset INTEGER NOT NULL, " +
                         "PRIMARY KEY(threadId))"
                 )
+
                 database.execSQL("DROP TABLE IF EXISTS thread_history_accesses")
                 database.execSQL("DROP TABLE IF EXISTS thread_histories")
                 database.execSQL(
@@ -123,71 +124,25 @@ abstract class AppDatabase : RoomDatabase() {
                         "boardId INTEGER NOT NULL, " +
                         "boardName TEXT NOT NULL, " +
                         "title TEXT NOT NULL, " +
-                        "resCount INTEGER NOT NULL)"
-                )
-                database.execSQL(
-                    "CREATE TABLE IF NOT EXISTS thread_history_accesses (" +
-                        "threadHistoryId INTEGER NOT NULL, " +
-                        "accessedAt INTEGER NOT NULL, " +
-                        "PRIMARY KEY(threadHistoryId, accessedAt))"
-                )
-            }
-        }
-
-        val MIGRATION_3_4 = object : androidx.room.migration.Migration(3, 4) {
-            override fun migrate(database: androidx.sqlite.db.SupportSQLiteDatabase) {
-                database.execSQL(
-                    "ALTER TABLE thread_histories ADD COLUMN prevResCount INTEGER NOT NULL DEFAULT 0"
-                )
-                database.execSQL(
-                    "ALTER TABLE thread_histories ADD COLUMN lastReadResNo INTEGER NOT NULL DEFAULT 0"
-                )
-                database.execSQL(
-                    "ALTER TABLE thread_histories ADD COLUMN firstNewResNo INTEGER"
+                        "resCount INTEGER NOT NULL, " +
+                        "prevResCount INTEGER NOT NULL DEFAULT 0, " +
+                        "lastReadResNo INTEGER NOT NULL DEFAULT 0, " +
+                        "firstNewResNo INTEGER" +
+                        ")"
                 )
                 database.execSQL(
                     "CREATE UNIQUE INDEX IF NOT EXISTS index_thread_histories_threadId ON thread_histories(threadId)"
                 )
                 database.execSQL(
-                    "CREATE TABLE IF NOT EXISTS thread_history_accesses_new (" +
-                            "id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
-                            "threadHistoryId INTEGER NOT NULL, " +
-                            "accessedAt INTEGER NOT NULL, " +
-                            "FOREIGN KEY(threadHistoryId) REFERENCES thread_histories(id) ON DELETE CASCADE)"
+                    "CREATE TABLE IF NOT EXISTS thread_history_accesses (" +
+                        "id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+                        "threadHistoryId INTEGER NOT NULL, " +
+                        "accessedAt INTEGER NOT NULL, " +
+                        "FOREIGN KEY(threadHistoryId) REFERENCES thread_histories(id) ON DELETE CASCADE)"
                 )
-                database.execSQL(
-                    "INSERT INTO thread_history_accesses_new (threadHistoryId, accessedAt) " +
-                            "SELECT threadHistoryId, accessedAt FROM thread_history_accesses"
-                )
-                database.execSQL("DROP TABLE thread_history_accesses")
-                database.execSQL("ALTER TABLE thread_history_accesses_new RENAME TO thread_history_accesses")
                 database.execSQL(
                     "CREATE INDEX IF NOT EXISTS index_thread_history_accesses_threadHistoryId ON thread_history_accesses(threadHistoryId)"
                 )
-                database.execSQL(
-                    "CREATE TABLE IF NOT EXISTS open_thread_tabs_new (" +
-                            "threadId TEXT NOT NULL, " +
-                            "boardUrl TEXT NOT NULL, " +
-                            "boardId INTEGER NOT NULL, " +
-                            "boardName TEXT NOT NULL, " +
-                            "title TEXT NOT NULL, " +
-                            "resCount INTEGER NOT NULL, " +
-                            "prevResCount INTEGER NOT NULL DEFAULT 0, " +
-                            "lastReadResNo INTEGER NOT NULL DEFAULT 0, " +
-                            "firstNewResNo INTEGER, " +
-                            "sortOrder INTEGER NOT NULL, " +
-                            "firstVisibleItemIndex INTEGER NOT NULL, " +
-                            "firstVisibleItemScrollOffset INTEGER NOT NULL, " +
-                            "PRIMARY KEY(threadId))"
-                )
-                database.execSQL(
-                    "INSERT INTO open_thread_tabs_new (" +
-                            "threadId, boardUrl, boardId, boardName, title, resCount, prevResCount, lastReadResNo, firstNewResNo, sortOrder, firstVisibleItemIndex, firstVisibleItemScrollOffset" +
-                            ") SELECT " +
-                            "threadId, boardUrl, boardId, boardName, title, resCount, prevResCount, lastReadResNo, firstNewResNo, sortOrder, firstVisibleItemIndex, firstVisibleItemScrollOffset FROM open_thread_tabs"
-                )
-                database.execSQL("DROP TABLE open_thread_tabs")
-                database.execSQL("ALTER TABLE open_thread_tabs_new RENAME TO open_thread_tabs")
             }
         }
     }

--- a/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/AppDatabase.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/AppDatabase.kt
@@ -96,9 +96,8 @@ abstract class AppDatabase : RoomDatabase() {
 
         val MIGRATION_2_3 = object : androidx.room.migration.Migration(2, 3) {
             override fun migrate(database: androidx.sqlite.db.SupportSQLiteDatabase) {
-                database.execSQL("DROP TABLE IF EXISTS open_thread_tabs")
                 database.execSQL(
-                    "CREATE TABLE IF NOT EXISTS open_thread_tabs (" +
+                    "CREATE TABLE IF NOT EXISTS open_thread_tabs_new (" +
                         "threadId TEXT NOT NULL, " +
                         "boardUrl TEXT NOT NULL, " +
                         "boardId INTEGER NOT NULL, " +
@@ -113,11 +112,21 @@ abstract class AppDatabase : RoomDatabase() {
                         "firstVisibleItemScrollOffset INTEGER NOT NULL, " +
                         "PRIMARY KEY(threadId))"
                 )
-
-                database.execSQL("DROP TABLE IF EXISTS thread_history_accesses")
-                database.execSQL("DROP TABLE IF EXISTS thread_histories")
                 database.execSQL(
-                    "CREATE TABLE IF NOT EXISTS thread_histories (" +
+                    "INSERT INTO open_thread_tabs_new (" +
+                        "threadId, boardUrl, boardId, boardName, title, resCount, " +
+                        "prevResCount, lastReadResNo, firstNewResNo, sortOrder, " +
+                        "firstVisibleItemIndex, firstVisibleItemScrollOffset" +
+                        ") SELECT " +
+                        "threadId, boardUrl, boardId, boardName, title, resCount, " +
+                        "prevResCount, lastReadResNo, firstNewResNo, sortOrder, " +
+                        "firstVisibleItemIndex, firstVisibleItemScrollOffset FROM open_thread_tabs"
+                )
+                database.execSQL("DROP TABLE open_thread_tabs")
+                database.execSQL("ALTER TABLE open_thread_tabs_new RENAME TO open_thread_tabs")
+
+                database.execSQL(
+                    "CREATE TABLE IF NOT EXISTS thread_histories_new (" +
                         "id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
                         "threadId TEXT NOT NULL, " +
                         "boardUrl TEXT NOT NULL, " +
@@ -131,15 +140,30 @@ abstract class AppDatabase : RoomDatabase() {
                         ")"
                 )
                 database.execSQL(
+                    "INSERT INTO thread_histories_new (" +
+                        "id, threadId, boardUrl, boardId, boardName, title, resCount" +
+                        ") SELECT " +
+                        "id, threadId, boardUrl, boardId, boardName, title, resCount FROM thread_histories"
+                )
+                database.execSQL("DROP TABLE thread_histories")
+                database.execSQL("ALTER TABLE thread_histories_new RENAME TO thread_histories")
+                database.execSQL(
                     "CREATE UNIQUE INDEX IF NOT EXISTS index_thread_histories_threadId ON thread_histories(threadId)"
                 )
+
                 database.execSQL(
-                    "CREATE TABLE IF NOT EXISTS thread_history_accesses (" +
+                    "CREATE TABLE IF NOT EXISTS thread_history_accesses_new (" +
                         "id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
                         "threadHistoryId INTEGER NOT NULL, " +
                         "accessedAt INTEGER NOT NULL, " +
                         "FOREIGN KEY(threadHistoryId) REFERENCES thread_histories(id) ON DELETE CASCADE)"
                 )
+                database.execSQL(
+                    "INSERT INTO thread_history_accesses_new (threadHistoryId, accessedAt) " +
+                        "SELECT threadHistoryId, accessedAt FROM thread_history_accesses"
+                )
+                database.execSQL("DROP TABLE thread_history_accesses")
+                database.execSQL("ALTER TABLE thread_history_accesses_new RENAME TO thread_history_accesses")
                 database.execSQL(
                     "CREATE INDEX IF NOT EXISTS index_thread_history_accesses_threadHistoryId ON thread_history_accesses(threadHistoryId)"
                 )

--- a/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/AppDatabase.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/AppDatabase.kt
@@ -118,7 +118,8 @@ abstract class AppDatabase : RoomDatabase() {
                         "prevResCount, lastReadResNo, firstNewResNo, sortOrder, " +
                         "firstVisibleItemIndex, firstVisibleItemScrollOffset" +
                         ") SELECT " +
-                        "threadId, boardUrl, boardId, boardName, title, resCount, " +
+                        "trim(replace(replace(boardUrl, 'https://', ''), 'http://', ''), '/') || '/' || threadKey, " +
+                        "boardUrl, boardId, boardName, title, resCount, " +
                         "prevResCount, lastReadResNo, firstNewResNo, sortOrder, " +
                         "firstVisibleItemIndex, firstVisibleItemScrollOffset FROM open_thread_tabs"
                 )
@@ -143,7 +144,8 @@ abstract class AppDatabase : RoomDatabase() {
                     "INSERT INTO thread_histories_new (" +
                         "id, threadId, boardUrl, boardId, boardName, title, resCount" +
                         ") SELECT " +
-                        "id, threadId, boardUrl, boardId, boardName, title, resCount FROM thread_histories"
+                        "id, trim(replace(replace(boardUrl, 'https://', ''), 'http://', ''), '/') || '/' || threadKey, " +
+                        "boardUrl, boardId, boardName, title, resCount FROM thread_histories"
                 )
                 database.execSQL("DROP TABLE thread_histories")
                 database.execSQL("ALTER TABLE thread_histories_new RENAME TO thread_histories")

--- a/app/src/main/java/com/websarva/wings/android/slevo/di/DatabaseModule.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/di/DatabaseModule.kt
@@ -57,8 +57,7 @@ object DatabaseModule {
         )
             .addMigrations(
                 AppDatabase.MIGRATION_1_2,
-                AppDatabase.MIGRATION_2_3,
-                AppDatabase.MIGRATION_3_4
+                AppDatabase.MIGRATION_2_3
             )
             .addCallback(callback)
             .apply {


### PR DESCRIPTION
## Summary
- set Room database version to 3
- merge previous 3-4 changes into MIGRATION_2_3 and remove MIGRATION_3_4
- update database module to register new migrations

## Testing
- `./gradlew :app:testDebugUnitTest`
- `./gradlew :app:lintDebug` *(fails: MainActivity must extend android.app.Activity)*
- `./gradlew :app:assembleDebug`


------
https://chatgpt.com/codex/tasks/task_e_68c13b864bd883329d7f138f5e11d396