### PR TITLE
feat: remember last post identity per board

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/AppDatabase.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/AppDatabase.kt
@@ -20,6 +20,7 @@ import com.websarva.wings.android.slevo.data.datasource.local.dao.cache.BoardVis
 import com.websarva.wings.android.slevo.data.datasource.local.dao.cache.BoardFetchMetaDao
 import com.websarva.wings.android.slevo.data.datasource.local.dao.history.PostHistoryDao
 import com.websarva.wings.android.slevo.data.datasource.local.dao.history.PostIdentityHistoryDao
+import com.websarva.wings.android.slevo.data.datasource.local.dao.history.PostLastIdentityDao
 import com.websarva.wings.android.slevo.data.datasource.local.entity.bbs.BbsServiceEntity
 import com.websarva.wings.android.slevo.data.datasource.local.entity.bbs.BoardCategoryCrossRef
 import com.websarva.wings.android.slevo.data.datasource.local.entity.bbs.BoardEntity
@@ -38,6 +39,7 @@ import com.websarva.wings.android.slevo.data.datasource.local.entity.cache.Board
 import com.websarva.wings.android.slevo.data.datasource.local.entity.cache.BoardFetchMetaEntity
 import com.websarva.wings.android.slevo.data.datasource.local.entity.history.PostHistoryEntity
 import com.websarva.wings.android.slevo.data.datasource.local.entity.history.PostIdentityHistoryEntity
+import com.websarva.wings.android.slevo.data.datasource.local.entity.history.PostLastIdentityEntity
 
 @TypeConverters(NgTypeConverter::class)
 @Database(
@@ -59,9 +61,10 @@ import com.websarva.wings.android.slevo.data.datasource.local.entity.history.Pos
         BoardVisitEntity::class,
         BoardFetchMetaEntity::class,
         PostHistoryEntity::class,
-        PostIdentityHistoryEntity::class
+        PostIdentityHistoryEntity::class,
+        PostLastIdentityEntity::class
     ],
-    version = 4,
+    version = 5,
     exportSchema = true
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -82,6 +85,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun boardFetchMetaDao(): BoardFetchMetaDao
     abstract fun postHistoryDao(): PostHistoryDao
     abstract fun postIdentityHistoryDao(): PostIdentityHistoryDao
+    abstract fun postLastIdentityDao(): PostLastIdentityDao
 
     companion object {
         val MIGRATION_1_2 = object : androidx.room.migration.Migration(1, 2) {
@@ -197,6 +201,24 @@ abstract class AppDatabase : RoomDatabase() {
                 )
                 database.execSQL(
                     "CREATE INDEX IF NOT EXISTS index_post_identity_histories_lastUsedAt ON post_identity_histories(lastUsedAt)"
+                )
+            }
+        }
+
+        val MIGRATION_4_5 = object : androidx.room.migration.Migration(4, 5) {
+            override fun migrate(database: androidx.sqlite.db.SupportSQLiteDatabase) {
+                database.execSQL(
+                    "CREATE TABLE IF NOT EXISTS post_last_identities (" +
+                        "boardId INTEGER NOT NULL, " +
+                        "name TEXT NOT NULL, " +
+                        "email TEXT NOT NULL, " +
+                        "updatedAt INTEGER NOT NULL, " +
+                        "PRIMARY KEY(boardId), " +
+                        "FOREIGN KEY(boardId) REFERENCES boards(boardId) ON DELETE CASCADE" +
+                        ")"
+                )
+                database.execSQL(
+                    "CREATE INDEX IF NOT EXISTS index_post_last_identities_boardId ON post_last_identities(boardId)"
                 )
             }
         }

--- a/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/dao/history/PostLastIdentityDao.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/dao/history/PostLastIdentityDao.kt
@@ -1,0 +1,15 @@
+package com.websarva.wings.android.slevo.data.datasource.local.dao.history
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import com.websarva.wings.android.slevo.data.datasource.local.entity.history.PostLastIdentityEntity
+
+@Dao
+interface PostLastIdentityDao {
+    @Upsert
+    suspend fun upsert(entity: PostLastIdentityEntity)
+
+    @Query("SELECT * FROM post_last_identities WHERE boardId = :boardId")
+    suspend fun findByBoardId(boardId: Long): PostLastIdentityEntity?
+}

