### PR TITLE
feat: add more menu to thread toolbar

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/more/MoreBottomSheet.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/more/MoreBottomSheet.kt
@@ -1,0 +1,97 @@
+package com.websarva.wings.android.slevo.ui.more
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.List
+import androidx.compose.material.icons.filled.History
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.websarva.wings.android.slevo.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MoreBottomSheet(
+    sheetState: SheetState,
+    onDismissRequest: () -> Unit,
+    onBookmarkClick: () -> Unit,
+    onBoardListClick: () -> Unit,
+    onHistoryClick: () -> Unit,
+    onSettingsClick: () -> Unit,
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        sheetState = sheetState,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 24.dp),
+            horizontalArrangement = Arrangement.SpaceEvenly
+        ) {
+            MoreItem(
+                icon = Icons.Filled.Star,
+                label = stringResource(R.string.bookmark),
+                onClick = onBookmarkClick
+            )
+            MoreItem(
+                icon = Icons.AutoMirrored.Filled.List,
+                label = stringResource(R.string.boardList),
+                onClick = onBoardListClick
+            )
+            MoreItem(
+                icon = Icons.Filled.History,
+                label = stringResource(R.string.history),
+                onClick = onHistoryClick
+            )
+            MoreItem(
+                icon = Icons.Filled.Settings,
+                label = stringResource(R.string.settings),
+                onClick = onSettingsClick
+            )
+        }
+    }
+}
+
+@Composable
+private fun MoreItem(icon: androidx.compose.ui.graphics.vector.ImageVector, label: String, onClick: () -> Unit) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.clickable(onClick = onClick)
+    ) {
+        Icon(icon, contentDescription = label)
+        Text(
+            text = label,
+            modifier = Modifier.padding(top = 4.dp)
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview(showBackground = true)
+@Composable
+fun MoreBottomSheetPreview() {
+    MoreBottomSheet(
+        sheetState = androidx.compose.material3.rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        onDismissRequest = {},
+        onBookmarkClick = {},
+        onBoardListClick = {},
+        onHistoryClick = {},
+        onSettingsClick = {},
+    )
+}

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/components/ThreadBottomBar.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/components/ThreadBottomBar.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.icons.filled.AccountTree
 import androidx.compose.material.icons.filled.Create
 import androidx.compose.material.icons.filled.CropSquare
 import androidx.compose.material.icons.filled.FormatListNumbered
+import androidx.compose.material.icons.filled.MoreHoriz
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Star
@@ -54,6 +55,7 @@ fun ThreadBottomBar(
     onSearchClick: () -> Unit,
     onBookmarkClick: () -> Unit,
     onThreadInfoClick: () -> Unit,
+    onMoreClick: () -> Unit,
     scrollBehavior: BottomAppBarScrollBehavior? = null,
 ) {
     FlexibleBottomAppBar(
@@ -147,6 +149,12 @@ fun ThreadBottomBar(
                         contentDescription = stringResource(R.string.post)
                     )
                 }
+                IconButton(onClick = onMoreClick) {
+                    Icon(
+                        imageVector = Icons.Filled.MoreHoriz,
+                        contentDescription = stringResource(R.string.more)
+                    )
+                }
             }
         }
     }
@@ -173,7 +181,8 @@ fun ThreadBottomBarPreview() {
         onRefreshClick = {},
         onSearchClick = {},
         onBookmarkClick = {},
-        onThreadInfoClick = {}
+        onThreadInfoClick = {},
+        onMoreClick = {}
     )
 }
 

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -30,6 +30,7 @@ import com.websarva.wings.android.slevo.ui.thread.components.ThreadInfoBottomShe
 import com.websarva.wings.android.slevo.ui.thread.dialog.ResponseWebViewDialog
 import com.websarva.wings.android.slevo.ui.thread.state.ThreadSortType
 import com.websarva.wings.android.slevo.ui.thread.viewmodel.*
