### PR TITLE
feat: add thread auto scroll control

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/components/ThreadBottomBar.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/components/ThreadBottomBar.kt
@@ -16,6 +16,8 @@ import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.outlined.StarOutline
 import androidx.compose.material3.BottomAppBarScrollBehavior
 import androidx.compose.material3.Card
@@ -56,6 +58,7 @@ fun ThreadBottomBar(
     onBookmarkClick: () -> Unit,
     onThreadInfoClick: () -> Unit,
     onMoreClick: () -> Unit,
+    onAutoScrollClick: () -> Unit,
     scrollBehavior: BottomAppBarScrollBehavior? = null,
 ) {
     FlexibleBottomAppBar(
@@ -149,6 +152,22 @@ fun ThreadBottomBar(
                         contentDescription = stringResource(R.string.post)
                     )
                 }
+                IconButton(onClick = onAutoScrollClick) {
+                    Icon(
+                        imageVector = if (uiState.isAutoScroll) {
+                            Icons.Filled.Pause
+                        } else {
+                            Icons.Filled.PlayArrow
+                        },
+                        contentDescription = stringResource(
+                            if (uiState.isAutoScroll) {
+                                R.string.stop_auto_scroll
+                            } else {
+                                R.string.start_auto_scroll
+                            }
+                        )
+                    )
+                }
                 IconButton(onClick = onMoreClick) {
                     Icon(
                         imageVector = Icons.Filled.Menu,
@@ -182,6 +201,7 @@ fun ThreadBottomBarPreview() {
         onSearchClick = {},
         onBookmarkClick = {},
         onThreadInfoClick = {},
-        onMoreClick = {}
+        onMoreClick = {},
+        onAutoScrollClick = {}
     )
 }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -145,6 +145,7 @@ fun ThreadScaffold(
                 onBookmarkClick = { viewModel.openBookmarkSheet() },
                 onThreadInfoClick = { viewModel.openThreadInfoSheet() },
                 onMoreClick = { viewModel.openMoreSheet() },
+                onAutoScrollClick = { viewModel.toggleAutoScroll() },
                 scrollBehavior = barScrollBehavior,
             )
         },

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -181,6 +181,7 @@ fun ThreadScaffold(
                 uiState = uiState,
                 listState = listState,
                 navController = navController,
+                onAutoScrollBottom = { viewModel.onAutoScrollReachedBottom() },
                 onBottomRefresh = { viewModel.reloadThread() },
                 onLastRead = { resNum ->
                     routeThreadId?.let { viewModel.updateThreadLastRead(it, resNum) }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
@@ -120,12 +120,12 @@ fun ThreadScreen(
             }
     }
 
-    val autoScrollStep = with(LocalDensity.current) { 1.dp.toPx() }
+    val autoScrollStep = with(LocalDensity.current) { 4.dp.toPx() }
     LaunchedEffect(uiState.isAutoScroll, autoScrollStep) {
         if (uiState.isAutoScroll) {
             while (isActive) {
                 if (listState.canScrollForward) {
-                    listState.animateScrollToItem(
+                    listState.scrollToItem(
                         listState.firstVisibleItemIndex,
                         listState.firstVisibleItemScrollOffset + autoScrollStep.toInt()
                     )

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
@@ -118,6 +118,12 @@ fun ThreadScreen(
             }
     }
 
+    LaunchedEffect(uiState.isAutoScroll, visiblePosts.size) {
+        if (uiState.isAutoScroll && visiblePosts.isNotEmpty()) {
+            listState.animateScrollToItem(visiblePosts.size)
+        }
+    }
+
     val density = LocalDensity.current
     val refreshThresholdPx = with(density) { 80.dp.toPx() }
     var overscroll by remember { mutableFloatStateOf(0f) }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
@@ -145,7 +145,7 @@ fun ThreadScreen(
 
             if (atEnd || consumed == 0f) {
                 onAutoScrollBottom()
-                break
+                continue
             }
         }
     }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
@@ -68,6 +68,7 @@ fun ThreadScreen(
     uiState: ThreadUiState,
     listState: LazyListState = rememberLazyListState(),
     navController: NavHostController,
+    onAutoScrollBottom: () -> Unit = {},
     onBottomRefresh: () -> Unit = {},
     onLastRead: (Int) -> Unit = {},
     onReplyToPost: (Int) -> Unit = {},
@@ -130,6 +131,7 @@ fun ThreadScreen(
                     )
                     delay(16L)
                 } else {
+                    onAutoScrollBottom()
                     delay(500L)
                 }
             }
@@ -429,6 +431,7 @@ fun ThreadScreenPreview() {
     ThreadScreen(
         uiState = uiState,
         navController = NavHostController(LocalContext.current),
+        onAutoScrollBottom = {},
         onBottomRefresh = {}
     )
 }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
@@ -123,7 +123,7 @@ fun ThreadScreen(
             }
     }
 
-    val autoScrollDpPerSec = 250f
+    val autoScrollDpPerSec = 40f
     val isScrollInProgress = listState.isScrollInProgress
     LaunchedEffect(uiState.isAutoScroll, isScrollInProgress, autoScrollDpPerSec, density) {
         if (!uiState.isAutoScroll || isScrollInProgress) return@LaunchedEffect

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
@@ -58,6 +58,7 @@ import com.websarva.wings.android.slevo.ui.thread.state.ReplyInfo
 import com.websarva.wings.android.slevo.ui.thread.state.ThreadSortType
 import com.websarva.wings.android.slevo.ui.thread.state.ThreadUiState
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlin.math.min
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
@@ -118,9 +119,20 @@ fun ThreadScreen(
             }
     }
 
-    LaunchedEffect(uiState.isAutoScroll, visiblePosts.size) {
-        if (uiState.isAutoScroll && visiblePosts.isNotEmpty()) {
-            listState.animateScrollToItem(visiblePosts.size)
+    val autoScrollStep = with(LocalDensity.current) { 1.dp.toPx() }
+    LaunchedEffect(uiState.isAutoScroll, autoScrollStep) {
+        if (uiState.isAutoScroll) {
+            while (isActive) {
+                if (listState.canScrollForward) {
+                    listState.animateScrollToItem(
+                        listState.firstVisibleItemIndex,
+                        listState.firstVisibleItemScrollOffset + autoScrollStep.toInt()
+                    )
+                    delay(16L)
+                } else {
+                    delay(500L)
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
@@ -124,8 +124,9 @@ fun ThreadScreen(
     }
 
     val autoScrollDpPerSec = 250f
-    LaunchedEffect(uiState.isAutoScroll, autoScrollDpPerSec, density) {
-        if (!uiState.isAutoScroll) return@LaunchedEffect
+    val isScrollInProgress = listState.isScrollInProgress
+    LaunchedEffect(uiState.isAutoScroll, isScrollInProgress, autoScrollDpPerSec, density) {
+        if (!uiState.isAutoScroll || isScrollInProgress) return@LaunchedEffect
         val pxPerSec = with(density) { autoScrollDpPerSec.dp.toPx() }
         var lastTime: Long? = null
         while (isActive) {

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/state/ThreadUiState.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/state/ThreadUiState.kt
@@ -33,6 +33,7 @@ data class ThreadUiState(
     val treeDepthMap: Map<Int, Int> = emptyMap(),
     val firstNewResNo: Int? = null,
     val prevResCount: Int = 0,
+    val isAutoScroll: Boolean = false,
     val visiblePosts: List<DisplayPost> = emptyList(),
     val replyCounts: List<Int> = emptyList(),
     val firstAfterIndex: Int = -1,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,6 +71,8 @@
     <string name="search_board_hint">板名またはURLで検索</string>
     <string name="new_label">new</string>
     <string name="new_responses">新着</string>
+    <string name="start_auto_scroll">自動スクロール開始</string>
+    <string name="stop_auto_scroll">自動スクロール停止</string>
 
     <string name="default_thread_sort_order">レスのデフォルトの並び順</string>
 


### PR DESCRIPTION
## Summary
- add auto-scroll toggle button in thread bottom bar
- periodically refresh thread every 10s when auto-scroll enabled

## Testing
- `./gradlew :app:testDebugUnitTest`
- `./gradlew :app:lintDebug` *(fails: Lint found errors in `SettingsCookieViewModel.kt`)*

------
https://chatgpt.com/codex/tasks/task_e_68c44c01d8a88332a80b44799b3e11af