### PR TITLE
fix: disable pager swipe during search mode

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/RouteScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/RouteScaffold.kt
@@ -108,9 +108,20 @@ fun <TabInfo : Any, UiState : BaseUiState<UiState>, ViewModel : BaseViewModel<Ui
         val bookmarkSheetState = rememberModalBottomSheetState()
         val tabListSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
+        val pagerUserScrollEnabled = run {
+            val currentViewModel = getViewModel(currentTabInfo)
+            val currentUiState = currentViewModel.uiState.collectAsState().value
+            when (currentUiState) {
+                is BoardUiState -> !currentUiState.isSearchActive
+                is ThreadUiState -> !currentUiState.isSearchMode
+                else -> true
+            }
+        }
+
         HorizontalPager(
             state = pagerState,
-            key = { page -> getKey(tabs[page]) }
+            key = { page -> getKey(tabs[page]) },
+            userScrollEnabled = pagerUserScrollEnabled
         ) { page ->
             val tab = tabs[page]
             val viewModel = getViewModel(tab)


### PR DESCRIPTION
## Summary
- disable RouteScaffold's HorizontalPager user scrolling while board or thread screens are in search mode to prevent accidental tab changes

## Testing
- ./gradlew :app:testDebugUnitTest --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d20a7761c08332bc2ddf7bf1f05211