### PR TITLE
Add thread scrollbar toggle setting

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -168,6 +168,7 @@ dependencies {
 
     // compose.foundation
     implementation(libs.androidx.foundation)
+    implementation(libs.lazycolumn.scrollbar)
 
     // Telephoto
     implementation(libs.zoomable.image.coil3)

--- a/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/SettingsLocalDataSource.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/SettingsLocalDataSource.kt
@@ -15,6 +15,12 @@ interface SettingsLocalDataSource {
     /** レスのデフォルト並び順を保存する */
     suspend fun setTreeSort(enabled: Boolean)
 
+    /** スレッド画面のミニマップ付きスクロールバーを表示するかを監視する */
+    fun observeIsThreadMinimapScrollbarEnabled(): Flow<Boolean>
+
+    /** スレッド画面のミニマップ付きスクロールバーを表示するかを保存する */
+    suspend fun setThreadMinimapScrollbarEnabled(enabled: Boolean)
+
     /** レス表示の文字倍率を監視する */
     fun observeTextScale(): Flow<Float>
 

--- a/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/impl/SettingsLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/impl/SettingsLocalDataSourceImpl.kt
@@ -16,6 +16,7 @@ import javax.inject.Singleton
 private val Context.dataStore by preferencesDataStore(name = "settings")
 private val DARK_MODE_KEY = booleanPreferencesKey("dark_mode")
 private val TREE_SORT_KEY = booleanPreferencesKey("tree_sort")
+private val THREAD_MINIMAP_SCROLLBAR_KEY = booleanPreferencesKey("thread_minimap_scrollbar")
 private val TEXT_SCALE_KEY = floatPreferencesKey("text_scale")
 private val INDIVIDUAL_TEXT_SCALE_KEY = booleanPreferencesKey("individual_text_scale")
 private val HEADER_TEXT_SCALE_KEY = floatPreferencesKey("header_text_scale")
@@ -43,6 +44,16 @@ class SettingsLocalDataSourceImpl @Inject constructor(
     override suspend fun setTreeSort(enabled: Boolean) {
         context.dataStore.edit { prefs ->
             prefs[TREE_SORT_KEY] = enabled
+        }
+    }
+
+    override fun observeIsThreadMinimapScrollbarEnabled(): Flow<Boolean> =
+        context.dataStore.data
+            .map { prefs -> prefs[THREAD_MINIMAP_SCROLLBAR_KEY] ?: true }
+
+    override suspend fun setThreadMinimapScrollbarEnabled(enabled: Boolean) {
+        context.dataStore.edit { prefs ->
+            prefs[THREAD_MINIMAP_SCROLLBAR_KEY] = enabled
         }
     }
 

--- a/app/src/main/java/com/websarva/wings/android/slevo/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/repository/SettingsRepository.kt
@@ -21,6 +21,12 @@ class SettingsRepository @Inject constructor(
     suspend fun setTreeSort(enabled: Boolean) =
         local.setTreeSort(enabled)
 
+    fun observeIsThreadMinimapScrollbarEnabled(): Flow<Boolean> =
+        local.observeIsThreadMinimapScrollbarEnabled()
+
+    suspend fun setThreadMinimapScrollbarEnabled(enabled: Boolean) =
+        local.setThreadMinimapScrollbarEnabled(enabled)
+
     fun observeTextScale(): Flow<Float> =
         local.observeTextScale()
 

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/settings/SettingsThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/settings/SettingsThreadScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -63,6 +64,26 @@ fun SettingsThreadScreen(
                     RadioButton(
                         selected = uiState.isTreeSort,
                         onClick = { viewModel.updateSort(true) }
+                    )
+                }
+            )
+            HorizontalDivider()
+            Text(
+                text = stringResource(R.string.thread_scrollbar_settings),
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)
+            )
+            ListItem(
+                modifier = Modifier.clickable {
+                    viewModel.updateMinimapScrollbar(!uiState.showMinimapScrollbar)
+                },
+                headlineContent = { Text(stringResource(R.string.show_minimap_scrollbar)) },
+                supportingContent = {
+                    Text(stringResource(R.string.show_minimap_scrollbar_description))
+                },
+                trailingContent = {
+                    Switch(
+                        checked = uiState.showMinimapScrollbar,
+                        onCheckedChange = { viewModel.updateMinimapScrollbar(it) }
                     )
                 }
             )

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/settings/SettingsThreadViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/settings/SettingsThreadViewModel.kt
@@ -24,6 +24,11 @@ class SettingsThreadViewModel @Inject constructor(
                 _uiState.update { it.copy(isTreeSort = isTree) }
             }
         }
+        viewModelScope.launch {
+            repository.observeIsThreadMinimapScrollbarEnabled().collect { enabled ->
+                _uiState.update { it.copy(showMinimapScrollbar = enabled) }
+            }
+        }
     }
 
     fun updateSort(isTree: Boolean) {
@@ -31,8 +36,15 @@ class SettingsThreadViewModel @Inject constructor(
             repository.setTreeSort(isTree)
         }
     }
