### PR TITLE
feat: move loading indicator to tab toolbar

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
@@ -182,6 +182,8 @@ fun BoardScaffold(
                         actions = actions,
                         scrollBehavior = barScrollBehavior,
                         onRefreshClick = { viewModel.refreshBoardData() },
+                        isLoading = uiState.isLoading,
+                        loadProgress = uiState.loadProgress,
                         titleStyle = MaterialTheme.typography.titleMedium,
                         titleFontWeight = FontWeight.Normal,
                         titleMaxLines = 1,
@@ -216,7 +218,6 @@ fun BoardScaffold(
                 },
                 isRefreshing = uiState.isLoading,
                 onRefresh = { viewModel.refreshBoardData() },
-                loadProgress = uiState.loadProgress,
                 listState = listState
             )
             if (uiState.showInfoDialog) {

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScreen.kt
@@ -17,15 +17,12 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.ProgressIndicatorDefaults
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.lerp
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
@@ -47,7 +44,6 @@ fun BoardScreen(
     onClick: (ThreadInfo) -> Unit,
     isRefreshing: Boolean,
     onRefresh: () -> Unit,
-    loadProgress: Float,
     listState: LazyListState = rememberLazyListState()
 ) {
     val (momentumMean, momentumStd) = remember(threads) {
@@ -94,17 +90,6 @@ fun BoardScreen(
                 // 各アイテムの下に区切り線を表示
                 HorizontalDivider()
             }
-        }
-        if (isRefreshing) {
-            LinearProgressIndicator(
-                progress = { loadProgress },
-                modifier = Modifier
-                    .align(Alignment.TopCenter)
-                    .fillMaxWidth(),
-                color = ProgressIndicatorDefaults.linearColor,
-                trackColor = ProgressIndicatorDefaults.linearTrackColor,
-                strokeCap = ProgressIndicatorDefaults.LinearStrokeCap,
-            )
         }
     }
 }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/common/TabToolBar.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/common/TabToolBar.kt
