### PR TITLE
feat: enable voice input in thread search

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
     <!--　インターネットへのアクセス許可-->
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
     <application
         android:name=".SlevoApplication"

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/components/ThreadSearchBar.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/components/ThreadSearchBar.kt
@@ -1,11 +1,22 @@
 package com.websarva.wings.android.slevo.ui.thread.components
 
+import android.Manifest
+import android.app.Activity
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.speech.RecognizerIntent
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FlexibleBottomAppBar
@@ -16,24 +27,26 @@ import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
 import com.websarva.wings.android.slevo.R
+import java.util.Locale
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalMaterial3Api::class)
 @Composable
@@ -46,6 +59,49 @@ fun ThreadSearchBar(
     val focusRequester = remember { FocusRequester() }
     val keyboardController = LocalSoftwareKeyboardController.current
     val focusManager = LocalFocusManager.current
+    val context = LocalContext.current
+    val voicePrompt = stringResource(R.string.voice_search_prompt)
+    val voicePermissionDeniedMessage = stringResource(R.string.voice_permission_denied)
+    val voiceUnavailableMessage = stringResource(R.string.speech_recognition_not_available)
+    val updatedOnQueryChange by rememberUpdatedState(newValue = onQueryChange)
+
+    val speechLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            val text = result.data?.getStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS)
+            val recognized = text?.firstOrNull().orEmpty()
+            if (recognized.isNotBlank()) {
+                updatedOnQueryChange(recognized)
+            }
+        }
+    }
+
+    val startSpeechRecognition: () -> Unit = {
+        val intent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+            putExtra(
+                RecognizerIntent.EXTRA_LANGUAGE_MODEL,
+                RecognizerIntent.LANGUAGE_MODEL_FREE_FORM
+            )
+            putExtra(RecognizerIntent.EXTRA_LANGUAGE, Locale.getDefault())
+            putExtra(RecognizerIntent.EXTRA_PROMPT, voicePrompt)
+        }
+        if (intent.resolveActivity(context.packageManager) != null) {
+            speechLauncher.launch(intent)
+        } else {
+            Toast.makeText(context, voiceUnavailableMessage, Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    val permissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        if (isGranted) {
+            startSpeechRecognition()
+        } else {
+            Toast.makeText(context, voicePermissionDeniedMessage, Toast.LENGTH_SHORT).show()
+        }
+    }
 
     LaunchedEffect(Unit) {
         focusRequester.requestFocus()
@@ -103,6 +159,27 @@ fun ThreadSearchBar(
                         contentDescription = "Clear search"
                     )
                 }
+            }
+            IconButton(
+                onClick = {
+                    keyboardController?.hide()
+                    focusManager.clearFocus()
+                    if (
+                        ContextCompat.checkSelfPermission(
+                            context,
+                            Manifest.permission.RECORD_AUDIO
+                        ) == PackageManager.PERMISSION_GRANTED
+                    ) {
+                        startSpeechRecognition()
+                    } else {
+                        permissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+                    }
+                }
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Mic,
+                    contentDescription = stringResource(R.string.voice_input)
+                )
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,10 @@
     <string name="boardList">板一覧</string>
     <string name="BBSList">掲示板一覧</string>
     <string name="search">検索</string>
+    <string name="voice_input">音声入力</string>
+    <string name="voice_search_prompt">検索ワードを話してください</string>
+    <string name="voice_permission_denied">音声入力を使用するにはマイクへのアクセスを許可してください</string>
+    <string name="speech_recognition_not_available">この端末では音声入力を利用できません</string>
     <string name="refresh">更新</string>
     <string name="create_thread">スレッド作成</string>
     <string name="sort">並び替え</string>


### PR DESCRIPTION
## Summary
- add a microphone action to `ThreadSearchBar` and launch speech recognition results into the query
- request the RECORD_AUDIO permission and show feedback for denied or unsupported voice input
- localize new voice input strings and declare the microphone permission in the manifest

## Testing
- ./gradlew :app:assembleDebug --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68ca4d68f9b883329b56b38486a97a2f