+
+    fun updateMinimapScrollbar(enabled: Boolean) {
+        viewModelScope.launch {
+            repository.setThreadMinimapScrollbarEnabled(enabled)
+        }
+    }
 }
 
 data class SettingsThreadUiState(
-    val isTreeSort: Boolean = false
+    val isTreeSort: Boolean = false,
+    val showMinimapScrollbar: Boolean = true,
 )

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
@@ -3,15 +3,16 @@ package com.websarva.wings.android.slevo.ui.thread.screen
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -60,7 +61,7 @@ import com.websarva.wings.android.slevo.ui.thread.state.ThreadUiState
 import com.websarva.wings.android.slevo.ui.tabs.TabsViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
-import androidx.compose.foundation.gestures.scrollBy
+import my.nanihadesuka.compose.LazyColumnScrollbar
 import kotlin.math.min
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
@@ -193,154 +194,172 @@ fun ThreadScreen(
     }
 
     Box(modifier = modifier.fillMaxSize()) {
-        Row(modifier = Modifier.fillMaxSize()) {
-            LazyColumn(
-                modifier = Modifier
-                    .weight(1f)
-                    .nestedScroll(nestedScrollConnection),
-                state = listState,
-            ) {
-                if (visiblePosts.isNotEmpty()) {
-                    val firstIndent = if (uiState.sortType == ThreadSortType.TREE) {
-                        visiblePosts.first().depth
-                    } else {
-                        0
-                    }
-                    item(key = "thread_header_divider") {
-                        HorizontalDivider(modifier = Modifier.padding(start = 16.dp * firstIndent))
-                    }
+        val lazyColumnContent: LazyListScope.() -> Unit = {
+            if (visiblePosts.isNotEmpty()) {
+                val firstIndent = if (uiState.sortType == ThreadSortType.TREE) {
+                    visiblePosts.first().depth
+                } else {
+                    0
                 }
-
-                itemsIndexed(
-                    items = visiblePosts,
-                    key = { _, display -> "${display.num}_${display.dimmed}" }
-                ) { idx, display ->
-                    val postNum = display.num
-                    val post = display.post
-                    val index = postNum - 1
-                    val indent = if (uiState.sortType == ThreadSortType.TREE) {
-                        display.depth
-                    } else {
-                        0
-                    }
-                    val nextIndent = if (idx + 1 < visiblePosts.size) {
-                        if (uiState.sortType == ThreadSortType.TREE) {
-                            visiblePosts[idx + 1].depth
-                        } else {
-                            0
-                        }
-                    } else {
-                        0
-                    }
-
-                    // 再構成を発生させない座標ホルダ（クリック時のみ参照）
-                    data class OffsetHolder(var value: IntOffset)
-
-                    val itemOffsetHolder = remember { OffsetHolder(IntOffset.Zero) }
-                    Column {
-                        if (firstAfterIndex != -1 && idx == firstAfterIndex) {
-                            NewArrivalBar()
-                        }
-                        PostItem(
-                            modifier = Modifier.onGloballyPositioned { coords ->
-                                val pos = coords.positionInWindow()
-                                itemOffsetHolder.value = IntOffset(pos.x.toInt(), pos.y.toInt())
-                            },
-                            post = post,
-                            postNum = postNum,
-                            idIndex = uiState.idIndexList.getOrElse(index) { 1 },
-                            idTotal = if (post.id.isBlank()) 1 else uiState.idCountMap[post.id]
-                                ?: 1,
-                            navController = navController,
-                            tabsViewModel = tabsViewModel,
-                            boardName = uiState.boardInfo.name,
-                            boardId = uiState.boardInfo.boardId,
-                            headerTextScale = if (uiState.isIndividualTextScale) uiState.headerTextScale else uiState.textScale * 0.85f,
-                            bodyTextScale = if (uiState.isIndividualTextScale) uiState.bodyTextScale else uiState.textScale,
-                            lineHeight = if (uiState.isIndividualTextScale) uiState.lineHeight else DEFAULT_THREAD_LINE_HEIGHT,
-                            indentLevel = indent,
-                            replyFromNumbers = uiState.replySourceMap[postNum] ?: emptyList(),
-                            isMyPost = postNum in uiState.myPostNumbers,
-                            dimmed = display.dimmed,
-                            searchQuery = uiState.searchQuery,
-                            onReplyFromClick = { nums ->
-                                val offset = if (popupStack.isEmpty()) {
-                                    itemOffsetHolder.value
-                                } else {
-                                    val last = popupStack.last()
-                                    IntOffset(
-                                        last.offset.x,
-                                        (last.offset.y - last.size.height).coerceAtLeast(0)
-                                    )
-                                }
-                                val targets = nums.filterNot { it in ngNumbers }.mapNotNull { num ->
-                                    posts.getOrNull(num - 1)
-                                }
-                                if (targets.isNotEmpty()) {
-                                    popupStack.add(PopupInfo(targets, offset))
-                                }
-                            },
-                            onReplyClick = { num ->
-                                if (num in 1..posts.size && num !in ngNumbers) {
-                                    val target = posts[num - 1]
-                                    val baseOffset = itemOffsetHolder.value
-                                    val offset = if (popupStack.isEmpty()) {
-                                        baseOffset
-                                    } else {
-                                        val last = popupStack.last()
-                                        IntOffset(
-                                            last.offset.x,
-                                            (last.offset.y - last.size.height).coerceAtLeast(0)
-                                        )
-                                    }
-                                    popupStack.add(PopupInfo(listOf(target), offset))
-                                }
-                            },
-                            onMenuReplyClick = { onReplyToPost(it) },
-                            onIdClick = { id ->
-                                val offset = if (popupStack.isEmpty()) {
-                                    itemOffsetHolder.value
-                                } else {
-                                    val last = popupStack.last()
-                                    IntOffset(
-                                        last.offset.x,
-                                        (last.offset.y - last.size.height).coerceAtLeast(0)
-                                    )
-                                }
-                                val targets = posts.mapIndexedNotNull { idx, p ->
-                                    val num = idx + 1
-                                    if (p.id == id && num !in ngNumbers) p else null
-                                }
-                                if (targets.isNotEmpty()) {
-                                    popupStack.add(PopupInfo(targets, offset))
-                                }
-                            }
-                        )
-                        HorizontalDivider(
-                            modifier = Modifier.padding(
-                                start = 16.dp * min(
-                                    indent,
-                                    nextIndent
-                                )
-                            )
-                        )
-                    }
+                item(key = "thread_header_divider") {
+                    HorizontalDivider(modifier = Modifier.padding(start = 16.dp * firstIndent))
                 }
             }
-            // 中央の区切り線
-            VerticalDivider()
 
-            // 右側: 固定の勢いバー
-            MomentumBar(
-                modifier = Modifier
-                    .width(24.dp)
-                    .fillMaxHeight(),
-                posts = displayPosts,
-                replyCounts = replyCounts,
-                lazyListState = listState,
-                firstAfterIndex = firstAfterIndex,
-                myPostNumbers = uiState.myPostNumbers
-            )
+            itemsIndexed(
+                items = visiblePosts,
+                key = { _, display -> "${display.num}_${display.dimmed}" }
+            ) { idx, display ->
+                val postNum = display.num
+                val post = display.post
+                val index = postNum - 1
+                val indent = if (uiState.sortType == ThreadSortType.TREE) {
+                    display.depth
+                } else {
+                    0
+                }
+                val nextIndent = if (idx + 1 < visiblePosts.size) {
+                    if (uiState.sortType == ThreadSortType.TREE) {
+                        visiblePosts[idx + 1].depth
+                    } else {
+                        0
+                    }
+                } else {
+                    0
+                }
+
+                // 再構成を発生させない座標ホルダ（クリック時のみ参照）
+                data class OffsetHolder(var value: IntOffset)
+
+                val itemOffsetHolder = remember { OffsetHolder(IntOffset.Zero) }
+                Column {
+                    if (firstAfterIndex != -1 && idx == firstAfterIndex) {
+                        NewArrivalBar()
+                    }
+                    PostItem(
+                        modifier = Modifier.onGloballyPositioned { coords ->
+                            val pos = coords.positionInWindow()
+                            itemOffsetHolder.value = IntOffset(pos.x.toInt(), pos.y.toInt())
+                        },
+                        post = post,
+                        postNum = postNum,
+                        idIndex = uiState.idIndexList.getOrElse(index) { 1 },
+                        idTotal = if (post.id.isBlank()) 1 else uiState.idCountMap[post.id]
+                            ?: 1,
+                        navController = navController,
+                        tabsViewModel = tabsViewModel,
+                        boardName = uiState.boardInfo.name,
+                        boardId = uiState.boardInfo.boardId,
+                        headerTextScale = if (uiState.isIndividualTextScale) uiState.headerTextScale else uiState.textScale * 0.85f,
+                        bodyTextScale = if (uiState.isIndividualTextScale) uiState.bodyTextScale else uiState.textScale,
+                        lineHeight = if (uiState.isIndividualTextScale) uiState.lineHeight else DEFAULT_THREAD_LINE_HEIGHT,
+                        indentLevel = indent,
+                        replyFromNumbers = uiState.replySourceMap[postNum] ?: emptyList(),
+                        isMyPost = postNum in uiState.myPostNumbers,
+                        dimmed = display.dimmed,
+                        searchQuery = uiState.searchQuery,
+                        onReplyFromClick = { nums ->
+                            val offset = if (popupStack.isEmpty()) {
+                                itemOffsetHolder.value
+                            } else {
+                                val last = popupStack.last()
+                                IntOffset(
+                                    last.offset.x,
+                                    (last.offset.y - last.size.height).coerceAtLeast(0)
+                                )
+                            }
+                            val targets = nums.filterNot { it in ngNumbers }.mapNotNull { num ->
+                                posts.getOrNull(num - 1)
+                            }
+                            if (targets.isNotEmpty()) {
+                                popupStack.add(PopupInfo(targets, offset))
+                            }
+                        },
+                        onReplyClick = { num ->
+                            if (num in 1..posts.size && num !in ngNumbers) {
+                                val target = posts[num - 1]
+                                val baseOffset = itemOffsetHolder.value
+                                val offset = if (popupStack.isEmpty()) {
+                                    baseOffset
+                                } else {
+                                    val last = popupStack.last()
+                                    IntOffset(
+                                        last.offset.x,
+                                        (last.offset.y - last.size.height).coerceAtLeast(0)
+                                    )
+                                }
+                                popupStack.add(PopupInfo(listOf(target), offset))
+                            }
+                        },
+                        onMenuReplyClick = { onReplyToPost(it) },
+                        onIdClick = { id ->
+                            val offset = if (popupStack.isEmpty()) {
+                                itemOffsetHolder.value
+                            } else {
+                                val last = popupStack.last()
+                                IntOffset(
+                                    last.offset.x,
+                                    (last.offset.y - last.size.height).coerceAtLeast(0)
+                                )
+                            }
+                            val targets = posts.mapIndexedNotNull { idx, p ->
+                                val num = idx + 1
+                                if (p.id == id && num !in ngNumbers) p else null
+                            }
+                            if (targets.isNotEmpty()) {
+                                popupStack.add(PopupInfo(targets, offset))
+                            }
+                        }
+                    )
+                    HorizontalDivider(
+                        modifier = Modifier.padding(
+                            start = 16.dp * min(
+                                indent,
+                                nextIndent
+                            )
+                        )
+                    )
+                }
+            }
+        }
+
+        if (uiState.showMinimapScrollbar) {
+            Row(modifier = Modifier.fillMaxSize()) {
+                LazyColumn(
+                    modifier = Modifier
+                        .weight(1f)
+                        .nestedScroll(nestedScrollConnection),
+                    state = listState,
+                    content = lazyColumnContent
+                )
+                // 中央の区切り線
+                VerticalDivider()
+
+                // 右側: 固定の勢いバー
+                MomentumBar(
+                    modifier = Modifier
+                        .width(24.dp)
+                        .fillMaxHeight(),
+                    posts = displayPosts,
+                    replyCounts = replyCounts,
+                    lazyListState = listState,
+                    firstAfterIndex = firstAfterIndex,
+                    myPostNumbers = uiState.myPostNumbers
+                )
+            }
+        } else {
+            LazyColumnScrollbar(
+                modifier = Modifier.fillMaxSize(),
+                state = listState,
+            ) {
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .nestedScroll(nestedScrollConnection),
+                    state = listState,
+                    content = lazyColumnContent
+                )
+            }
         }
 
         if (popupStack.isNotEmpty()) {

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/state/ThreadUiState.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/state/ThreadUiState.kt
@@ -36,6 +36,7 @@ data class ThreadUiState(
     val firstNewResNo: Int? = null,
     val prevResCount: Int = 0,
     val isAutoScroll: Boolean = false,
+    val showMinimapScrollbar: Boolean = true,
     val textScale: Float = 1f,
     val isIndividualTextScale: Boolean = false,
     val headerTextScale: Float = 0.85f,

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/viewmodel/ThreadViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/viewmodel/ThreadViewModel.kt
@@ -108,6 +108,11 @@ class ThreadViewModel @AssistedInject constructor(
                 _uiState.update { it.copy(lineHeight = height) }
             }
         }
+        viewModelScope.launch {
+            settingsRepository.observeIsThreadMinimapScrollbarEnabled().collect { enabled ->
+                _uiState.update { it.copy(showMinimapScrollbar = enabled) }
+            }
+        }
     }
 
     internal val _postUiState = MutableStateFlow(PostUiState())

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,6 +87,9 @@
     <string name="reset">リセット</string>
 
     <string name="default_thread_sort_order">レスのデフォルトの並び順</string>
+    <string name="thread_scrollbar_settings">スクロールバー</string>
+    <string name="show_minimap_scrollbar">ミニマップ付きスクロールバーを表示する</string>
+    <string name="show_minimap_scrollbar_description">スレッド画面右側のミニマップ付きスクロールバーを有効にします</string>
 
     <string name="about_this_app">このアプリについて</string>
     <string name="version_name_label">バージョン: %1$s</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ coilComposeVersion = "3.2.0"
 datastorePreferences = "1.1.5"
 foundation = "1.8.0"
 foundationPager = "<compose_version>"
+lazyColumnScrollbar = "2.2.0"
 hiltAndroid = "2.51.1"
 hiltNavigationCompose = "1.2.0"
 jsoup = "1.17.2"
@@ -90,6 +91,7 @@ okhttp3-okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
 zoomable-image-coil3 = { module = "me.saket.telephoto:zoomable-image-coil3", version.ref = "zoomableImageCoil3" }
 desugar-jdk-libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugarJdkLibs" }
+lazycolumn-scrollbar = { module = "com.github.nanihadesuka:LazyColumnScrollbar", version.ref = "lazyColumnScrollbar" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven("https://jitpack.io")
     }
 }
 


### PR DESCRIPTION
## Summary
- add a DataStore flag and repository APIs to persist the thread minimap scrollbar preference
- expose the preference on SettingsThreadScreen with new copy and wiring in the view model
- switch ThreadScreen to LazyColumnScrollbar when the minimap is disabled and add the library dependency via JitPack

## Testing
- ./gradlew :app:testDebugUnitTest *(fails: Failed to find target with hash string 'android-35')*

------
https://chatgpt.com/codex/tasks/task_e_68d238188d088332904e235eee312017