### PR TITLE
Hoist tab list sheet state out of RouteScaffold pager

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
@@ -113,7 +113,7 @@ fun BoardScaffold(
         currentPage = currentPage,
         onPageChange = { tabsViewModel.setBoardCurrentPage(it) },
         bottomBarScrollBehavior = { listState -> rememberBottomBarShowOnBottomBehavior(listState) },
-        bottomBar = { viewModel, uiState, barScrollBehavior ->
+        bottomBar = { viewModel, uiState, barScrollBehavior, openTabListSheet ->
             val keyboardController = LocalSoftwareKeyboardController.current
             val focusManager = LocalFocusManager.current
             val isThreeButtonBar = remember { isThreeButtonNavigation(context) }
@@ -138,7 +138,7 @@ fun BoardScaffold(
                 TabToolBarAction(
                     icon = Icons.Filled.CropSquare,
                     contentDescriptionRes = R.string.open_tablist,
-                    onClick = { viewModel.openTabListSheet() },
+                    onClick = openTabListSheet,
                 ),
                 TabToolBarAction(
                     icon = Icons.Filled.Create,

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardUiState.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardUiState.kt
@@ -29,15 +29,12 @@ data class BoardUiState(
     val resetScroll: Boolean = false,
     val loadProgress: Float = 0f,
     override val isLoading: Boolean = false,
-    override val showTabListSheet: Boolean = false,
 ) : BaseUiState<BoardUiState> {
     override fun copyState(
         isLoading: Boolean,
-        showTabListSheet: Boolean
     ): BoardUiState {
         return this.copy(
             isLoading = isLoading,
-            showTabListSheet = showTabListSheet
         )
     }
 }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/common/BaseUiState.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/common/BaseUiState.kt
@@ -2,11 +2,9 @@ package com.websarva.wings.android.slevo.ui.common
 
 interface BaseUiState<T> where T : BaseUiState<T> {
     val isLoading: Boolean
-    val showTabListSheet: Boolean
 
     // 共通プロパティを更新して、自身の具象型の新しいインスタンスを返すメソッド
     fun copyState(
         isLoading: Boolean = this.isLoading,
-        showTabListSheet: Boolean = this.showTabListSheet
     ): T
 }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/common/BaseViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/common/BaseViewModel.kt
@@ -33,14 +33,6 @@ abstract class BaseViewModel<S> : ViewModel() where S : BaseUiState<S> {
      */
     protected abstract suspend fun loadData(isRefresh: Boolean)
 
-    fun openTabListSheet() {
-        _uiState.update { it.copyState(showTabListSheet = true) }
-    }
-
-    fun closeTabListSheet() {
-        _uiState.update { it.copyState(showTabListSheet = false) }
-    }
-
     fun release() {
         onCleared()
     }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -124,7 +124,7 @@ fun ThreadScaffold(
         currentPage = currentPage,
         onPageChange = { tabsViewModel.setThreadCurrentPage(it) },
         bottomBarScrollBehavior = { listState -> rememberBottomBarShowOnBottomBehavior(listState) },
-        bottomBar = { viewModel, uiState, barScrollBehavior ->
+        bottomBar = { viewModel, uiState, barScrollBehavior, openTabListSheet ->
             val context = LocalContext.current
             val isThreeButtonBar = remember { isThreeButtonNavigation(context) }
             val modifier = if (isThreeButtonBar) {
@@ -164,7 +164,7 @@ fun ThreadScaffold(
                         isTreeSort = uiState.sortType == ThreadSortType.TREE,
                         onSortClick = { viewModel.toggleSortType() },
                         onPostClick = { viewModel.showPostDialog() },
-                        onTabListClick = { viewModel.openTabListSheet() },
+                        onTabListClick = openTabListSheet,
                         onRefreshClick = { viewModel.reloadThread() },
                         onSearchClick = { viewModel.startSearch() },
                         onBookmarkClick = { viewModel.openBookmarkSheet() },

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/state/ThreadUiState.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/state/ThreadUiState.kt
@@ -18,7 +18,6 @@ data class ThreadUiState(
     val boardInfo: BoardInfo = BoardInfo(0, "", ""),
     val singleBookmarkState: SingleBookmarkState = SingleBookmarkState(),
     override val isLoading: Boolean = false,
-    override val showTabListSheet: Boolean = false,
     val showThreadInfoSheet: Boolean = false,
     val showMoreSheet: Boolean = false,
     val showDisplaySettingsSheet: Boolean = false,
@@ -47,11 +46,9 @@ data class ThreadUiState(
 ) : BaseUiState<ThreadUiState> {
     override fun copyState(
         isLoading: Boolean,
-        showTabListSheet: Boolean
     ): ThreadUiState {
         return this.copy(
             isLoading = isLoading,
-            showTabListSheet = showTabListSheet
         )
     }
 }


### PR DESCRIPTION
## Summary
- remove the tab list sheet flag from BaseUiState and BaseViewModel
- hoist tab list sheet state in RouteScaffold and show the sheet outside the pager
- update board and thread scaffolds to trigger the shared sheet through a callback

## Testing
- ./gradlew :app:testDebugUnitTest --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d23bf2cd0c8332b9bea021e00ed11a