### PR TITLE
Add gesture settings screen

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/AppNavGraph.kt
@@ -258,6 +258,9 @@ sealed class AppRoute {
     data object SettingsCookie : AppRoute()
 
     @Serializable
+    data object SettingsGesture : AppRoute()
+
+    @Serializable
     data object Tabs : AppRoute()
 
 
@@ -284,6 +287,7 @@ sealed class AppRoute {
         const val SETTINGS_NG = "SettingsNg"
         const val SETTINGS_THREAD = "SettingsThread"
         const val SETTINGS_COOKIE = "SettingsCookie"
+        const val SETTINGS_GESTURE = "SettingsGesture"
         const val TABS = "Tabs"
         const val HISTORY_LIST = "HistoryList"
         const val ABOUT = "About"

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/SettingsRoute.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/SettingsRoute.kt
@@ -8,6 +8,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
 import com.websarva.wings.android.slevo.ui.settings.SettingsCookieScreen
 import com.websarva.wings.android.slevo.ui.settings.SettingsGeneralScreen
+import com.websarva.wings.android.slevo.ui.settings.SettingsGestureScreen
 import com.websarva.wings.android.slevo.ui.settings.SettingsNgScreen
 import com.websarva.wings.android.slevo.ui.settings.SettingsScreen
 import com.websarva.wings.android.slevo.ui.settings.SettingsThreadScreen
@@ -27,6 +28,7 @@ fun NavGraphBuilder.addSettingsRoute(
         composable<AppRoute.SettingsHome> {
             SettingsScreen(
                 onGeneralClick = { navController.navigate(AppRoute.SettingsGeneral) },
+                onGestureClick = { navController.navigate(AppRoute.SettingsGesture) },
                 onThreadClick = { navController.navigate(AppRoute.SettingsThread) },
                 onNgClick = { navController.navigate(AppRoute.SettingsNg) },
                 onCookieClick = { navController.navigate(AppRoute.SettingsCookie) }
@@ -52,6 +54,11 @@ fun NavGraphBuilder.addSettingsRoute(
         }
         composable<AppRoute.SettingsCookie> {
             SettingsCookieScreen(
+                onNavigateUp = { navController.navigateUp() }
+            )
+        }
+        composable<AppRoute.SettingsGesture> {
+            SettingsGestureScreen(
                 onNavigateUp = { navController.navigateUp() }
             )
         }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/settings/SettingsGestureScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/settings/SettingsGestureScreen.kt
@@ -1,0 +1,150 @@
+package com.websarva.wings.android.slevo.ui.settings
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.websarva.wings.android.slevo.R
+import com.websarva.wings.android.slevo.ui.topbar.SmallTopAppBarScreen
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsGestureScreen(
+    onNavigateUp: () -> Unit,
+    viewModel: SettingsGestureViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    Scaffold(
+        topBar = {
+            SmallTopAppBarScreen(
+                title = stringResource(id = R.string.gesture_settings),
+                onNavigateUp = onNavigateUp,
+            )
+        }
+    ) { innerPadding ->
+        LazyColumn(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize()
+        ) {
+            item {
+                ListItem(
+                    headlineContent = { Text(stringResource(id = R.string.enable_gesture_feature)) },
+                    trailingContent = {
+                        Switch(
+                            checked = uiState.isGestureEnabled,
+                            onCheckedChange = { viewModel.toggleGesture(it) }
+                        )
+                    }
+                )
+                HorizontalDivider()
+            }
+            item {
+                Text(
+                    text = stringResource(id = R.string.gesture_list_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)
+                )
+            }
+            items(uiState.gestureItems) { item ->
+                val directionLabel = stringResource(id = item.direction.labelRes)
+                val actionLabel = item.action?.let { stringResource(id = it.labelRes) }
+                    ?: stringResource(id = R.string.gesture_action_unassigned)
+                val itemModifier = if (uiState.isGestureEnabled) {
+                    Modifier.clickable { viewModel.onGestureItemClick(item.direction) }
+                } else {
+                    Modifier
+                }
+                ListItem(
+                    modifier = itemModifier,
+                    headlineContent = { Text(directionLabel) },
+                    trailingContent = { Text(actionLabel) }
+                )
+                HorizontalDivider()
+            }
+        }
+    }
+
+    uiState.selectedDirection?.let { direction ->
+        val currentAction = uiState.gestureItems.firstOrNull { it.direction == direction }?.action
+        val actions = enumValues<GestureAction>()
+        AlertDialog(
+            onDismissRequest = { viewModel.dismissGestureDialog() },
+            title = { Text(text = stringResource(id = direction.labelRes)) },
+            text = {
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    GestureActionSelectionRow(
+                        label = stringResource(id = R.string.gesture_action_unassigned),
+                        selected = currentAction == null,
+                        onClick = { viewModel.assignGestureAction(direction, null) }
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    actions.forEachIndexed { index, action ->
+                        GestureActionSelectionRow(
+                            label = stringResource(id = action.labelRes),
+                            selected = currentAction == action,
+                            onClick = { viewModel.assignGestureAction(direction, action) }
+                        )
+                        if (index != actions.lastIndex) {
+                            Spacer(modifier = Modifier.height(4.dp))
+                        }
+                    }
+                }
+            },
+            confirmButton = {},
+            dismissButton = {
+                TextButton(onClick = { viewModel.dismissGestureDialog() }) {
+                    Text(text = stringResource(id = R.string.close))
+                }
+            }
+        )
+    }
+}
+
+@Composable
+private fun GestureActionSelectionRow(
+    label: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        RadioButton(
+            selected = selected,
+            onClick = onClick
+        )
+        Spacer(modifier = Modifier.width(16.dp))
+        Text(text = label)
+    }
+}

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/settings/SettingsGestureViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/settings/SettingsGestureViewModel.kt
@@ -1,0 +1,77 @@
+package com.websarva.wings.android.slevo.ui.settings
+
+import androidx.annotation.StringRes
+import androidx.lifecycle.ViewModel
+import com.websarva.wings.android.slevo.R
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+@HiltViewModel
+class SettingsGestureViewModel @Inject constructor() : ViewModel() {
+    private val _uiState = MutableStateFlow(SettingsGestureUiState())
+    val uiState: StateFlow<SettingsGestureUiState> = _uiState.asStateFlow()
+
+    fun toggleGesture(enabled: Boolean) {
+        _uiState.update { it.copy(isGestureEnabled = enabled) }
+    }
+
+    fun onGestureItemClick(direction: GestureDirection) {
+        _uiState.update { it.copy(selectedDirection = direction) }
+    }
+
+    fun dismissGestureDialog() {
+        _uiState.update { it.copy(selectedDirection = null) }
+    }
+
+    fun assignGestureAction(direction: GestureDirection, action: GestureAction?) {
+        _uiState.update { state ->
+            val updatedItems = state.gestureItems.map { item ->
+                if (item.direction == direction) {
+                    item.copy(action = action)
+                } else {
+                    item
+                }
+            }
+            state.copy(
+                gestureItems = updatedItems,
+                selectedDirection = null
+            )
+        }
+    }
+}
+
+data class SettingsGestureUiState(
+    val isGestureEnabled: Boolean = false,
+    val gestureItems: List<GestureItem> = GestureDirection.values().map { direction ->
+        GestureItem(direction = direction, action = null)
+    },
+    val selectedDirection: GestureDirection? = null,
+)
+
+data class GestureItem(
+    val direction: GestureDirection,
+    val action: GestureAction?,
+)
+
+enum class GestureDirection(@StringRes val labelRes: Int) {
+    Right(R.string.gesture_direction_right),
+    RightUp(R.string.gesture_direction_right_up),
+    RightLeft(R.string.gesture_direction_right_left),
+    RightDown(R.string.gesture_direction_right_down),
+    Left(R.string.gesture_direction_left),
+    LeftUp(R.string.gesture_direction_left_up),
+    LeftRight(R.string.gesture_direction_left_right),
+    LeftDown(R.string.gesture_direction_left_down),
+}
+
+enum class GestureAction(@StringRes val labelRes: Int) {
+    ToTop(R.string.gesture_action_to_top),
+    ToBottom(R.string.gesture_action_to_bottom),
+    Refresh(R.string.refresh),
+    PostOrCreateThread(R.string.gesture_action_post_or_create_thread),
+    Search(R.string.search),
+}

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/settings/SettingsScreen.kt
@@ -11,12 +11,15 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.websarva.wings.android.slevo.R
 import com.websarva.wings.android.slevo.ui.topbar.HomeTopAppBarScreen
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(
     onGeneralClick: () -> Unit,
+    onGestureClick: () -> Unit,
     onThreadClick: () -> Unit,
     onNgClick: () -> Unit,
     onCookieClick: () -> Unit,
@@ -39,6 +42,13 @@ fun SettingsScreen(
                 ListItem(
                     modifier = Modifier.clickable(onClick = onGeneralClick),
                     headlineContent = { Text("全般") }
+                )
+                HorizontalDivider()
+            }
+            item {
+                ListItem(
+                    modifier = Modifier.clickable(onClick = onGestureClick),
+                    headlineContent = { Text(stringResource(id = R.string.gesture_settings)) }
                 )
                 HorizontalDivider()
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,6 +91,22 @@
     <string name="show_minimap_scrollbar">ミニマップ付きスクロールバーを表示する</string>
     <string name="show_minimap_scrollbar_description">スレッド画面右側のミニマップ付きスクロールバーを有効にします</string>
 
+    <string name="gesture_settings">ジェスチャー</string>
+    <string name="enable_gesture_feature">ジェスチャー機能を有効にする</string>
+    <string name="gesture_list_title">ジェスチャーの割り当て</string>
+    <string name="gesture_action_unassigned">未設定</string>
+    <string name="gesture_action_to_top">先頭へ</string>
+    <string name="gesture_action_to_bottom">末尾へ</string>
+    <string name="gesture_action_post_or_create_thread">書き込み/スレッド作成</string>
+    <string name="gesture_direction_right">右</string>
+    <string name="gesture_direction_right_up">右→上</string>
+    <string name="gesture_direction_right_left">右→左</string>
+    <string name="gesture_direction_right_down">右→下</string>
+    <string name="gesture_direction_left">左</string>
+    <string name="gesture_direction_left_up">左→上</string>
+    <string name="gesture_direction_left_right">左→右</string>
+    <string name="gesture_direction_left_down">左→下</string>
+
     <string name="about_this_app">このアプリについて</string>
     <string name="version_name_label">バージョン: %1$s</string>
     <string name="github">GitHub</string>


### PR DESCRIPTION
## Summary
- add a gesture settings entry to the settings hub and navigation graph
- implement a gesture settings screen with enable toggle and action assignment dialog
- define gesture directions/actions along with localized strings

## Testing
- ./gradlew :app:compileDebugKotlin --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d7ba1191ac8332b37044e0f2ebb608