### PR TITLE
refactor: centralize board/thread navigation

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
@@ -24,6 +24,7 @@ import com.websarva.wings.android.slevo.ui.common.PostDialog
 import com.websarva.wings.android.slevo.ui.common.PostingDialog
 import com.websarva.wings.android.slevo.ui.navigation.AppRoute
 import com.websarva.wings.android.slevo.ui.navigation.RouteScaffold
+import com.websarva.wings.android.slevo.ui.navigation.navigateToThread
 import com.websarva.wings.android.slevo.ui.tabs.BoardTabInfo
 import com.websarva.wings.android.slevo.ui.tabs.TabsViewModel
 import com.websarva.wings.android.slevo.ui.theme.bookmarkColor
@@ -159,14 +160,10 @@ fun BoardScaffold(
                         threadTitle = threadInfo.title,
                         resCount = threadInfo.resCount
                     )
-                    tabsViewModel.ensureThreadTab(route).let { index ->
-                        if (index >= 0) {
-                            tabsViewModel.setThreadCurrentPage(index)
-                        }
-                    }
-                    navController.navigate(route) {
-                        launchSingleTop = true
-                    }
+                    navController.navigateToThread(
+                        route = route,
+                        tabsViewModel = tabsViewModel,
+                    )
                 },
                 isRefreshing = uiState.isLoading,
                 onRefresh = { viewModel.refreshBoardData() },

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/bookmarklist/BookmarkListScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/bookmarklist/BookmarkListScaffold.kt
@@ -28,6 +28,8 @@ import com.websarva.wings.android.slevo.ui.common.bookmark.BookmarkBottomSheet
 import com.websarva.wings.android.slevo.ui.common.bookmark.AddGroupDialog
 import com.websarva.wings.android.slevo.ui.common.bookmark.DeleteGroupDialog
 import com.websarva.wings.android.slevo.ui.navigation.AppRoute
+import com.websarva.wings.android.slevo.ui.navigation.navigateToBoard
+import com.websarva.wings.android.slevo.ui.navigation.navigateToThread
 import com.websarva.wings.android.slevo.ui.tabs.TabsViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -91,14 +93,10 @@ fun BookmarkListScaffold(
                     boardName = board.name,
                     boardUrl = board.url
                 )
-                tabsViewModel.ensureBoardTab(route).let { index ->
-                    if (index >= 0) {
-                        tabsViewModel.setBoardCurrentPage(index)
-                    }
-                }
-                navController.navigate(route) {
-                    launchSingleTop = true
-                }
+                navController.navigateToBoard(
+                    route = route,
+                    tabsViewModel = tabsViewModel,
+                )
             },
             threadGroups = uiState.groupedThreadBookmarks,
             onThreadClick = { thread ->
@@ -110,14 +108,10 @@ fun BookmarkListScaffold(
                     boardId = thread.boardId,
                     resCount = thread.resCount
                 )
-                tabsViewModel.ensureThreadTab(route).let { index ->
-                    if (index >= 0) {
-                        tabsViewModel.setThreadCurrentPage(index)
-                    }
-                }
-                navController.navigate(route) {
-                    launchSingleTop = true
-                }
+                navController.navigateToThread(
+                    route = route,
+                    tabsViewModel = tabsViewModel,
+                )
             },
             selectMode = uiState.selectMode,
             selectedBoardIds = uiState.selectedBoards,

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/history/HistoryListScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/history/HistoryListScaffold.kt
@@ -19,6 +19,7 @@ import androidx.navigation.NavHostController
 import com.websarva.wings.android.slevo.R
 import com.websarva.wings.android.slevo.data.model.threadKey
 import com.websarva.wings.android.slevo.ui.navigation.AppRoute
+import com.websarva.wings.android.slevo.ui.navigation.navigateToThread
 import com.websarva.wings.android.slevo.ui.topbar.HomeTopAppBarScreen
 import com.websarva.wings.android.slevo.ui.tabs.TabsViewModel
 
@@ -61,12 +62,10 @@ fun HistoryListScaffold(
                     threadTitle = history.history.title,
                     resCount = history.history.resCount
                 )
-                tabsViewModel.ensureThreadTab(route).let { index ->
-                    if (index >= 0) {
-                        tabsViewModel.setThreadCurrentPage(index)
-                    }
-                }
-                navController.navigate(route) { launchSingleTop = true }
+                navController.navigateToThread(
+                    route = route,
+                    tabsViewModel = tabsViewModel,
+                )
             }
         )
     }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/NavigationExtensions.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/NavigationExtensions.kt
