### PR TITLE
Restrict RouteScaffold pager swipe to toolbar

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/common/SearchBottomBar.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/common/SearchBottomBar.kt
@@ -9,6 +9,9 @@ import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.draggable
+import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -112,8 +115,13 @@ fun SearchBottomBar(
         keyboardController?.show()
     }
 
+    val swipeBlockerState = rememberDraggableState { _ -> }
     FlexibleBottomAppBar(
-        modifier = modifier,
+        modifier = modifier.draggable(
+            state = swipeBlockerState,
+            orientation = Orientation.Horizontal,
+            enabled = true
+        ),
     ) {
         Card {
             Row(

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/RouteScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/RouteScaffold.kt
@@ -1,5 +1,8 @@
 package com.websarva.wings.android.slevo.ui.navigation
 
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.draggable
+import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -151,6 +154,7 @@ fun <TabInfo : Any, UiState : BaseUiState<UiState>, ViewModel : BaseViewModel<Ui
             }
 
             val bottomBehavior = bottomBarScrollBehavior?.invoke(listState)
+            val swipeBlockerState = rememberDraggableState { _ -> }
             Scaffold(
                 modifier = Modifier
                     .let { modifier ->
@@ -159,12 +163,19 @@ fun <TabInfo : Any, UiState : BaseUiState<UiState>, ViewModel : BaseViewModel<Ui
                     },
                 bottomBar = { bottomBar(viewModel, uiState, bottomBehavior) }
             ) { innerPadding ->
+                val contentModifier = Modifier
+                    .padding(innerPadding)
+                    .draggable(
+                        state = swipeBlockerState,
+                        orientation = Orientation.Horizontal,
+                        enabled = true
+                    )
                 // 各画面の実際のコンテンツを呼び出す
                 content(
                     viewModel,
                     uiState,
                     listState,
-                    Modifier.padding(innerPadding),
+                    contentModifier,
                     navController
                 )
 


### PR DESCRIPTION
## Summary
- consume horizontal drags in the page body so RouteScaffold's pager only reacts to swipes over the toolbar area
- consume horizontal drags in the search bottom bar so it no longer triggers pager switches

## Testing
- ./gradlew :app:assembleDebug --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68ce9ec4f94c8332b72b7461916c850e