### PR TITLE
feat: show filtered identity history suggestions

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/dao/history/PostIdentityHistoryDao.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/dao/history/PostIdentityHistoryDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Query
 import androidx.room.Upsert
 import com.websarva.wings.android.slevo.data.datasource.local.entity.history.PostIdentityHistoryEntity
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface PostIdentityHistoryDao {
@@ -14,6 +15,11 @@ interface PostIdentityHistoryDao {
         "SELECT id FROM post_identity_histories WHERE boardId = :boardId AND type = :type ORDER BY lastUsedAt DESC"
     )
     suspend fun findIdsOrdered(boardId: Long, type: String): List<Long>
+
+    @Query(
+        "SELECT value FROM post_identity_histories WHERE boardId = :boardId AND type = :type ORDER BY lastUsedAt DESC"
+    )
+    fun observeValues(boardId: Long, type: String): Flow<List<String>>
 
     @Query("DELETE FROM post_identity_histories WHERE id IN (:ids)")
     suspend fun deleteByIds(ids: List<Long>)

--- a/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/dao/history/PostIdentityHistoryDao.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/dao/history/PostIdentityHistoryDao.kt
@@ -23,4 +23,9 @@ interface PostIdentityHistoryDao {
 
     @Query("DELETE FROM post_identity_histories WHERE id IN (:ids)")
     suspend fun deleteByIds(ids: List<Long>)
+
+    @Query(
+        "DELETE FROM post_identity_histories WHERE boardId = :boardId AND type = :type AND value = :value"
+    )
+    suspend fun deleteByValue(boardId: Long, type: String, value: String)
 }

--- a/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/dao/history/PostLastIdentityDao.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/datasource/local/dao/history/PostLastIdentityDao.kt
@@ -12,4 +12,7 @@ interface PostLastIdentityDao {
 
     @Query("SELECT * FROM post_last_identities WHERE boardId = :boardId")
     suspend fun findByBoardId(boardId: Long): PostLastIdentityEntity?
+
+    @Query("DELETE FROM post_last_identities WHERE boardId = :boardId")
+    suspend fun deleteByBoardId(boardId: Long)
 }

--- a/app/src/main/java/com/websarva/wings/android/slevo/data/repository/PostHistoryRepository.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/repository/PostHistoryRepository.kt
@@ -59,6 +59,9 @@ class PostHistoryRepository @Inject constructor(
     fun observeMyPostNumbers(threadHistoryId: Long): Flow<Set<Int>> =
         dao.observeResNums(threadHistoryId).map { it.toSet() }
 
+    fun observeIdentityHistories(boardId: Long, type: PostIdentityType): Flow<List<String>> =
+        identityDao.observeValues(boardId, type.name)
+
     suspend fun recordIdentity(boardId: Long, name: String?, email: String?) {
         val now = System.currentTimeMillis()
         if (boardId != 0L) {

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
@@ -254,9 +254,13 @@ fun BoardScaffold(
                     mail = uiState.createFormState.mail,
                     message = uiState.createFormState.message,
                     namePlaceholder = uiState.boardInfo.noname.ifBlank { stringResource(R.string.name) },
+                    nameHistory = uiState.createNameHistory,
+                    mailHistory = uiState.createMailHistory,
                     onNameChange = { viewModel.updateCreateName(it) },
                     onMailChange = { viewModel.updateCreateMail(it) },
                     onMessageChange = { viewModel.updateCreateMessage(it) },
+                    onNameHistorySelect = { viewModel.selectCreateNameHistory(it) },
+                    onMailHistorySelect = { viewModel.selectCreateMailHistory(it) },
                     onPostClick = {
                         parseBoardUrl(uiState.boardInfo.url)?.let { (host, boardKey) ->
                             viewModel.createThreadFirstPhase(

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
@@ -261,6 +261,8 @@ fun BoardScaffold(
                     onMessageChange = { viewModel.updateCreateMessage(it) },
                     onNameHistorySelect = { viewModel.selectCreateNameHistory(it) },
                     onMailHistorySelect = { viewModel.selectCreateMailHistory(it) },
+                    onNameHistoryDelete = { viewModel.deleteCreateNameHistory(it) },
+                    onMailHistoryDelete = { viewModel.deleteCreateMailHistory(it) },
                     onPostClick = {
                         parseBoardUrl(uiState.boardInfo.url)?.let { (host, boardKey) ->
                             viewModel.createThreadFirstPhase(

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardUiState.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardUiState.kt
@@ -20,6 +20,8 @@ data class BoardUiState(
     val searchQuery: String = "",
     val createDialog: Boolean = false,
     val createFormState: CreateThreadFormState = CreateThreadFormState(),
+    val createNameHistory: List<String> = emptyList(),
+    val createMailHistory: List<String> = emptyList(),
     val isPosting: Boolean = false,
     val postConfirmation: ConfirmationData? = null,
     val isConfirmationScreen: Boolean = false,

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardViewModel.kt
@@ -353,6 +353,38 @@ class BoardViewModel @AssistedInject constructor(
         updateCreateMailHistorySuggestions(mail)
     }
 
+    fun deleteCreateNameHistory(name: String) {
+        val normalized = name.trim()
+        if (normalized.isEmpty()) {
+            return
+        }
+        latestCreateNameHistories = latestCreateNameHistories.filterNot { it == normalized }
+        updateCreateNameHistorySuggestions(_uiState.value.createFormState.name)
+        val boardId = _uiState.value.boardInfo.boardId
+        if (boardId == 0L) {
+            return
+        }
+        viewModelScope.launch {
+            postHistoryRepository.deleteIdentity(boardId, PostIdentityType.NAME, normalized)
+        }
+    }
+
+    fun deleteCreateMailHistory(mail: String) {
+        val normalized = mail.trim()
+        if (normalized.isEmpty()) {
+            return
+        }
+        latestCreateMailHistories = latestCreateMailHistories.filterNot { it == normalized }
+        updateCreateMailHistorySuggestions(_uiState.value.createFormState.mail)
+        val boardId = _uiState.value.boardInfo.boardId
+        if (boardId == 0L) {
+            return
+        }
+        viewModelScope.launch {
+            postHistoryRepository.deleteIdentity(boardId, PostIdentityType.EMAIL, normalized)
+        }
+    }
+
     private fun startObservingIdentityHistories(boardId: Long) {
         if (observedCreateIdentityBoardId == boardId) {
             updateCreateNameHistorySuggestions(_uiState.value.createFormState.name)

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/common/PostDialog.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/common/PostDialog.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -68,6 +69,8 @@ fun PostDialog(
     onMessageChange: (String) -> Unit,
     onNameHistorySelect: (String) -> Unit,
     onMailHistorySelect: (String) -> Unit,
+    onNameHistoryDelete: (String) -> Unit,
+    onMailHistoryDelete: (String) -> Unit,
     onPostClick: () -> Unit,
     confirmButtonText: String,
     title: String? = null,
@@ -164,6 +167,14 @@ fun PostDialog(
                                                 onNameHistorySelect(value)
                                                 isNameFocused = false
                                                 focusManager.clearFocus()
+                                            },
+                                            trailingIcon = {
+                                                IconButton(onClick = { onNameHistoryDelete(value) }) {
+                                                    Icon(
+                                                        imageVector = Icons.Filled.Close,
+                                                        contentDescription = stringResource(R.string.delete)
+                                                    )
+                                                }
                                             }
                                         )
                                     }
@@ -215,6 +226,14 @@ fun PostDialog(
                                                 onMailHistorySelect(value)
                                                 isMailFocused = false
                                                 focusManager.clearFocus()
+                                            },
+                                            trailingIcon = {
+                                                IconButton(onClick = { onMailHistoryDelete(value) }) {
+                                                    Icon(
+                                                        imageVector = Icons.Filled.Close,
+                                                        contentDescription = stringResource(R.string.delete)
+                                                    )
+                                                }
                                             }
                                         )
                                     }
@@ -331,6 +350,8 @@ fun PostDialogPreview() {
         onMessageChange = { /* メッセージ変更処理 */ },
         onNameHistorySelect = {},
         onMailHistorySelect = {},
+        onNameHistoryDelete = {},
+        onMailHistoryDelete = {},
         onPostClick = { /* 投稿処理 */ },
         confirmButtonText = "書き込み",
         onImageSelect = { }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/common/PostDialog.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/common/PostDialog.kt
@@ -2,7 +2,10 @@ package com.websarva.wings.android.slevo.ui.common
 
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -22,6 +25,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SuggestionChip
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -53,9 +57,13 @@ fun PostDialog(
     mail: String,
     message: String,
     namePlaceholder: String,
+    nameHistory: List<String>,
+    mailHistory: List<String>,
     onNameChange: (String) -> Unit,
     onMailChange: (String) -> Unit,
     onMessageChange: (String) -> Unit,
+    onNameHistorySelect: (String) -> Unit,
+    onMailHistorySelect: (String) -> Unit,
     onPostClick: () -> Unit,
     confirmButtonText: String,
     title: String? = null,
@@ -97,37 +105,49 @@ fun PostDialog(
                             .padding(8.dp),
                     ) {
                         val focusManager = LocalFocusManager.current
-                        OutlinedTextField(
-                            value = name,
-                            onValueChange = { onNameChange(it) },
-                            placeholder = {
-                                Text(
-                                    text = namePlaceholder,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis
+                        Column(modifier = Modifier.weight(1f)) {
+                            OutlinedTextField(
+                                value = name,
+                                onValueChange = { onNameChange(it) },
+                                placeholder = {
+                                    Text(
+                                        text = namePlaceholder,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis
+                                    )
+                                },
+                                modifier = Modifier
+                                    .fillMaxWidth(),
+                                singleLine = true,
+                                keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Next),
+                                keyboardActions = KeyboardActions(
+                                    onNext = { focusManager.moveFocus(FocusDirection.Next) }
                                 )
-                            },
-                            modifier = Modifier
-                                .weight(1f),
-                            singleLine = true,
-                            keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Next),
-                            keyboardActions = KeyboardActions(
-                                onNext = { focusManager.moveFocus(FocusDirection.Next) }
                             )
-                        )
+                            IdentityHistoryChips(
+                                history = nameHistory,
+                                onHistorySelect = onNameHistorySelect,
+                            )
+                        }
                         Spacer(modifier = Modifier.width(8.dp))
-                        OutlinedTextField(
-                            value = mail,
-                            onValueChange = { onMailChange(it) },
-                            placeholder = { Text(stringResource(R.string.e_mail)) },
-                            modifier = Modifier
-                                .weight(1f),
-                            singleLine = true,
-                            keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Next),
-                            keyboardActions = KeyboardActions(
-                                onNext = { focusManager.moveFocus(FocusDirection.Next) }
+                        Column(modifier = Modifier.weight(1f)) {
+                            OutlinedTextField(
+                                value = mail,
+                                onValueChange = { onMailChange(it) },
+                                placeholder = { Text(stringResource(R.string.e_mail)) },
+                                modifier = Modifier
+                                    .fillMaxWidth(),
+                                singleLine = true,
+                                keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Next),
+                                keyboardActions = KeyboardActions(
+                                    onNext = { focusManager.moveFocus(FocusDirection.Next) }
+                                )
                             )
-                        )
+                            IdentityHistoryChips(
+                                history = mailHistory,
+                                onHistorySelect = onMailHistorySelect,
+                            )
+                        }
                     }
 
                     if (title != null && onTitleChange != null) {
@@ -213,6 +233,30 @@ fun PostDialog(
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun IdentityHistoryChips(
+    history: List<String>,
+    onHistorySelect: (String) -> Unit,
+) {
+    if (history.isEmpty()) return
+
+    FlowRow(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 4.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        history.forEach { value ->
+            SuggestionChip(
+                onClick = { onHistorySelect(value) },
+                label = { Text(value) }
+            )
+        }
+    }
+}
+
 @Preview(showBackground = true)
 @Composable
 fun PostDialogPreview() {
@@ -222,9 +266,13 @@ fun PostDialogPreview() {
         mail = "",
         message = "",
         namePlaceholder = "それでも動く名無し",
+        nameHistory = listOf("太郎", "名無し"),
+        mailHistory = listOf("sage", "mail@example.com"),
         onNameChange = { /* 名前変更処理 */ },
         onMailChange = { /* メール変更処理 */ },
         onMessageChange = { /* メッセージ変更処理 */ },
+        onNameHistorySelect = {},
+        onMailHistorySelect = {},
         onPostClick = { /* 投稿処理 */ },
         confirmButtonText = "書き込み",
         onImageSelect = { }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/common/PostDialog.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/common/PostDialog.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.PopupProperties
 import com.websarva.wings.android.slevo.R
 import com.websarva.wings.android.slevo.ui.util.extractImageUrls
 
@@ -135,7 +136,8 @@ fun PostDialog(
                                         isNameFocused = false
                                         focusManager.clearFocus()
                                     },
-                                    modifier = Modifier.fillMaxWidth()
+                                    modifier = Modifier.fillMaxWidth(),
+                                    properties = PopupProperties(focusable = false)
                                 ) {
                                     nameHistory.forEach { value ->
                                         DropdownMenuItem(
@@ -173,7 +175,8 @@ fun PostDialog(
                                         isMailFocused = false
                                         focusManager.clearFocus()
                                     },
-                                    modifier = Modifier.fillMaxWidth()
+                                    modifier = Modifier.fillMaxWidth(),
+                                    properties = PopupProperties(focusable = false)
                                 ) {
                                     mailHistory.forEach { value ->
                                         DropdownMenuItem(

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/common/PostDialog.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/common/PostDialog.kt
@@ -37,6 +37,8 @@ import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -111,8 +113,13 @@ fun PostDialog(
                             .padding(8.dp),
                     ) {
                         val focusManager = LocalFocusManager.current
+                        val density = LocalDensity.current
                         Column(modifier = Modifier.weight(1f)) {
                             var isNameFocused by remember { mutableStateOf(false) }
+                            var nameTextFieldWidth by remember { mutableStateOf(0.dp) }
+                            val filteredNameHistory = remember(nameHistory, name) {
+                                nameHistory.filter { it != name }
+                            }
                             Box {
                                 OutlinedTextField(
                                     value = name,
@@ -128,6 +135,11 @@ fun PostDialog(
                                         .fillMaxWidth()
                                         .onFocusChanged { focusState ->
                                             isNameFocused = focusState.isFocused
+                                        }
+                                        .onGloballyPositioned { coordinates ->
+                                            nameTextFieldWidth = with(density) {
+                                                coordinates.size.width.toDp()
+                                            }
                                         },
                                     singleLine = true,
                                     keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Next),
@@ -136,18 +148,22 @@ fun PostDialog(
                                     )
                                 )
                                 DropdownMenu(
-                                    expanded = isNameFocused && nameHistory.isNotEmpty(),
+                                    expanded = isNameFocused && filteredNameHistory.isNotEmpty(),
                                     onDismissRequest = {
                                         isNameFocused = false
                                         focusManager.clearFocus()
                                     },
-                                    properties = PopupProperties(focusable = false)
+                                    properties = PopupProperties(focusable = false),
+                                    modifier = Modifier.width(nameTextFieldWidth)
                                 ) {
-                                    nameHistory.forEach { value ->
+                                    filteredNameHistory.forEach { value ->
                                         DropdownMenuItem(
                                             text = { Text(value) },
                                             onClick = {
+                                                onNameChange(value)
                                                 onNameHistorySelect(value)
+                                                isNameFocused = false
+                                                focusManager.clearFocus()
                                             }
                                         )
                                     }
@@ -157,6 +173,10 @@ fun PostDialog(
                         Spacer(modifier = Modifier.width(8.dp))
                         Column(modifier = Modifier.weight(1f)) {
                             var isMailFocused by remember { mutableStateOf(false) }
+                            var mailTextFieldWidth by remember { mutableStateOf(0.dp) }
+                            val mailFilteredHistory = remember(mailHistory, mail) {
+                                mailHistory.filter { it != mail }
+                            }
                             Box {
                                 OutlinedTextField(
                                     value = mail,
@@ -166,6 +186,11 @@ fun PostDialog(
                                         .fillMaxWidth()
                                         .onFocusChanged { focusState ->
                                             isMailFocused = focusState.isFocused
+                                        }
+                                        .onGloballyPositioned { coordinates ->
+                                            mailTextFieldWidth = with(density) {
+                                                coordinates.size.width.toDp()
+                                            }
                                         },
                                     singleLine = true,
                                     keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Next),
@@ -174,18 +199,22 @@ fun PostDialog(
                                     )
                                 )
                                 DropdownMenu(
-                                    expanded = isMailFocused && mailHistory.isNotEmpty(),
+                                    expanded = isMailFocused && mailFilteredHistory.isNotEmpty(),
                                     onDismissRequest = {
                                         isMailFocused = false
                                         focusManager.clearFocus()
                                     },
-                                    properties = PopupProperties(focusable = false)
+                                    properties = PopupProperties(focusable = false),
+                                    modifier = Modifier.width(mailTextFieldWidth)
                                 ) {
-                                    mailHistory.forEach { value ->
+                                    mailFilteredHistory.forEach { value ->
                                         DropdownMenuItem(
                                             text = { Text(value) },
                                             onClick = {
+                                                onMailChange(value)
                                                 onMailHistorySelect(value)
+                                                isMailFocused = false
+                                                focusManager.clearFocus()
                                             }
                                         )
                                     }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/common/PostDialog.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/common/PostDialog.kt
@@ -2,10 +2,8 @@ package com.websarva.wings.android.slevo.ui.common
 
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -21,11 +19,12 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.SuggestionChip
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -37,6 +36,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
@@ -106,47 +106,85 @@ fun PostDialog(
                     ) {
                         val focusManager = LocalFocusManager.current
                         Column(modifier = Modifier.weight(1f)) {
-                            OutlinedTextField(
-                                value = name,
-                                onValueChange = { onNameChange(it) },
-                                placeholder = {
-                                    Text(
-                                        text = namePlaceholder,
-                                        maxLines = 1,
-                                        overflow = TextOverflow.Ellipsis
+                            var isNameFocused by remember { mutableStateOf(false) }
+                            Box {
+                                OutlinedTextField(
+                                    value = name,
+                                    onValueChange = { onNameChange(it) },
+                                    placeholder = {
+                                        Text(
+                                            text = namePlaceholder,
+                                            maxLines = 1,
+                                            overflow = TextOverflow.Ellipsis
+                                        )
+                                    },
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .onFocusChanged { focusState ->
+                                            isNameFocused = focusState.isFocused
+                                        },
+                                    singleLine = true,
+                                    keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Next),
+                                    keyboardActions = KeyboardActions(
+                                        onNext = { focusManager.moveFocus(FocusDirection.Next) }
                                     )
-                                },
-                                modifier = Modifier
-                                    .fillMaxWidth(),
-                                singleLine = true,
-                                keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Next),
-                                keyboardActions = KeyboardActions(
-                                    onNext = { focusManager.moveFocus(FocusDirection.Next) }
                                 )
-                            )
-                            IdentityHistoryChips(
-                                history = nameHistory,
-                                onHistorySelect = onNameHistorySelect,
-                            )
+                                DropdownMenu(
+                                    expanded = isNameFocused && nameHistory.isNotEmpty(),
+                                    onDismissRequest = {
+                                        isNameFocused = false
+                                        focusManager.clearFocus()
+                                    },
+                                    modifier = Modifier.fillMaxWidth()
+                                ) {
+                                    nameHistory.forEach { value ->
+                                        DropdownMenuItem(
+                                            text = { Text(value) },
+                                            onClick = {
+                                                onNameHistorySelect(value)
+                                            }
+                                        )
+                                    }
+                                }
+                            }
                         }
                         Spacer(modifier = Modifier.width(8.dp))
                         Column(modifier = Modifier.weight(1f)) {
-                            OutlinedTextField(
-                                value = mail,
-                                onValueChange = { onMailChange(it) },
-                                placeholder = { Text(stringResource(R.string.e_mail)) },
-                                modifier = Modifier
-                                    .fillMaxWidth(),
-                                singleLine = true,
-                                keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Next),
-                                keyboardActions = KeyboardActions(
-                                    onNext = { focusManager.moveFocus(FocusDirection.Next) }
+                            var isMailFocused by remember { mutableStateOf(false) }
+                            Box {
+                                OutlinedTextField(
+                                    value = mail,
+                                    onValueChange = { onMailChange(it) },
+                                    placeholder = { Text(stringResource(R.string.e_mail)) },
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .onFocusChanged { focusState ->
+                                            isMailFocused = focusState.isFocused
+                                        },
+                                    singleLine = true,
+                                    keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Next),
+                                    keyboardActions = KeyboardActions(
+                                        onNext = { focusManager.moveFocus(FocusDirection.Next) }
+                                    )
                                 )
-                            )
-                            IdentityHistoryChips(
-                                history = mailHistory,
-                                onHistorySelect = onMailHistorySelect,
-                            )
+                                DropdownMenu(
+                                    expanded = isMailFocused && mailHistory.isNotEmpty(),
+                                    onDismissRequest = {
+                                        isMailFocused = false
+                                        focusManager.clearFocus()
+                                    },
+                                    modifier = Modifier.fillMaxWidth()
+                                ) {
+                                    mailHistory.forEach { value ->
+                                        DropdownMenuItem(
+                                            text = { Text(value) },
+                                            onClick = {
+                                                onMailHistorySelect(value)
+                                            }
+                                        )
+                                    }
+                                }
+                            }
                         }
                     }
 
@@ -229,30 +267,6 @@ fun PostDialog(
                     Text(text = confirmButtonText)
                 }
             }
-        }
-    }
-}
-
-@OptIn(ExperimentalLayoutApi::class)
-@Composable
-private fun IdentityHistoryChips(
-    history: List<String>,
-    onHistorySelect: (String) -> Unit,
-) {
-    if (history.isEmpty()) return
-
-    FlowRow(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(top = 4.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
-    ) {
-        history.forEach { value ->
-            SuggestionChip(
-                onClick = { onHistorySelect(value) },
-                label = { Text(value) }
-            )
         }
     }
 }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -40,6 +40,8 @@ import com.websarva.wings.android.slevo.ui.thread.components.ThreadToolBar
 import com.websarva.wings.android.slevo.ui.thread.dialog.ResponseWebViewDialog
 import com.websarva.wings.android.slevo.ui.thread.dialog.ThreadToolbarOverflowMenu
 import com.websarva.wings.android.slevo.ui.thread.state.ThreadSortType
+import com.websarva.wings.android.slevo.ui.thread.viewmodel.deletePostMailHistory
+import com.websarva.wings.android.slevo.ui.thread.viewmodel.deletePostNameHistory
 import com.websarva.wings.android.slevo.ui.thread.viewmodel.hideConfirmationScreen
 import com.websarva.wings.android.slevo.ui.thread.viewmodel.hideErrorWebView
 import com.websarva.wings.android.slevo.ui.thread.viewmodel.hidePostDialog
@@ -293,6 +295,8 @@ fun ThreadScaffold(
                     onMessageChange = { viewModel.updatePostMessage(it) },
                     onNameHistorySelect = { viewModel.selectPostNameHistory(it) },
                     onMailHistorySelect = { viewModel.selectPostMailHistory(it) },
+                    onNameHistoryDelete = { viewModel.deletePostNameHistory(it) },
+                    onMailHistoryDelete = { viewModel.deletePostMailHistory(it) },
                     onPostClick = {
                         parseBoardUrl(uiState.boardInfo.url)?.let { (host, boardKey) ->
                             viewModel.postFirstPhase(

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -45,6 +45,8 @@ import com.websarva.wings.android.slevo.ui.thread.viewmodel.hideErrorWebView
 import com.websarva.wings.android.slevo.ui.thread.viewmodel.hidePostDialog
 import com.websarva.wings.android.slevo.ui.thread.viewmodel.postFirstPhase
 import com.websarva.wings.android.slevo.ui.thread.viewmodel.postTo5chSecondPhase
+import com.websarva.wings.android.slevo.ui.thread.viewmodel.selectPostMailHistory
+import com.websarva.wings.android.slevo.ui.thread.viewmodel.selectPostNameHistory
 import com.websarva.wings.android.slevo.ui.thread.viewmodel.showPostDialog
 import com.websarva.wings.android.slevo.ui.thread.viewmodel.showReplyDialog
 import com.websarva.wings.android.slevo.ui.thread.viewmodel.updatePostMail
@@ -284,9 +286,13 @@ fun ThreadScaffold(
                     mail = postUiState.postFormState.mail,
                     message = postUiState.postFormState.message,
                     namePlaceholder = uiState.boardInfo.noname.ifBlank { "name" },
+                    nameHistory = postUiState.nameHistory,
+                    mailHistory = postUiState.mailHistory,
                     onNameChange = { viewModel.updatePostName(it) },
                     onMailChange = { viewModel.updatePostMail(it) },
                     onMessageChange = { viewModel.updatePostMessage(it) },
+                    onNameHistorySelect = { viewModel.selectPostNameHistory(it) },
+                    onMailHistorySelect = { viewModel.selectPostMailHistory(it) },
                     onPostClick = {
                         parseBoardUrl(uiState.boardInfo.url)?.let { (host, boardKey) ->
                             viewModel.postFirstPhase(

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/state/PostUiState.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/state/PostUiState.kt
@@ -8,6 +8,8 @@ import com.websarva.wings.android.slevo.data.repository.ConfirmationData
 data class PostUiState(
     val postDialog: Boolean = false,
     val postFormState: PostFormState = PostFormState(),
+    val nameHistory: List<String> = emptyList(),
+    val mailHistory: List<String> = emptyList(),
     val isPosting: Boolean = false,
     val postConfirmation: ConfirmationData? = null,
     val isConfirmationScreen: Boolean = false,

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/viewmodel/ThreadViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/viewmodel/ThreadViewModel.kt
@@ -796,6 +796,31 @@ class ThreadViewModel @AssistedInject constructor(
         _postUiState.update { it.copy(mailHistory = filtered) }
     }
 
+    internal fun deletePostIdentityHistory(type: PostIdentityType, value: String) {
+        val normalized = value.trim()
+        if (normalized.isEmpty()) {
+            return
+        }
+        when (type) {
+            PostIdentityType.NAME -> {
+                latestNameHistories = latestNameHistories.filterNot { it == normalized }
+                refreshNameHistorySuggestions(_postUiState.value.postFormState.name)
+            }
+
+            PostIdentityType.EMAIL -> {
+                latestMailHistories = latestMailHistories.filterNot { it == normalized }
+                refreshMailHistorySuggestions(_postUiState.value.postFormState.mail)
+            }
+        }
+        val boardId = _uiState.value.boardInfo.boardId
+        if (boardId == 0L) {
+            return
+        }
+        viewModelScope.launch {
+            postHistoryRepository.deleteIdentity(boardId, type, normalized)
+        }
+    }
+
     private fun filterIdentityHistories(source: List<String>, query: String): List<String> {
         val normalized = query.trim()
         return if (normalized.isEmpty()) {

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/viewmodel/ThreadViewModelPost.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/viewmodel/ThreadViewModelPost.kt
@@ -41,10 +41,12 @@ fun ThreadViewModel.hideConfirmationScreen() {
 
 fun ThreadViewModel.updatePostName(name: String) {
     _postUiState.update { it.copy(postFormState = it.postFormState.copy(name = name)) }
+    refreshNameHistorySuggestions(name)
 }
 
 fun ThreadViewModel.updatePostMail(mail: String) {
     _postUiState.update { it.copy(postFormState = it.postFormState.copy(mail = mail)) }
+    refreshMailHistorySuggestions(mail)
 }
 
 fun ThreadViewModel.updatePostMessage(message: String) {
@@ -149,5 +151,15 @@ fun ThreadViewModel.uploadImage(context: Context, uri: Uri) {
 
 fun ThreadViewModel.clearPostResultMessage() {
     _postUiState.update { it.copy(postResultMessage = null) }
+}
+
+fun ThreadViewModel.selectPostNameHistory(name: String) {
+    _postUiState.update { it.copy(postFormState = it.postFormState.copy(name = name)) }
+    refreshNameHistorySuggestions(name)
+}
+
+fun ThreadViewModel.selectPostMailHistory(mail: String) {
+    _postUiState.update { it.copy(postFormState = it.postFormState.copy(mail = mail)) }
+    refreshMailHistorySuggestions(mail)
 }
 

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/viewmodel/ThreadViewModelPost.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/viewmodel/ThreadViewModelPost.kt
@@ -3,6 +3,7 @@ package com.websarva.wings.android.slevo.ui.thread.viewmodel
 import android.content.Context
 import android.net.Uri
 import androidx.lifecycle.viewModelScope
+import com.websarva.wings.android.slevo.data.datasource.local.entity.history.PostIdentityType
 import com.websarva.wings.android.slevo.data.repository.ConfirmationData
 import com.websarva.wings.android.slevo.data.repository.PostResult
 import com.websarva.wings.android.slevo.ui.thread.state.PostFormState
@@ -161,5 +162,13 @@ fun ThreadViewModel.selectPostNameHistory(name: String) {
 fun ThreadViewModel.selectPostMailHistory(mail: String) {
     _postUiState.update { it.copy(postFormState = it.postFormState.copy(mail = mail)) }
     refreshMailHistorySuggestions(mail)
+}
+
+fun ThreadViewModel.deletePostNameHistory(name: String) {
+    deletePostIdentityHistory(PostIdentityType.NAME, name)
+}
+
+fun ThreadViewModel.deletePostMailHistory(mail: String) {
+    deletePostIdentityHistory(PostIdentityType.EMAIL, mail)
 }
 


### PR DESCRIPTION
## Summary
- expose Room flows for post identity histories and connect them through the repository
- surface filtered name and mail history suggestions on thread posts and thread creation dialogs
- update the post dialog UI to show selectable chips for matching history entries

## Testing
- ./gradlew --console=plain :app:compileDebugKotlin

------
https://chatgpt.com/codex/tasks/task_e_68dcbc91bba88332a58c9c8365eec7c7