@@ -1,0 +1,47 @@
+package com.websarva.wings.android.slevo.ui.navigation
+
+import androidx.navigation.NavHostController
+import androidx.navigation.NavOptionsBuilder
+import com.websarva.wings.android.slevo.ui.tabs.TabsViewModel
+
+/**
+ * 板画面への遷移を共通化した拡張関数。
+ */
+fun NavHostController.navigateToBoard(
+    route: AppRoute.Board,
+    tabsViewModel: TabsViewModel? = null,
+    builder: NavOptionsBuilder.() -> Unit = {},
+) {
+    tabsViewModel?.let { viewModel ->
+        viewModel.ensureBoardTab(route).let { index ->
+            if (index >= 0) {
+                viewModel.setBoardCurrentPage(index)
+            }
+        }
+    }
+    navigate(route) {
+        launchSingleTop = true
+        builder()
+    }
+}
+
+/**
+ * スレ画面への遷移を共通化した拡張関数。
+ */
+fun NavHostController.navigateToThread(
+    route: AppRoute.Thread,
+    tabsViewModel: TabsViewModel? = null,
+    builder: NavOptionsBuilder.() -> Unit = {},
+) {
+    tabsViewModel?.let { viewModel ->
+        viewModel.ensureThreadTab(route).let { index ->
+            if (index >= 0) {
+                viewModel.setThreadCurrentPage(index)
+            }
+        }
+    }
+    navigate(route) {
+        launchSingleTop = true
+        builder()
+    }
+}

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/RegisteredBBSNavigation.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/RegisteredBBSNavigation.kt
@@ -302,17 +302,14 @@ fun NavGraphBuilder.addRegisteredBBSNavigation(
                             boardName = board.name,
                             boardUrl = board.url
                         )
-                        tabsViewModel.ensureBoardTab(route).let { index ->
-                            if (index >= 0) {
-                                tabsViewModel.setBoardCurrentPage(index)
-                            }
-                        }
-                        navController.navigate(route) {
+                        navController.navigateToBoard(
+                            route = route,
+                            tabsViewModel = tabsViewModel,
+                        ) {
                             popUpTo(route) {
                                 inclusive = false
                                 saveState = true
                             }
-                            launchSingleTop = true
                             restoreState = true
                         }
                     }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/OpenBoardsList.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/OpenBoardsList.kt
@@ -28,6 +28,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import com.websarva.wings.android.slevo.R
 import com.websarva.wings.android.slevo.ui.navigation.AppRoute
+import com.websarva.wings.android.slevo.ui.navigation.navigateToBoard
 import com.websarva.wings.android.slevo.ui.theme.BookmarkColor
 import com.websarva.wings.android.slevo.ui.theme.bookmarkColor
 
@@ -73,15 +74,10 @@ fun OpenBoardsList(
                                     boardName = tab.boardName,
                                     boardUrl = tab.boardUrl
                                 )
-                                tabsViewModel?.let { viewModel ->
-                                    viewModel.ensureBoardTab(route).let { index ->
-                                        if (index >= 0) {
-                                            viewModel.setBoardCurrentPage(index)
-                                        }
-                                    }
-                                }
-                                navController.navigate(route) {
-                                    launchSingleTop = true
+                                navController.navigateToBoard(
+                                    route = route,
+                                    tabsViewModel = tabsViewModel,
+                                ) {
                                     restoreState = true
                                 }
                             }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/OpenThreadsList.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/OpenThreadsList.kt
@@ -36,6 +36,7 @@ import androidx.navigation.compose.rememberNavController
 import com.websarva.wings.android.slevo.R
 import com.websarva.wings.android.slevo.data.model.ThreadId
 import com.websarva.wings.android.slevo.ui.navigation.AppRoute
+import com.websarva.wings.android.slevo.ui.navigation.navigateToThread
 import com.websarva.wings.android.slevo.ui.theme.BookmarkColor
 import com.websarva.wings.android.slevo.ui.theme.bookmarkColor
 
@@ -84,15 +85,10 @@ fun OpenThreadsList(
                                     threadTitle = tab.title,
                                     resCount = tab.resCount
                                 )
-                                tabsViewModel?.let { viewModel ->
-                                    viewModel.ensureThreadTab(route).let { index ->
-                                        if (index >= 0) {
-                                            viewModel.setThreadCurrentPage(index)
-                                        }
-                                    }
-                                }
-                                navController.navigate(route) {
-                                    launchSingleTop = true
+                                navController.navigateToThread(
+                                    route = route,
+                                    tabsViewModel = tabsViewModel,
+                                ) {
                                     restoreState = true
                                 }
                             }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabScreenContent.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabScreenContent.kt
@@ -22,6 +22,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavHostController
 import com.websarva.wings.android.slevo.R
 import com.websarva.wings.android.slevo.ui.navigation.AppRoute