+import com.websarva.wings.android.slevo.ui.more.MoreBottomSheet
 import com.websarva.wings.android.slevo.ui.topbar.SearchTopAppBar
 import com.websarva.wings.android.slevo.ui.util.rememberBottomBarShowOnBottomBehavior
 import com.websarva.wings.android.slevo.ui.util.isThreeButtonNavigation
@@ -135,6 +136,7 @@ fun ThreadScaffold(
                 onSearchClick = { viewModel.startSearch() },
                 onBookmarkClick = { viewModel.openBookmarkSheet() },
                 onThreadInfoClick = { viewModel.openThreadInfoSheet() },
+                onMoreClick = { viewModel.openMoreSheet() },
                 scrollBehavior = barScrollBehavior,
             )
         },
@@ -180,6 +182,7 @@ fun ThreadScaffold(
         optionalSheetContent = { viewModel, uiState ->
             val postUiState by viewModel.postUiState.collectAsState()
             val threadInfoSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+            val moreSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
             if (uiState.showThreadInfoSheet) {
                 val threadUrl = parseBoardUrl(uiState.boardInfo.url)?.let { (host, boardKey) ->
                     "https://$host/test/read.cgi/$boardKey/${uiState.threadInfo.key}/"
@@ -189,6 +192,29 @@ fun ThreadScaffold(
                     onDismissRequest = { viewModel.closeThreadInfoSheet() },
                     threadInfo = uiState.threadInfo,
                     threadUrl = threadUrl,
+                )
+            }
+
+            if (uiState.showMoreSheet) {
+                MoreBottomSheet(
+                    sheetState = moreSheetState,
+                    onDismissRequest = { viewModel.closeMoreSheet() },
+                    onBookmarkClick = {
+                        viewModel.closeMoreSheet()
+                        navController.navigate(AppRoute.BookmarkList)
+                    },
+                    onBoardListClick = {
+                        viewModel.closeMoreSheet()
+                        navController.navigate(AppRoute.ServiceList)
+                    },
+                    onHistoryClick = {
+                        viewModel.closeMoreSheet()
+                        navController.navigate(AppRoute.HistoryList)
+                    },
+                    onSettingsClick = {
+                        viewModel.closeMoreSheet()
+                        navController.navigate(AppRoute.SettingsHome)
+                    }
                 )
             }
 

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/state/ThreadUiState.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/state/ThreadUiState.kt
@@ -19,6 +19,7 @@ data class ThreadUiState(
     override val isLoading: Boolean = false,
     override val showTabListSheet: Boolean = false,
     val showThreadInfoSheet: Boolean = false,
+    val showMoreSheet: Boolean = false,
     val myPostNumbers: Set<Int> = emptySet(),
     // UI描画用の派生情報（ViewModelで算出）
     val idCountMap: Map<String, Int> = emptyMap(),

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/viewmodel/ThreadViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/viewmodel/ThreadViewModel.kt
@@ -574,6 +574,14 @@ class ThreadViewModel @AssistedInject constructor(
         _uiState.update { it.copy(showThreadInfoSheet = false) }
     }
 
+    fun openMoreSheet() {
+        _uiState.update { it.copy(showMoreSheet = true) }
+    }
+
+    fun closeMoreSheet() {
+        _uiState.update { it.copy(showMoreSheet = false) }
+    }
+
     // 書き込み画面を表示
     fun startSearch() {
         _uiState.update { it.copy(isSearchMode = true) }


### PR DESCRIPTION
## Summary
- add more button to thread toolbar
- show bottom sheet with bookmark, board list, history and settings links

## Testing
- `./gradlew :app:testDebugUnitTest` *(passed)*
- `./gradlew :app:lintDebug` *(failed: MainActivity must extend android.app.Activity)*

------
https://chatgpt.com/codex/tasks/task_e_68c17b437d3883329cb50fd251438f01