### PR TITLE
Add external browser button to thread info sheet

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/components/ThreadInfoBottomSheet.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/components/ThreadInfoBottomSheet.kt
@@ -179,14 +179,14 @@ private fun ThreadInfoBottomSheetContent(
                 onClick = onBoardClick,
             )
             LabeledIconButton(
-                icon = Icons.Filled.OpenInBrowser,
-                label = stringResource(R.string.open),
-                onClick = onOpenBrowserClick,
-            )
-            LabeledIconButton(
                 icon = Icons.Filled.ContentCopy,
                 label = stringResource(R.string.copy),
                 onClick = onCopyClick,
+            )
+            LabeledIconButton(
+                icon = Icons.Filled.OpenInBrowser,
+                label = stringResource(R.string.open_in_external_browser),
+                onClick = onOpenBrowserClick,
             )
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,4 +91,5 @@
     <string name="title_and_url">タイトル + URL</string>
     <string name="res_number_label">レス番号</string>
     <string name="header_and_body">ヘッダー + 本文</string>
+    <string name="open_in_external_browser">外部ブラウザで開く</string>
 </resources>


### PR DESCRIPTION
## Summary
- add button to open the thread in an external browser from the info sheet

## Testing
- `./gradlew :app:testDebugUnitTest`
- `./gradlew :app:lintDebug` *(fails: Call requires API level 26 in SettingsCookieViewModel.kt)*

------
https://chatgpt.com/codex/tasks/task_e_68c4163fa0c88332ba097d68a1016e6a