+import com.websarva.wings.android.slevo.ui.navigation.navigateToBoard
+import com.websarva.wings.android.slevo.ui.navigation.navigateToThread
 import com.websarva.wings.android.slevo.ui.util.parseBoardUrl
 import com.websarva.wings.android.slevo.ui.util.parseThreadUrl
 
@@ -80,12 +82,10 @@ fun TabScreenContent(
                             boardName = board,
                             threadTitle = url
                         )
-                        tabsViewModel.ensureThreadTab(route).let { index ->
-                            if (index >= 0) {
-                                tabsViewModel.setThreadCurrentPage(index)
-                            }
-                        }
-                        navController.navigate(route) { launchSingleTop = true }
+                        navController.navigateToThread(
+                            route = route,
+                            tabsViewModel = tabsViewModel,
+                        )
                     } else {
                         parseBoardUrl(url)?.let { (host, board) ->
                             val boardUrl = "https://$host/$board/"
@@ -93,12 +93,10 @@ fun TabScreenContent(
                                 boardName = boardUrl,
                                 boardUrl = boardUrl
                             )
-                            tabsViewModel.ensureBoardTab(route).let { index ->
-                                if (index >= 0) {
-                                    tabsViewModel.setBoardCurrentPage(index)
-                                }
-                            }
-                            navController.navigate(route) { launchSingleTop = true }
+                            navController.navigateToBoard(
+                                route = route,
+                                tabsViewModel = tabsViewModel,
+                            )
                         }
                     }
                     showUrlDialog = false

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/components/ThreadInfoBottomSheet.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/components/ThreadInfoBottomSheet.kt
@@ -50,6 +50,7 @@ import com.websarva.wings.android.slevo.data.model.NgType
 import com.websarva.wings.android.slevo.ui.common.CopyDialog
 import com.websarva.wings.android.slevo.ui.common.CopyItem
 import com.websarva.wings.android.slevo.ui.navigation.AppRoute
+import com.websarva.wings.android.slevo.ui.navigation.navigateToBoard
 import com.websarva.wings.android.slevo.ui.thread.dialog.NgDialogRoute
 import com.websarva.wings.android.slevo.ui.common.LabeledIconButton
 import com.websarva.wings.android.slevo.ui.tabs.TabsViewModel
@@ -90,16 +91,10 @@ fun ThreadInfoBottomSheet(
                         boardName = boardInfo.name,
                         boardUrl = boardInfo.url
                     )
-                    tabsViewModel?.let { viewModel ->
-                        viewModel.ensureBoardTab(route).let { index ->
-                            if (index >= 0) {
-                                viewModel.setBoardCurrentPage(index)
-                            }
-                        }
-                    }
-                    navController.navigate(route) {
-                        launchSingleTop = true
-                    }
+                    navController.navigateToBoard(
+                        route = route,
+                        tabsViewModel = tabsViewModel,
+                    )
                     onDismissRequest()
                 },
                 onOpenBrowserClick = {

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/item/PostItem.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/item/PostItem.kt
@@ -51,6 +51,7 @@ import com.websarva.wings.android.slevo.data.model.DEFAULT_THREAD_LINE_HEIGHT
 import com.websarva.wings.android.slevo.data.model.NgType
 import com.websarva.wings.android.slevo.ui.common.ImageThumbnailGrid
 import com.websarva.wings.android.slevo.ui.navigation.AppRoute
+import com.websarva.wings.android.slevo.ui.navigation.navigateToThread
 import com.websarva.wings.android.slevo.ui.tabs.TabsViewModel
 import com.websarva.wings.android.slevo.ui.theme.idColor
 import com.websarva.wings.android.slevo.ui.theme.replyCountColor
@@ -452,14 +453,10 @@ fun PostItem(
                                                             boardName = board,
                                                             threadTitle = url
                                                         )
-                                                        tabsViewModel?.let { viewModel ->
-                                                            viewModel.ensureThreadTab(route).let { index ->
-                                                                if (index >= 0) {
-                                                                    viewModel.setThreadCurrentPage(index)
-                                                                }
-                                                            }
-                                                        }
-                                                        navController.navigate(route) { launchSingleTop = true }
+                                                        navController.navigateToThread(
+                                                            route = route,
+                                                            tabsViewModel = tabsViewModel,
+                                                        )
                                                     } ?: uriHandler.openUri(url)
                                                 }
                                             highlightedText.getStringAnnotations("REPLY", pos, pos)


### PR DESCRIPTION
## Summary
- add navigation helper extensions for board and thread destinations so screens share the same transition logic
- replace duplicate navigation code in board- and thread-related screens with the new helpers

## Testing
- ./gradlew :app:testDebugUnitTest --console=plain *(fails: `:app:processDebugManifest` cannot find merged manifest in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce841c42cc83329ab11ae050f56530