### PR TITLE
feat: add search bottom bar to thread screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
     <!--　インターネットへのアクセス許可-->
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
     <application
         android:name=".SlevoApplication"

--- a/app/src/main/java/com/websarva/wings/android/slevo/MainActivity.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/MainActivity.kt
@@ -1,21 +1,20 @@
 package com.websarva.wings.android.slevo
 
 import android.app.Activity
-import android.os.Build
 import android.os.Bundle
+import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
-import androidx.annotation.RequiresApi
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowInsetsControllerCompat
 import com.websarva.wings.android.slevo.ui.AppScaffold
-import com.websarva.wings.android.slevo.ui.tabs.TabsViewModel
 import com.websarva.wings.android.slevo.ui.settings.SettingsViewModel
+import com.websarva.wings.android.slevo.ui.tabs.TabsViewModel
 import com.websarva.wings.android.slevo.ui.theme.SlevoTheme
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -24,10 +23,11 @@ class MainActivity : ComponentActivity() {
     private val settingsViewModel: SettingsViewModel by viewModels()
     private val tabsViewModel: TabsViewModel by viewModels()
 
-    @RequiresApi(Build.VERSION_CODES.O)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+        // レイアウトをキーボード表示時にリサイズさせる（ime パディングが即座に反映されやすくなる）
+        window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
 
         setContent {
             val uiState by settingsViewModel.uiState.collectAsState()

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardViewModel.kt
@@ -18,6 +18,7 @@ import com.websarva.wings.android.slevo.data.model.NgType
 import com.websarva.wings.android.slevo.ui.common.BaseViewModel
 import com.websarva.wings.android.slevo.ui.common.bookmark.SingleBookmarkViewModel
 import com.websarva.wings.android.slevo.ui.common.bookmark.SingleBookmarkViewModelFactory
+import com.websarva.wings.android.slevo.ui.util.toHiragana
 import com.websarva.wings.android.slevo.ui.util.parseServiceName
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -200,9 +201,10 @@ class BoardViewModel @AssistedInject constructor(
     private fun applyFiltersAndSort() {
         originalThreads?.let { allThreads ->
             // 1. フィルタリング
-            val searchFiltered = if (_uiState.value.searchQuery.isNotBlank()) {
+            val query = _uiState.value.searchQuery.toHiragana()
+            val searchFiltered = if (query.isNotBlank()) {
                 allThreads.filter {
-                    it.title.contains(_uiState.value.searchQuery, ignoreCase = true)
+                    it.title.toHiragana().contains(query, ignoreCase = true)
                 }
             } else {
                 allThreads

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/components/ThreadSearchBar.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/components/ThreadSearchBar.kt
@@ -14,9 +14,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBackIos
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Mic
+import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FlexibleBottomAppBar
@@ -111,75 +112,77 @@ fun ThreadSearchBar(
     FlexibleBottomAppBar(
         modifier = modifier,
     ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 8.dp)
-        ) {
-            IconButton(onClick = {
-                keyboardController?.hide()
-                focusManager.clearFocus()
-                onCloseSearch()
-            }) {
-                Icon(
-                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                    contentDescription = stringResource(R.string.cancel)
-                )
-            }
-            TextField(
-                value = searchQuery,
-                onValueChange = onQueryChange,
+        Card {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier
-                    .weight(1f)
-                    .focusRequester(focusRequester),
-                placeholder = { Text(stringResource(R.string.search) + "...") },
-                singleLine = true,
-                keyboardOptions = KeyboardOptions.Default.copy(
-                    imeAction = ImeAction.Search
-                ),
-                keyboardActions = KeyboardActions(
-                    onSearch = {
-                        keyboardController?.hide()
-                        focusManager.clearFocus()
-                    }
-                ),
-                colors = TextFieldDefaults.colors(
-                    focusedContainerColor = Color.Transparent,
-                    unfocusedContainerColor = Color.Transparent,
-                    disabledContainerColor = Color.Transparent,
-                    focusedIndicatorColor = Color.Transparent,
-                    unfocusedIndicatorColor = Color.Transparent,
-                )
-            )
-            if (searchQuery.isNotEmpty()) {
-                IconButton(onClick = { onQueryChange("") }) {
-                    Icon(
-                        imageVector = Icons.Filled.Clear,
-                        contentDescription = "Clear search"
-                    )
-                }
-            }
-            IconButton(
-                onClick = {
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp)
+            ) {
+                IconButton(onClick = {
                     keyboardController?.hide()
                     focusManager.clearFocus()
-                    if (
-                        ContextCompat.checkSelfPermission(
-                            context,
-                            Manifest.permission.RECORD_AUDIO
-                        ) == PackageManager.PERMISSION_GRANTED
-                    ) {
-                        startSpeechRecognition()
-                    } else {
-                        permissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+                    onCloseSearch()
+                }) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBackIos,
+                        contentDescription = stringResource(R.string.cancel)
+                    )
+                }
+                TextField(
+                    value = searchQuery,
+                    onValueChange = onQueryChange,
+                    modifier = Modifier
+                        .weight(1f)
+                        .focusRequester(focusRequester),
+                    placeholder = { Text(stringResource(R.string.search_in_thread)) },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions.Default.copy(
+                        imeAction = ImeAction.Search
+                    ),
+                    keyboardActions = KeyboardActions(
+                        onSearch = {
+                            keyboardController?.hide()
+                            focusManager.clearFocus()
+                        }
+                    ),
+                    colors = TextFieldDefaults.colors(
+                        focusedContainerColor = Color.Transparent,
+                        unfocusedContainerColor = Color.Transparent,
+                        disabledContainerColor = Color.Transparent,
+                        focusedIndicatorColor = Color.Transparent,
+                        unfocusedIndicatorColor = Color.Transparent,
+                    )
+                )
+                if (searchQuery.isNotEmpty()) {
+                    IconButton(onClick = { onQueryChange("") }) {
+                        Icon(
+                            imageVector = Icons.Filled.Clear,
+                            contentDescription = "Clear search"
+                        )
                     }
                 }
-            ) {
-                Icon(
-                    imageVector = Icons.Filled.Mic,
-                    contentDescription = stringResource(R.string.voice_input)
-                )
+                IconButton(
+                    onClick = {
+                        keyboardController?.hide()
+                        focusManager.clearFocus()
+                        if (
+                            ContextCompat.checkSelfPermission(
+                                context,
+                                Manifest.permission.RECORD_AUDIO
+                            ) == PackageManager.PERMISSION_GRANTED
+                        ) {
+                            startSpeechRecognition()
+                        } else {
+                            permissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+                        }
+                    }
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Mic,
+                        contentDescription = stringResource(R.string.voice_input)
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/components/ThreadSearchBar.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/components/ThreadSearchBar.kt
@@ -1,0 +1,124 @@
+package com.websarva.wings.android.slevo.ui.thread.components
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material3.BottomAppBarScrollBehavior
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FlexibleBottomAppBar
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.unit.dp
+import com.websarva.wings.android.slevo.R
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalMaterial3Api::class)
+@Composable
+fun ThreadSearchBar(
+    modifier: Modifier = Modifier,
+    searchQuery: String,
+    onQueryChange: (String) -> Unit,
+    onCloseSearch: () -> Unit,
+    scrollBehavior: BottomAppBarScrollBehavior? = null,
+) {
+    val focusRequester = remember { FocusRequester() }
+    val keyboardController = LocalSoftwareKeyboardController.current
+    val focusManager = LocalFocusManager.current
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+        keyboardController?.show()
+    }
+
+    FlexibleBottomAppBar(
+        modifier = modifier,
+        scrollBehavior = scrollBehavior,
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp)
+        ) {
+            IconButton(onClick = {
+                keyboardController?.hide()
+                focusManager.clearFocus()
+                onCloseSearch()
+            }) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = stringResource(R.string.cancel)
+                )
+            }
+            TextField(
+                value = searchQuery,
+                onValueChange = onQueryChange,
+                modifier = Modifier
+                    .weight(1f)
+                    .focusRequester(focusRequester),
+                placeholder = { Text(stringResource(R.string.search) + "...") },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions.Default.copy(
+                    imeAction = ImeAction.Search
+                ),
+                keyboardActions = KeyboardActions(
+                    onSearch = {
+                        keyboardController?.hide()
+                        focusManager.clearFocus()
+                    }
+                ),
+                colors = TextFieldDefaults.colors(
+                    focusedContainerColor = Color.Transparent,
+                    unfocusedContainerColor = Color.Transparent,
+                    disabledContainerColor = Color.Transparent,
+                    focusedIndicatorColor = Color.Transparent,
+                    unfocusedIndicatorColor = Color.Transparent,
+                )
+            )
+            if (searchQuery.isNotEmpty()) {
+                IconButton(onClick = { onQueryChange("") }) {
+                    Icon(
+                        imageVector = Icons.Filled.Clear,
+                        contentDescription = "Clear search"
+                    )
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalMaterial3Api::class)
+@Preview(showBackground = true)
+@Composable
+fun ThreadSearchBarPreview() {
+    var query by remember { mutableStateOf("") }
+    ThreadSearchBar(
+        searchQuery = query,
+        onQueryChange = { query = it },
+        onCloseSearch = {},
+    )
+}

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/components/ThreadSearchBar.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/components/ThreadSearchBar.kt
@@ -8,6 +8,7 @@ import android.speech.RecognizerIntent
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -154,34 +155,40 @@ fun ThreadSearchBar(
                         unfocusedIndicatorColor = Color.Transparent,
                     )
                 )
-                if (searchQuery.isNotEmpty()) {
-                    IconButton(onClick = { onQueryChange("") }) {
-                        Icon(
-                            imageVector = Icons.Filled.Clear,
-                            contentDescription = "Clear search"
-                        )
-                    }
-                }
-                IconButton(
-                    onClick = {
-                        keyboardController?.hide()
-                        focusManager.clearFocus()
-                        if (
-                            ContextCompat.checkSelfPermission(
-                                context,
-                                Manifest.permission.RECORD_AUDIO
-                            ) == PackageManager.PERMISSION_GRANTED
+                AnimatedContent(
+                    targetState = searchQuery.isNotEmpty(),
+                    label = "SearchBarIcon"
+                ) { hasQuery ->
+                    if (hasQuery) {
+                        IconButton(onClick = { onQueryChange("") }) {
+                            Icon(
+                                imageVector = Icons.Filled.Clear,
+                                contentDescription = "Clear search"
+                            )
+                        }
+                    } else {
+                        IconButton(
+                            onClick = {
+                                keyboardController?.hide()
+                                focusManager.clearFocus()
+                                if (
+                                    ContextCompat.checkSelfPermission(
+                                        context,
+                                        Manifest.permission.RECORD_AUDIO
+                                    ) == PackageManager.PERMISSION_GRANTED
+                                ) {
+                                    startSpeechRecognition()
+                                } else {
+                                    permissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+                                }
+                            }
                         ) {
-                            startSpeechRecognition()
-                        } else {
-                            permissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+                            Icon(
+                                imageVector = Icons.Filled.Mic,
+                                contentDescription = stringResource(R.string.voice_input)
+                            )
                         }
                     }
-                ) {
-                    Icon(
-                        imageVector = Icons.Filled.Mic,
-                        contentDescription = stringResource(R.string.voice_input)
-                    )
                 }
             }
         }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/components/ThreadSearchBar.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/components/ThreadSearchBar.kt
@@ -1,11 +1,22 @@
 package com.websarva.wings.android.slevo.ui.thread.components
 
+import android.Manifest
+import android.app.Activity
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.speech.RecognizerIntent
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FlexibleBottomAppBar
@@ -16,24 +27,26 @@ import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
 import com.websarva.wings.android.slevo.R
+import java.util.Locale
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalMaterial3Api::class)
 @Composable
@@ -46,6 +59,49 @@ fun ThreadSearchBar(
     val focusRequester = remember { FocusRequester() }
     val keyboardController = LocalSoftwareKeyboardController.current
     val focusManager = LocalFocusManager.current
+    val context = LocalContext.current
+    val voicePrompt = stringResource(R.string.voice_search_prompt)
+    val voicePermissionDeniedMessage = stringResource(R.string.voice_permission_denied)
+    val voiceUnavailableMessage = stringResource(R.string.speech_recognition_not_available)
+    val updatedOnQueryChange by rememberUpdatedState(newValue = onQueryChange)
+
+    val speechLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            val text = result.data?.getStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS)
+            val recognized = text?.firstOrNull().orEmpty()
+            if (recognized.isNotBlank()) {
+                updatedOnQueryChange(recognized)
+            }
+        }
+    }
+
+    val startSpeechRecognition: () -> Unit = {
+        val intent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+            putExtra(
+                RecognizerIntent.EXTRA_LANGUAGE_MODEL,
+                RecognizerIntent.LANGUAGE_MODEL_FREE_FORM
+            )
+            putExtra(RecognizerIntent.EXTRA_LANGUAGE, Locale.getDefault())
+            putExtra(RecognizerIntent.EXTRA_PROMPT, voicePrompt)
+        }
+        if (intent.resolveActivity(context.packageManager) != null) {
+            speechLauncher.launch(intent)
+        } else {
+            Toast.makeText(context, voiceUnavailableMessage, Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    val permissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        if (isGranted) {
+            startSpeechRecognition()
+        } else {
+            Toast.makeText(context, voicePermissionDeniedMessage, Toast.LENGTH_SHORT).show()
+        }
+    }
 
     LaunchedEffect(Unit) {
         focusRequester.requestFocus()
@@ -103,6 +159,27 @@ fun ThreadSearchBar(
                         contentDescription = "Clear search"
                     )
                 }
+            }
+            IconButton(
+                onClick = {
+                    keyboardController?.hide()
+                    focusManager.clearFocus()
+                    if (
+                        ContextCompat.checkSelfPermission(
+                            context,
+                            Manifest.permission.RECORD_AUDIO
+                        ) == PackageManager.PERMISSION_GRANTED
+                    ) {
+                        startSpeechRecognition()
+                    } else {
+                        permissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+                    }
+                }
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Mic,
+                    contentDescription = stringResource(R.string.voice_input)
+                )
             }
         }
     }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/components/ThreadSearchBar.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/components/ThreadSearchBar.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Clear
-import androidx.compose.material3.BottomAppBarScrollBehavior
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FlexibleBottomAppBar
@@ -43,7 +42,6 @@ fun ThreadSearchBar(
     searchQuery: String,
     onQueryChange: (String) -> Unit,
     onCloseSearch: () -> Unit,
-    scrollBehavior: BottomAppBarScrollBehavior? = null,
 ) {
     val focusRequester = remember { FocusRequester() }
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -56,7 +54,6 @@ fun ThreadSearchBar(
 
     FlexibleBottomAppBar(
         modifier = modifier,
-        scrollBehavior = scrollBehavior,
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/dialog/ReplyPopup.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/dialog/ReplyPopup.kt
@@ -62,6 +62,7 @@ fun ReplyPopup(
     navController: NavHostController,
     boardName: String,
     boardId: Long,
+    searchQuery: String = "",
     onClose: () -> Unit
 ) {
     val visibilityStates = remember { mutableStateListOf<MutableTransitionState<Boolean>>() }
@@ -158,6 +159,7 @@ fun ReplyPopup(
                                 navController = navController,
                                 boardName = boardName,
                                 boardId = boardId,
+                                searchQuery = searchQuery,
                                 isMyPost = postNum in myPostNumbers,
                                 replyFromNumbers = replySourceMap[postNum]?.filterNot { it in ngPostNumbers } ?: emptyList(),
                                 onReplyFromClick = { nums ->
@@ -251,6 +253,7 @@ fun ReplyPopupPreview() {
         navController = navController,
         boardName = "test",
         boardId = 1L,
+        searchQuery = "",
         onClose = {},
         myPostNumbers = emptySet()
     )

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/item/PostItemDialogs.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/item/PostItemDialogs.kt
@@ -1,0 +1,147 @@
+package com.websarva.wings.android.slevo.ui.thread.item
+
+import android.content.ClipData
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.platform.toClipEntry
+import androidx.compose.ui.res.stringResource
+import com.websarva.wings.android.slevo.R
+import com.websarva.wings.android.slevo.data.model.NgType
+import com.websarva.wings.android.slevo.ui.common.CopyDialog
+import com.websarva.wings.android.slevo.ui.common.CopyItem
+import com.websarva.wings.android.slevo.ui.thread.dialog.NgDialogRoute
+import com.websarva.wings.android.slevo.ui.thread.dialog.NgSelectDialog
+import com.websarva.wings.android.slevo.ui.thread.dialog.TextMenuDialog
+import com.websarva.wings.android.slevo.ui.thread.state.ReplyInfo
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+@Stable
+class PostItemDialogState internal constructor() {
+    var copyDialogVisible by mutableStateOf(false)
+        private set
+    var ngSelectDialogVisible by mutableStateOf(false)
+        private set
+    var textMenuData by mutableStateOf<Pair<String, NgType>?>(null)
+        private set
+    var ngDialogData by mutableStateOf<Pair<String, NgType>?>(null)
+        private set
+
+    fun showCopyDialog() {
+        copyDialogVisible = true
+    }
+
+    fun hideCopyDialog() {
+        copyDialogVisible = false
+    }
+
+    fun showNgSelectDialog() {
+        ngSelectDialogVisible = true
+    }
+
+    fun hideNgSelectDialog() {
+        ngSelectDialogVisible = false
+    }
+
+    fun showTextMenu(text: String, type: NgType) {
+        textMenuData = text to type
+    }
+
+    fun hideTextMenu() {
+        textMenuData = null
+    }
+
+    fun openNgDialog(text: String, type: NgType) {
+        ngDialogData = text to type
+    }
+
+    fun hideNgDialog() {
+        ngDialogData = null
+    }
+}
+
+@Composable
+fun rememberPostItemDialogState(): PostItemDialogState {
+    return remember { PostItemDialogState() }
+}
+
+@Composable
+fun PostItemDialogs(
+    post: ReplyInfo,
+    postNum: Int,
+    boardName: String,
+    boardId: Long,
+    scope: CoroutineScope,
+    dialogState: PostItemDialogState
+) {
+    if (dialogState.copyDialogVisible) {
+        val header = buildString {
+            append(postNum)
+            if (post.name.isNotBlank()) append(" ${post.name}")
+            if (post.date.isNotBlank()) append(" ${post.date}")
+            if (post.id.isNotBlank()) append(" ID:${post.id}")
+        }
+        CopyDialog(
+            items = listOf(
+                CopyItem(postNum.toString(), stringResource(R.string.res_number_label)),
+                CopyItem(post.name, stringResource(R.string.name_label)),
+                CopyItem(post.id, stringResource(R.string.id_label)),
+                CopyItem(post.content, stringResource(R.string.post_message)),
+                CopyItem("$header\n${post.content}", stringResource(R.string.header_and_body)),
+            ),
+            onDismissRequest = { dialogState.hideCopyDialog() }
+        )
+    }
+
+    if (dialogState.ngSelectDialogVisible) {
+        NgSelectDialog(
+            onNgIdClick = {
+                dialogState.hideNgSelectDialog()
+                dialogState.openNgDialog(post.id, NgType.USER_ID)
+            },
+            onNgNameClick = {
+                dialogState.hideNgSelectDialog()
+                dialogState.openNgDialog(post.name, NgType.USER_NAME)
+            },
+            onNgWordClick = {
+                dialogState.hideNgSelectDialog()
+                dialogState.openNgDialog(post.content, NgType.WORD)
+            },
+            onDismiss = { dialogState.hideNgSelectDialog() }
+        )
+    }
+
+    dialogState.textMenuData?.let { (text, type) ->
+        val clipboard = LocalClipboard.current
+        TextMenuDialog(
+            text = text,
+            onCopyClick = {
+                scope.launch {
+                    val clip = ClipData.newPlainText("", text).toClipEntry()
+                    clipboard.setClipEntry(clip)
+                }
+                dialogState.hideTextMenu()
+            },
+            onNgClick = {
+                dialogState.hideTextMenu()
+                dialogState.openNgDialog(text, type)
+            },
+            onDismiss = { dialogState.hideTextMenu() }
+        )
+    }
+
+    dialogState.ngDialogData?.let { (text, type) ->
+        NgDialogRoute(
+            text = text,
+            type = type,
+            boardName = boardName,
+            boardId = boardId.takeIf { it != 0L },
+            onDismiss = { dialogState.hideNgDialog() }
+        )
+    }
+}

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/item/PressFeedback.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/item/PressFeedback.kt
@@ -1,0 +1,28 @@
+package com.websarva.wings.android.slevo.ui.thread.item
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+private const val PressFeedbackDelayMillis = 80L
+
+suspend fun handlePressFeedback(
+    scope: CoroutineScope,
+    feedbackDelayMillis: Long = PressFeedbackDelayMillis,
+    onFeedbackStart: () -> Unit,
+    onFeedbackEnd: () -> Unit,
+    awaitRelease: suspend () -> Unit
+) {
+    var job: Job? = null
+    try {
+        job = scope.launch {
+            delay(feedbackDelayMillis)
+            onFeedbackStart()
+        }
+        awaitRelease()
+    } finally {
+        job?.cancel()
+        onFeedbackEnd()
+    }
+}

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/item/SearchQueryHighlighter.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/item/SearchQueryHighlighter.kt
@@ -1,0 +1,81 @@
+package com.websarva.wings.android.slevo.ui.thread.item
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import com.websarva.wings.android.slevo.ui.util.toHiragana
+
+@Composable
+fun rememberHighlightedText(
+    baseText: AnnotatedString,
+    rawContent: String,
+    searchQuery: String,
+    highlightColor: Color
+): AnnotatedString {
+    return remember(baseText, rawContent, searchQuery, highlightColor) {
+        val highlightStyle = SpanStyle(background = highlightColor)
+        baseText.highlightSearchQuery(
+            rawContent = rawContent,
+            searchQuery = searchQuery,
+            highlightStyle = highlightStyle
+        )
+    }
+}
+
+fun AnnotatedString.highlightSearchQuery(
+    rawContent: String,
+    searchQuery: String,
+    highlightStyle: SpanStyle
+): AnnotatedString {
+    val highlightRanges = calculateHighlightRanges(rawContent, searchQuery)
+    if (highlightRanges.isEmpty()) {
+        return this
+    }
+    val builder = AnnotatedString.Builder(this)
+    val textLength = length
+    highlightRanges.forEach { range ->
+        val start = range.first.coerceIn(0, textLength)
+        val end = (range.last + 1).coerceAtMost(textLength)
+        if (start < end) {
+            builder.addStyle(
+                style = highlightStyle,
+                start = start,
+                end = end
+            )
+        }
+    }
+    return builder.toAnnotatedString()
+}
+
+fun calculateHighlightRanges(
+    rawContent: String,
+    searchQuery: String
+): List<IntRange> {
+    if (searchQuery.isBlank()) {
+        return emptyList()
+    }
+    val normalizedContent = rawContent.toHiragana()
+    val normalizedQuery = searchQuery.toHiragana()
+    if (normalizedQuery.isBlank()) {
+        return emptyList()
+    }
+    val ranges = mutableListOf<IntRange>()
+    var startIndex = 0
+    val step = normalizedQuery.length.coerceAtLeast(1)
+    while (true) {
+        val foundIndex = normalizedContent.indexOf(
+            normalizedQuery,
+            startIndex = startIndex,
+            ignoreCase = true
+        )
+        if (foundIndex == -1) break
+        val end = foundIndex + normalizedQuery.length
+        if (end > foundIndex) {
+            ranges.add(foundIndex until end)
+        }
+        startIndex = foundIndex + step
+    }
+    return ranges
+}

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -2,6 +2,13 @@ package com.websarva.wings.android.slevo.ui.thread.screen
 
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.TopAppBarDefaults
@@ -48,7 +55,7 @@ import com.websarva.wings.android.slevo.ui.util.rememberBottomBarShowOnBottomBeh
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalAnimationApi::class)
 @Composable
 fun ThreadScaffold(
     threadRoute: AppRoute.Thread,
@@ -128,29 +135,38 @@ fun ThreadScaffold(
             BackHandler(enabled = uiState.isSearchMode) {
                 viewModel.closeSearch()
             }
-            if (uiState.isSearchMode) {
-                ThreadSearchBar(
-                    modifier = modifier,
-                    searchQuery = uiState.searchQuery,
-                    onQueryChange = { viewModel.updateSearchQuery(it) },
-                    onCloseSearch = { viewModel.closeSearch() },
-                )
-            } else {
-                ThreadToolBar(
-                    modifier = modifier,
-                    uiState = uiState,
-                    isTreeSort = uiState.sortType == ThreadSortType.TREE,
-                    onSortClick = { viewModel.toggleSortType() },
-                    onPostClick = { viewModel.showPostDialog() },
-                    onTabListClick = { viewModel.openTabListSheet() },
-                    onRefreshClick = { viewModel.reloadThread() },
-                    onSearchClick = { viewModel.startSearch() },
-                    onBookmarkClick = { viewModel.openBookmarkSheet() },
-                    onThreadInfoClick = { viewModel.openThreadInfoSheet() },
-                    onMoreClick = { viewModel.openMoreSheet() },
-                    onAutoScrollClick = { viewModel.toggleAutoScroll() },
-                    scrollBehavior = barScrollBehavior,
-                )
+            AnimatedContent(
+                targetState = uiState.isSearchMode,
+                transitionSpec = {
+                    slideInVertically { it } + fadeIn() togetherWith
+                            slideOutVertically { it } + fadeOut()
+                },
+                label = "BottomBarAnimation"
+            ) { isSearchMode ->
+                if (isSearchMode) {
+                    ThreadSearchBar(
+                        modifier = modifier,
+                        searchQuery = uiState.searchQuery,
+                        onQueryChange = { viewModel.updateSearchQuery(it) },
+                        onCloseSearch = { viewModel.closeSearch() },
+                    )
+                } else {
+                    ThreadToolBar(
+                        modifier = modifier,
+                        uiState = uiState,
+                        isTreeSort = uiState.sortType == ThreadSortType.TREE,
+                        onSortClick = { viewModel.toggleSortType() },
+                        onPostClick = { viewModel.showPostDialog() },
+                        onTabListClick = { viewModel.openTabListSheet() },
+                        onRefreshClick = { viewModel.reloadThread() },
+                        onSearchClick = { viewModel.startSearch() },
+                        onBookmarkClick = { viewModel.openBookmarkSheet() },
+                        onThreadInfoClick = { viewModel.openThreadInfoSheet() },
+                        onMoreClick = { viewModel.openMoreSheet() },
+                        onAutoScrollClick = { viewModel.toggleAutoScroll() },
+                        scrollBehavior = barScrollBehavior,
+                    )
+                }
             }
         },
         content = { viewModel, uiState, listState, modifier, navController ->

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -9,6 +9,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.TopAppBarDefaults
@@ -130,9 +131,9 @@ fun ThreadScaffold(
             val context = LocalContext.current
             val isThreeButtonBar = remember { isThreeButtonNavigation(context) }
             val modifier = if (isThreeButtonBar) {
-                Modifier.navigationBarsPadding()
+                Modifier.navigationBarsPadding().imePadding()
             } else {
-                Modifier
+                Modifier.imePadding()
             }
             val keyboardController = LocalSoftwareKeyboardController.current
             val focusManager = LocalFocusManager.current

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -1,6 +1,7 @@
 package com.websarva.wings.android.slevo.ui.thread.screen
 
 import android.widget.Toast
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.TopAppBarDefaults
@@ -124,13 +125,15 @@ fun ThreadScaffold(
             } else {
                 Modifier
             }
+            BackHandler(enabled = uiState.isSearchMode) {
+                viewModel.closeSearch()
+            }
             if (uiState.isSearchMode) {
                 ThreadSearchBar(
                     modifier = modifier,
                     searchQuery = uiState.searchQuery,
                     onQueryChange = { viewModel.updateSearchQuery(it) },
                     onCloseSearch = { viewModel.closeSearch() },
-                    scrollBehavior = barScrollBehavior,
                 )
             } else {
                 ThreadToolBar(

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -26,6 +26,7 @@ import com.websarva.wings.android.slevo.ui.navigation.RouteScaffold
 import com.websarva.wings.android.slevo.ui.tabs.TabsViewModel
 import com.websarva.wings.android.slevo.ui.thread.components.ThreadToolBar
 import com.websarva.wings.android.slevo.ui.thread.components.ThreadInfoBottomSheet
+import com.websarva.wings.android.slevo.ui.thread.components.ThreadSearchBar
 import com.websarva.wings.android.slevo.ui.thread.dialog.ResponseWebViewDialog
 import com.websarva.wings.android.slevo.ui.thread.state.ThreadSortType
 import com.websarva.wings.android.slevo.ui.thread.viewmodel.ThreadPagerViewModel
@@ -40,7 +41,6 @@ import com.websarva.wings.android.slevo.ui.thread.viewmodel.updatePostMail
 import com.websarva.wings.android.slevo.ui.thread.viewmodel.updatePostMessage
 import com.websarva.wings.android.slevo.ui.thread.viewmodel.updatePostName
 import com.websarva.wings.android.slevo.ui.thread.viewmodel.uploadImage
-import com.websarva.wings.android.slevo.ui.topbar.SearchTopAppBar
 import com.websarva.wings.android.slevo.ui.util.isThreeButtonNavigation
 import com.websarva.wings.android.slevo.ui.util.parseBoardUrl
 import com.websarva.wings.android.slevo.ui.util.rememberBottomBarShowOnBottomBehavior
@@ -115,38 +115,40 @@ fun ThreadScaffold(
         onPageChange = { pagerViewModel.setCurrentPage(it) },
         scrollBehavior = scrollBehavior,
         bottomBarScrollBehavior = { listState -> rememberBottomBarShowOnBottomBehavior(listState) },
-        topBar = { viewModel, uiState, _, scrollBehavior ->
-            if (uiState.isSearchMode) {
-                SearchTopAppBar(
-                    searchQuery = uiState.searchQuery,
-                    onQueryChange = { viewModel.updateSearchQuery(it) },
-                    onCloseSearch = { viewModel.closeSearch() },
-                    scrollBehavior = scrollBehavior
-                )
-            }
-        },
+        topBar = { _, _, _, _ -> },
         bottomBar = { viewModel, uiState, barScrollBehavior ->
             val context = LocalContext.current
             val isThreeButtonBar = remember { isThreeButtonNavigation(context) }
-            ThreadToolBar(
-                modifier = if (isThreeButtonBar) {
-                    Modifier.navigationBarsPadding()
-                } else {
-                    Modifier
-                },
-                uiState = uiState,
-                isTreeSort = uiState.sortType == ThreadSortType.TREE,
-                onSortClick = { viewModel.toggleSortType() },
-                onPostClick = { viewModel.showPostDialog() },
-                onTabListClick = { viewModel.openTabListSheet() },
-                onRefreshClick = { viewModel.reloadThread() },
-                onSearchClick = { viewModel.startSearch() },
-                onBookmarkClick = { viewModel.openBookmarkSheet() },
-                onThreadInfoClick = { viewModel.openThreadInfoSheet() },
-                onMoreClick = { viewModel.openMoreSheet() },
-                onAutoScrollClick = { viewModel.toggleAutoScroll() },
-                scrollBehavior = barScrollBehavior,
-            )
+            val modifier = if (isThreeButtonBar) {
+                Modifier.navigationBarsPadding()
+            } else {
+                Modifier
+            }
+            if (uiState.isSearchMode) {
+                ThreadSearchBar(
+                    modifier = modifier,
+                    searchQuery = uiState.searchQuery,
+                    onQueryChange = { viewModel.updateSearchQuery(it) },
+                    onCloseSearch = { viewModel.closeSearch() },
+                    scrollBehavior = barScrollBehavior,
+                )
+            } else {
+                ThreadToolBar(
+                    modifier = modifier,
+                    uiState = uiState,
+                    isTreeSort = uiState.sortType == ThreadSortType.TREE,
+                    onSortClick = { viewModel.toggleSortType() },
+                    onPostClick = { viewModel.showPostDialog() },
+                    onTabListClick = { viewModel.openTabListSheet() },
+                    onRefreshClick = { viewModel.reloadThread() },
+                    onSearchClick = { viewModel.startSearch() },
+                    onBookmarkClick = { viewModel.openBookmarkSheet() },
+                    onThreadInfoClick = { viewModel.openThreadInfoSheet() },
+                    onMoreClick = { viewModel.openMoreSheet() },
+                    onAutoScrollClick = { viewModel.toggleAutoScroll() },
+                    scrollBehavior = barScrollBehavior,
+                )
+            }
         },
         content = { viewModel, uiState, listState, modifier, navController ->
             LaunchedEffect(uiState.threadInfo.key, uiState.isLoading) {

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -20,6 +20,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
@@ -132,7 +134,11 @@ fun ThreadScaffold(
             } else {
                 Modifier
             }
+            val keyboardController = LocalSoftwareKeyboardController.current
+            val focusManager = LocalFocusManager.current
             BackHandler(enabled = uiState.isSearchMode) {
+                keyboardController?.hide()
+                focusManager.clearFocus()
                 viewModel.closeSearch()
             }
             AnimatedContent(

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
@@ -257,6 +257,7 @@ fun ThreadScreen(
                             replyFromNumbers = uiState.replySourceMap[postNum] ?: emptyList(),
                             isMyPost = postNum in uiState.myPostNumbers,
                             dimmed = display.dimmed,
+                            searchQuery = uiState.searchQuery,
                             onReplyFromClick = { nums ->
                                 val offset = if (popupStack.isEmpty()) {
                                     itemOffsetHolder.value
@@ -364,6 +365,7 @@ fun ThreadScreen(
             navController = navController,
             boardName = uiState.boardInfo.name,
             boardId = uiState.boardInfo.boardId,
+            searchQuery = uiState.searchQuery,
             onClose = { if (popupStack.isNotEmpty()) popupStack.removeAt(popupStack.lastIndex) }
         )
 

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/viewmodel/ThreadViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/viewmodel/ThreadViewModel.kt
@@ -21,6 +21,7 @@ import com.websarva.wings.android.slevo.data.repository.ThreadReadStateRepositor
 import com.websarva.wings.android.slevo.ui.common.BaseViewModel
 import com.websarva.wings.android.slevo.ui.common.bookmark.SingleBookmarkViewModel
 import com.websarva.wings.android.slevo.ui.common.bookmark.SingleBookmarkViewModelFactory
+import com.websarva.wings.android.slevo.ui.util.toHiragana
 import com.websarva.wings.android.slevo.ui.tabs.ThreadTabInfo
 import com.websarva.wings.android.slevo.data.datasource.local.entity.ThreadReadState
 import com.websarva.wings.android.slevo.ui.thread.state.DisplayPost
@@ -402,10 +403,11 @@ class ThreadViewModel @AssistedInject constructor(
         )
 
         // 検索クエリがあれば絞り込み
-        val filteredPosts = if (uiState.value.searchQuery.isNotBlank()) {
+        val query = uiState.value.searchQuery.toHiragana()
+        val filteredPosts = if (query.isNotBlank()) {
             orderedPosts.filter {
-                it.post.content.contains(
-                    uiState.value.searchQuery,
+                it.post.content.toHiragana().contains(
+                    query,
                     ignoreCase = true
                 )
             }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/util/KanaUtils.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/util/KanaUtils.kt
@@ -1,0 +1,14 @@
+package com.websarva.wings.android.slevo.ui.util
+
+fun String.toHiragana(): String = buildString {
+    for (ch in this@toHiragana) {
+        append(
+            if (ch in 'ァ'..'ヶ') {
+                (ch.code - 0x60).toChar()
+            } else {
+                ch
+            }
+        )
+    }
+}
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -99,4 +99,5 @@
     <string name="header_and_body">ヘッダー + 本文</string>
     <string name="open_in_external_browser">外部ブラウザで開く</string>
     <string name="share">共有</string>
+    <string name="search_in_thread">スレッド内を検索</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,10 @@
     <string name="boardList">板一覧</string>
     <string name="BBSList">掲示板一覧</string>
     <string name="search">検索</string>
+    <string name="voice_input">音声入力</string>
+    <string name="voice_search_prompt">検索ワードを話してください</string>
+    <string name="voice_permission_denied">音声入力を使用するにはマイクへのアクセスを許可してください</string>
+    <string name="speech_recognition_not_available">この端末では音声入力を利用できません</string>
     <string name="refresh">更新</string>
     <string name="create_thread">スレッド作成</string>
     <string name="sort">並び替え</string>

--- a/app/src/test/java/com/websarva/wings/android/slevo/ui/thread/item/SearchQueryHighlighterTest.kt
+++ b/app/src/test/java/com/websarva/wings/android/slevo/ui/thread/item/SearchQueryHighlighterTest.kt
@@ -1,0 +1,65 @@
+package com.websarva.wings.android.slevo.ui.thread.item
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SearchQueryHighlighterTest {
+
+    @Test
+    fun highlightSearchQuery_addsSpanToMatches() {
+        val base = AnnotatedString("テスト投稿です")
+        val highlightStyle = SpanStyle(background = Color.Magenta)
+
+        val highlighted = base.highlightSearchQuery(
+            rawContent = "テスト投稿です",
+            searchQuery = "投稿",
+            highlightStyle = highlightStyle
+        )
+
+        assertEquals(base.text, highlighted.text)
+        val spans = highlighted.spanStyles
+        assertEquals(1, spans.size)
+        val span = spans.first()
+        assertEquals(highlightStyle, span.item)
+        assertEquals(3, span.start)
+        assertEquals(5, span.end)
+    }
+
+    @Test
+    fun highlightSearchQuery_returnsOriginalWhenQueryBlank() {
+        val base = AnnotatedString("テスト")
+        val highlightStyle = SpanStyle(background = Color.Magenta)
+
+        val highlighted = base.highlightSearchQuery(
+            rawContent = "テスト",
+            searchQuery = "",
+            highlightStyle = highlightStyle
+        )
+
+        assertEquals(base, highlighted)
+    }
+
+    @Test
+    fun calculateHighlightRanges_normalizesKana() {
+        val ranges = calculateHighlightRanges(
+            rawContent = "カタカナのテキスト",
+            searchQuery = "かたか",
+        )
+
+        assertEquals(listOf(0 until 3), ranges)
+    }
+
+    @Test
+    fun calculateHighlightRanges_returnsEmptyWhenNotFound() {
+        val ranges = calculateHighlightRanges(
+            rawContent = "sample",
+            searchQuery = "missing"
+        )
+
+        assertTrue(ranges.isEmpty())
+    }
+}


### PR DESCRIPTION
## Summary
- add `ThreadSearchBar` composable for bottom search UI
- switch thread screen bottom bar to search mode when activated and remove top bar

## Testing
- `./gradlew :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_68c7f8b7b020833280c9be268f56a807