### PR TITLE
feat: center board toolbar title

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import com.websarva.wings.android.slevo.R
@@ -185,8 +186,9 @@ fun BoardScaffold(
                         isLoading = uiState.isLoading,
                         loadProgress = uiState.loadProgress,
                         titleStyle = MaterialTheme.typography.titleMedium,
-                        titleFontWeight = FontWeight.Normal,
+                        titleFontWeight = FontWeight.Bold,
                         titleMaxLines = 1,
+                        titleTextAlign = TextAlign.Center,
                     )
                 }
             }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/common/TabToolBar.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/common/TabToolBar.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -65,6 +66,7 @@ fun TabToolBar(
     titleStyle: TextStyle = MaterialTheme.typography.titleSmall,
     titleFontWeight: FontWeight = FontWeight.Bold,
     titleMaxLines: Int = 2,
+    titleTextAlign: TextAlign = TextAlign.Start,
 ) {
     Box(modifier = modifier.fillMaxWidth()) {
         FlexibleBottomAppBar(
@@ -114,6 +116,7 @@ fun TabToolBar(
                             style = titleStyle,
                             maxLines = titleMaxLines,
                             overflow = TextOverflow.Ellipsis,
+                            textAlign = titleTextAlign,
                             modifier = Modifier.weight(1f),
                         )
                         IconButton(onClick = onRefreshClick) {


### PR DESCRIPTION
## Summary
- add a text alignment option to the shared TabToolBar component
- center and bold the board screen toolbar title using the new option

## Testing
- ./gradlew :app:lintDebug --console=plain *(fails: existing Instantiatable lint error for MainActivity)*

------
https://chatgpt.com/codex/tasks/task_e_68ce98fe5a188332899ea284e7db23a2