@@ -4,6 +4,7 @@ import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -21,7 +22,9 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Text
+import androidx.compose.material3.ProgressIndicatorDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -58,6 +61,8 @@ fun TabToolBar(
     scrollBehavior: BottomAppBarScrollBehavior? = null,
     onTitleClick: (() -> Unit)? = null,
     onRefreshClick: (() -> Unit),
+    isLoading: Boolean = false,
+    loadProgress: Float = 0f,
     titleStyle: TextStyle = MaterialTheme.typography.titleSmall,
     titleFontWeight: FontWeight = FontWeight.Bold,
     titleMaxLines: Int = 2,
@@ -72,6 +77,18 @@ fun TabToolBar(
                 .fillMaxWidth()
                 .padding(vertical = 4.dp),
         ) {
+            if (isLoading) {
+                LinearProgressIndicator(
+                    progress = { loadProgress },
+                    modifier = Modifier
+                        .fillMaxWidth(),
+                    color = ProgressIndicatorDefaults.linearColor,
+                    trackColor = ProgressIndicatorDefaults.linearTrackColor,
+                    strokeCap = ProgressIndicatorDefaults.LinearStrokeCap,
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+            }
+
             val cardModifier = Modifier
                 .fillMaxWidth()
                 .padding(vertical = 4.dp)

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/common/TabToolBar.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/common/TabToolBar.kt
@@ -4,7 +4,6 @@ import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -20,11 +19,11 @@ import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FlexibleBottomAppBar
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.LinearProgressIndicator
-import androidx.compose.material3.Text
 import androidx.compose.material3.ProgressIndicatorDefaults
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -67,106 +66,106 @@ fun TabToolBar(
     titleFontWeight: FontWeight = FontWeight.Bold,
     titleMaxLines: Int = 2,
 ) {
-    FlexibleBottomAppBar(
-        modifier = modifier,
-        expandedHeight = 96.dp,
-        scrollBehavior = scrollBehavior,
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = 4.dp),
+    Box(modifier = modifier.fillMaxWidth()) {
+        FlexibleBottomAppBar(
+            expandedHeight = 96.dp,
+            scrollBehavior = scrollBehavior,
         ) {
-            if (isLoading) {
-                LinearProgressIndicator(
-                    progress = { loadProgress },
-                    modifier = Modifier
-                        .fillMaxWidth(),
-                    color = ProgressIndicatorDefaults.linearColor,
-                    trackColor = ProgressIndicatorDefaults.linearTrackColor,
-                    strokeCap = ProgressIndicatorDefaults.LinearStrokeCap,
-                )
-                Spacer(modifier = Modifier.height(4.dp))
-            }
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 4.dp),
+            ) {
+                val cardModifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 4.dp)
 
-            val cardModifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = 4.dp)
-
-            val cardContent: @Composable () -> Unit = {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    IconButton(onClick = onBookmarkClick) {
-                        if (bookmarkState.isBookmarked) {
-                            val tintColor =
-                                bookmarkState.selectedGroup?.colorName?.let { bookmarkColor(it) }
-                                    ?: LocalContentColor.current
-                            Box {
-                                Icon(
-                                    imageVector = Icons.Filled.Star,
-                                    contentDescription = null,
-                                    tint = tintColor,
-                                )
+                val cardContent: @Composable () -> Unit = {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        IconButton(onClick = onBookmarkClick) {
+                            if (bookmarkState.isBookmarked) {
+                                val tintColor =
+                                    bookmarkState.selectedGroup?.colorName?.let { bookmarkColor(it) }
+                                        ?: LocalContentColor.current
+                                Box {
+                                    Icon(
+                                        imageVector = Icons.Filled.Star,
+                                        contentDescription = null,
+                                        tint = tintColor,
+                                    )
+                                    Icon(
+                                        imageVector = Icons.Outlined.StarOutline,
+                                        contentDescription = stringResource(R.string.bookmark),
+                                    )
+                                }
+                            } else {
                                 Icon(
                                     imageVector = Icons.Outlined.StarOutline,
                                     contentDescription = stringResource(R.string.bookmark),
                                 )
                             }
-                        } else {
+                        }
+                        Text(
+                            text = title,
+                            fontWeight = titleFontWeight,
+                            style = titleStyle,
+                            maxLines = titleMaxLines,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.weight(1f),
+                        )
+                        IconButton(onClick = onRefreshClick) {
                             Icon(
-                                imageVector = Icons.Outlined.StarOutline,
-                                contentDescription = stringResource(R.string.bookmark),
+                                imageVector = Icons.Filled.Refresh,
+                                contentDescription = stringResource(R.string.refresh),
                             )
                         }
                     }
-                    Text(
-                        text = title,
-                        fontWeight = titleFontWeight,
-                        style = titleStyle,
-                        maxLines = titleMaxLines,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.weight(1f),
-                    )
-                    IconButton(onClick = onRefreshClick) {
-                        Icon(
-                            imageVector = Icons.Filled.Refresh,
-                            contentDescription = stringResource(R.string.refresh),
-                        )
+                }
+
+                if (onTitleClick != null) {
+                    Card(
+                        modifier = cardModifier,
+                        onClick = onTitleClick,
+                    ) {
+                        cardContent()
+                    }
+                } else {
+                    Card(modifier = cardModifier) {
+                        cardContent()
                     }
                 }
-            }
 
-            if (onTitleClick != null) {
-                Card(
-                    modifier = cardModifier,
-                    onClick = onTitleClick,
+                Spacer(modifier = Modifier.padding(2.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceEvenly,
                 ) {
-                    cardContent()
-                }
-            } else {
-                Card(modifier = cardModifier) {
-                    cardContent()
-                }
-            }
-
-            Spacer(modifier = Modifier.padding(2.dp))
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceEvenly,
-            ) {
-                actions.forEach { action ->
-                    IconButton(onClick = action.onClick) {
-                        Icon(
-                            imageVector = action.icon,
-                            contentDescription = stringResource(action.contentDescriptionRes),
-                            tint = action.tint ?: LocalContentColor.current,
-                        )
+                    actions.forEach { action ->
+                        IconButton(onClick = action.onClick) {
+                            Icon(
+                                imageVector = action.icon,
+                                contentDescription = stringResource(action.contentDescriptionRes),
+                                tint = action.tint ?: LocalContentColor.current,
+                            )
+                        }
                     }
                 }
             }
+        }
+        if (isLoading) {
+            LinearProgressIndicator(
+                progress = { loadProgress },
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .fillMaxWidth(),
+                color = ProgressIndicatorDefaults.linearColor,
+                trackColor = ProgressIndicatorDefaults.linearTrackColor,
+                strokeCap = ProgressIndicatorDefaults.LinearStrokeCap,
+            )
         }
     }
 }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/components/ThreadToolBar.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/components/ThreadToolBar.kt
@@ -89,6 +89,8 @@ fun ThreadToolBar(
         scrollBehavior = scrollBehavior,
         onTitleClick = onThreadInfoClick,
         onRefreshClick = onRefreshClick,
+        isLoading = uiState.isLoading,
+        loadProgress = uiState.loadProgress,
         titleStyle = MaterialTheme.typography.titleSmall,
         titleFontWeight = FontWeight.Bold,
         titleMaxLines = 2,

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
@@ -21,8 +21,6 @@ import androidx.compose.material3.ContainedLoadingIndicator
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.LinearProgressIndicator
-import androidx.compose.material3.ProgressIndicatorDefaults
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -375,18 +373,6 @@ fun ThreadScreen(
             searchQuery = uiState.searchQuery,
             onClose = { if (popupStack.isNotEmpty()) popupStack.removeAt(popupStack.lastIndex) }
         )
-
-        if (uiState.isLoading) {
-            LinearProgressIndicator(
-                progress = { uiState.loadProgress },
-                modifier = Modifier
-                    .align(Alignment.TopCenter)
-                    .fillMaxWidth(),
-                color = ProgressIndicatorDefaults.linearColor,
-                trackColor = ProgressIndicatorDefaults.linearTrackColor,
-                strokeCap = ProgressIndicatorDefaults.LinearStrokeCap,
-            )
-        }
 
         val arrowRotation by animateFloatAsState(
             targetValue = if (triggerRefresh) 180f else (overscroll / refreshThresholdPx).coerceIn(


### PR DESCRIPTION
## Summary
- add a linear progress indicator to the shared TabToolBar component
- pass board and thread loading state into the toolbar so screens no longer render their own indicators

## Testing
- ./gradlew :app:testDebugUnitTest --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68ce8a4bacd8833292eabb2750c291da