### PR TITLE
Highlight search terms in thread posts

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/dialog/ReplyPopup.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/dialog/ReplyPopup.kt
@@ -62,6 +62,7 @@ fun ReplyPopup(
     navController: NavHostController,
     boardName: String,
     boardId: Long,
+    searchQuery: String = "",
     onClose: () -> Unit
 ) {
     val visibilityStates = remember { mutableStateListOf<MutableTransitionState<Boolean>>() }
@@ -158,6 +159,7 @@ fun ReplyPopup(
                                 navController = navController,
                                 boardName = boardName,
                                 boardId = boardId,
+                                searchQuery = searchQuery,
                                 isMyPost = postNum in myPostNumbers,
                                 replyFromNumbers = replySourceMap[postNum]?.filterNot { it in ngPostNumbers } ?: emptyList(),
                                 onReplyFromClick = { nums ->
@@ -251,6 +253,7 @@ fun ReplyPopupPreview() {
         navController = navController,
         boardName = "test",
         boardId = 1L,
+        searchQuery = "",
         onClose = {},
         myPostNumbers = emptySet()
     )

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
@@ -257,6 +257,7 @@ fun ThreadScreen(
                             replyFromNumbers = uiState.replySourceMap[postNum] ?: emptyList(),
                             isMyPost = postNum in uiState.myPostNumbers,
                             dimmed = display.dimmed,
+                            searchQuery = uiState.searchQuery,
                             onReplyFromClick = { nums ->
                                 val offset = if (popupStack.isEmpty()) {
                                     itemOffsetHolder.value
@@ -364,6 +365,7 @@ fun ThreadScreen(
             navController = navController,
             boardName = uiState.boardInfo.name,
             boardId = uiState.boardInfo.boardId,
+            searchQuery = uiState.searchQuery,
             onClose = { if (popupStack.isNotEmpty()) popupStack.removeAt(popupStack.lastIndex) }
         )
 


### PR DESCRIPTION
## Summary
- highlight search query matches inside thread post bodies to make search results easier to spot
- pass the current search query to thread item views, including reply popups, so the highlighting is consistent everywhere

## Testing
- ./gradlew :app:testDebugUnitTest --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68ca5305a6e88332bd3d85c1e9bc02e0