--- a/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/entity/history/PostLastIdentityEntity.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/entity/history/PostLastIdentityEntity.kt
@@ -1,0 +1,28 @@
+package com.websarva.wings.android.slevo.data.datasource.local.entity.history
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import com.websarva.wings.android.slevo.data.datasource.local.entity.bbs.BoardEntity
+
+@Entity(
+    tableName = "post_last_identities",
+    foreignKeys = [
+        ForeignKey(
+            entity = BoardEntity::class,
+            parentColumns = ["boardId"],
+            childColumns = ["boardId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [
+        Index("boardId")
+    ]
+)
+data class PostLastIdentityEntity(
+    @PrimaryKey val boardId: Long,
+    val name: String,
+    val email: String,
+    val updatedAt: Long,
+)

--- a/app/src/main/java/com/websarva/wings/android/slevo/di/DatabaseModule.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/di/DatabaseModule.kt
@@ -20,6 +20,7 @@ import com.websarva.wings.android.slevo.data.datasource.local.dao.cache.BoardVis
 import com.websarva.wings.android.slevo.data.datasource.local.dao.cache.ThreadSummaryDao
 import com.websarva.wings.android.slevo.data.datasource.local.dao.history.PostHistoryDao
 import com.websarva.wings.android.slevo.data.datasource.local.dao.history.PostIdentityHistoryDao
+import com.websarva.wings.android.slevo.data.datasource.local.dao.history.PostLastIdentityDao
 import com.websarva.wings.android.slevo.data.datasource.local.dao.history.ThreadHistoryDao
 import dagger.Module
 import dagger.Provides
@@ -59,7 +60,8 @@ object DatabaseModule {
             .addMigrations(
                 AppDatabase.MIGRATION_1_2, // v.1.1.0 で追加
                 AppDatabase.MIGRATION_2_3, // v.1.1.3 で追加
-                AppDatabase.MIGRATION_3_4 // v.?.?.? で追加
+                AppDatabase.MIGRATION_3_4, // v.?.?.? で追加
+                AppDatabase.MIGRATION_4_5
             )
             .addCallback(callback)
             .apply {
@@ -165,4 +167,8 @@ object DatabaseModule {
     @Provides
     fun providePostIdentityHistoryDao(db: AppDatabase): PostIdentityHistoryDao =
         db.postIdentityHistoryDao()
+
+    @Provides
+    fun providePostLastIdentityDao(db: AppDatabase): PostLastIdentityDao =
+        db.postLastIdentityDao()
 }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardViewModel.kt
@@ -71,6 +71,22 @@ class BoardViewModel @AssistedInject constructor(
                     state.copy(boardInfo = state.boardInfo.copy(noname = noname))
                 }
             }
+
+            postHistoryRepository.getLastIdentity(ensuredId)?.let { identity ->
+                _uiState.update { state ->
+                    val form = state.createFormState
+                    if (form.name.isEmpty() && form.mail.isEmpty()) {
+                        state.copy(
+                            createFormState = form.copy(
+                                name = identity.name,
+                                mail = identity.email
+                            )
+                        )
+                    } else {
+                        state
+                    }
+                }
+            }
         }
 
         viewModelScope.launch {
@@ -351,7 +367,10 @@ class BoardViewModel @AssistedInject constructor(
                     _uiState.update {
                         it.copy(
                             postResultMessage = "書き込みに成功しました。",
-                            createFormState = CreateThreadFormState()
+                            createFormState = CreateThreadFormState(
+                                name = formState.name,
+                                mail = formState.mail
+                            )
                         )
                     }
                     if (boardId != 0L) {
@@ -399,7 +418,10 @@ class BoardViewModel @AssistedInject constructor(
                     _uiState.update {
                         it.copy(
                             postResultMessage = "書き込みに成功しました。",
-                            createFormState = CreateThreadFormState()
+                            createFormState = CreateThreadFormState(
+                                name = formState.name,
+                                mail = formState.mail
+                            )
                         )
                     }
                     if (boardId != 0L) {

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/viewmodel/ThreadViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/viewmodel/ThreadViewModel.kt
@@ -167,6 +167,30 @@ class ThreadViewModel @AssistedInject constructor(
             }
         }
 
+        viewModelScope.launch {
+            val ensuredId = boardRepository.ensureBoard(boardInfo)
+            if (ensuredId != boardInfo.boardId) {
+                _uiState.update { state ->
+                    state.copy(boardInfo = state.boardInfo.copy(boardId = ensuredId))
+                }
+            }
+            postHistoryRepository.getLastIdentity(ensuredId)?.let { identity ->
+                _postUiState.update { current ->
+                    val form = current.postFormState
+                    if (form.name.isEmpty() && form.mail.isEmpty()) {
+                        current.copy(
+                            postFormState = form.copy(
+                                name = identity.name,
+                                mail = identity.email
+                            )
+                        )
+                    } else {
+                        current
+                    }
+                }
+            }
+        }
+
         // Factoryを使ってBookmarkStateViewModelを生成
         singleBookmarkViewModel = singleBookmarkViewModelFactory.create(boardInfo, threadInfo)
 
@@ -708,6 +732,15 @@ class ThreadViewModel @AssistedInject constructor(
                     email = mail
                 )
             }
+        }
+        _postUiState.update { state ->
+            state.copy(
+                postFormState = state.postFormState.copy(
+                    name = name,
+                    mail = mail,
+                    message = ""
+                )
+            )
         }
         pendingPost = PendingPost(resNum, message, name, mail)
         reloadThread()


### PR DESCRIPTION
## Summary
- add a Room table and migration to persist the last used post identity per board
- preload the previously used name and mail in thread posting and board creation forms
- keep the last identity after posting so subsequent dialogs reuse the stored values

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7c6c5a8988332a792e2de961b211c