### PR TITLE
Add gesture navigation for board and thread content areas

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/data/model/GestureSettings.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/model/GestureSettings.kt
@@ -1,5 +1,6 @@
 package com.websarva.wings.android.slevo.data.model
 
+import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import com.websarva.wings.android.slevo.R
 
@@ -13,20 +14,47 @@ data class GestureSettings(
     companion object {
         val DEFAULT = GestureSettings(
             isEnabled = false,
-            assignments = GestureDirection.values().associateWith { null }
+            assignments = GestureDirection.entries.associateWith { null }
         )
     }
 }
 
-enum class GestureDirection(@StringRes val labelRes: Int) {
-    Right(R.string.gesture_direction_right),
-    RightUp(R.string.gesture_direction_right_up),
-    RightLeft(R.string.gesture_direction_right_left),
-    RightDown(R.string.gesture_direction_right_down),
-    Left(R.string.gesture_direction_left),
-    LeftUp(R.string.gesture_direction_left_up),
-    LeftRight(R.string.gesture_direction_left_right),
-    LeftDown(R.string.gesture_direction_left_down),
+enum class GestureDirection(
+    @StringRes val labelRes: Int,
+    @DrawableRes val iconRes: Int,
+) {
+    Right(
+        labelRes = R.string.gesture_direction_right,
+        iconRes = R.drawable.ic_gesture_right,
+    ),
+    RightUp(
+        labelRes = R.string.gesture_direction_right_up,
+        iconRes = R.drawable.ic_gesture_right_then_up,
+    ),
+    RightLeft(
+        labelRes = R.string.gesture_direction_right_left,
+        iconRes = R.drawable.ic_gesture_right_then_left,
+    ),
+    RightDown(
+        labelRes = R.string.gesture_direction_right_down,
+        iconRes = R.drawable.ic_gesture_right_then_down,
+    ),
+    Left(
+        labelRes = R.string.gesture_direction_left,
+        iconRes = R.drawable.ic_gesture_left,
+    ),
+    LeftUp(
+        labelRes = R.string.gesture_direction_left_up,
+        iconRes = R.drawable.ic_gesture_left_then_up,
+    ),
+    LeftRight(
+        labelRes = R.string.gesture_direction_left_right,
+        iconRes = R.drawable.ic_gesture_left_then_right,
+    ),
+    LeftDown(
+        labelRes = R.string.gesture_direction_left_down,
+        iconRes = R.drawable.ic_gesture_left_then_down,
+    ),
 }
 
 enum class GestureAction(@StringRes val labelRes: Int) {

--- a/app/src/main/java/com/websarva/wings/android/slevo/data/model/GestureSettings.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/model/GestureSettings.kt
@@ -63,4 +63,12 @@ enum class GestureAction(@StringRes val labelRes: Int) {
     Refresh(R.string.refresh),
     PostOrCreateThread(R.string.gesture_action_post_or_create_thread),
     Search(R.string.search),
+    OpenTabList(R.string.gesture_action_open_tab_list),
+    OpenBookmarkList(R.string.gesture_action_open_bookmark_list),
+    OpenBoardList(R.string.gesture_action_open_board_list),
+    OpenHistory(R.string.gesture_action_open_history),
+    OpenNewTab(R.string.gesture_action_open_new_tab),
+    SwitchToNextTab(R.string.gesture_action_switch_to_next_tab),
+    SwitchToPreviousTab(R.string.gesture_action_switch_to_previous_tab),
+    CloseTab(R.string.gesture_action_close_tab),
 }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
@@ -191,7 +191,7 @@ fun BoardScaffold(
                 }
             }
         },
-        content = { viewModel, uiState, listState, modifier, navController, showBottomBar ->
+        content = { viewModel, uiState, listState, modifier, navController, showBottomBar, openTabListSheet, openUrlDialog ->
             LaunchedEffect(uiState.resetScroll) {
                 if (uiState.resetScroll) {
                     listState.scrollToItem(0)
@@ -226,6 +226,17 @@ fun BoardScaffold(
                         GestureAction.Refresh -> viewModel.refreshBoardData()
                         GestureAction.PostOrCreateThread -> viewModel.showCreateDialog()
                         GestureAction.Search -> viewModel.setSearchMode(true)
+                        GestureAction.OpenTabList -> openTabListSheet()
+                        GestureAction.OpenBookmarkList -> navController.navigate(AppRoute.BookmarkList)
+                        GestureAction.OpenBoardList -> navController.navigate(AppRoute.ServiceList)
+                        GestureAction.OpenHistory -> navController.navigate(AppRoute.HistoryList)
+                        GestureAction.OpenNewTab -> openUrlDialog()
+                        GestureAction.SwitchToNextTab -> tabsViewModel.moveBoardPage(1)
+                        GestureAction.SwitchToPreviousTab -> tabsViewModel.moveBoardPage(-1)
+                        GestureAction.CloseTab ->
+                            if (uiState.boardInfo.url.isNotBlank()) {
+                                tabsViewModel.closeBoardTabByUrl(uiState.boardInfo.url)
+                            }
                         GestureAction.ToTop, GestureAction.ToBottom -> Unit
                     }
                 }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
@@ -18,8 +18,6 @@ import androidx.compose.material.icons.filled.CropSquare
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.material3.TopAppBarState
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -33,8 +31,6 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import com.websarva.wings.android.slevo.R
 import com.websarva.wings.android.slevo.data.model.BoardInfo

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
@@ -191,7 +191,7 @@ fun BoardScaffold(
                 }
             }
         },
-        content = { viewModel, uiState, listState, modifier, navController ->
+        content = { viewModel, uiState, listState, modifier, navController, showBottomBar ->
             LaunchedEffect(uiState.resetScroll) {
                 if (uiState.resetScroll) {
                     listState.scrollToItem(0)
@@ -220,6 +220,7 @@ fun BoardScaffold(
                 onRefresh = { viewModel.refreshBoardData() },
                 listState = listState,
                 gestureSettings = uiState.gestureSettings,
+                showBottomBar = showBottomBar,
                 onGestureAction = { action ->
                     when (action) {
                         GestureAction.Refresh -> viewModel.refreshBoardData()

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import com.websarva.wings.android.slevo.R
 import com.websarva.wings.android.slevo.data.model.BoardInfo
+import com.websarva.wings.android.slevo.data.model.GestureAction
 import com.websarva.wings.android.slevo.ui.common.PostDialog
 import com.websarva.wings.android.slevo.ui.common.PostingDialog
 import com.websarva.wings.android.slevo.ui.common.SearchBottomBar
@@ -221,7 +222,16 @@ fun BoardScaffold(
                 },
                 isRefreshing = uiState.isLoading,
                 onRefresh = { viewModel.refreshBoardData() },
-                listState = listState
+                listState = listState,
+                gestureSettings = uiState.gestureSettings,
+                onGestureAction = { action ->
+                    when (action) {
+                        GestureAction.Refresh -> viewModel.refreshBoardData()
+                        GestureAction.PostOrCreateThread -> viewModel.showCreateDialog()
+                        GestureAction.Search -> viewModel.setSearchMode(true)
+                        GestureAction.ToTop, GestureAction.ToBottom -> Unit
+                    }
+                }
             )
             if (uiState.showInfoDialog) {
                 BoardInfoDialog(

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -58,6 +59,7 @@ fun BoardScreen(
     onRefresh: () -> Unit,
     listState: LazyListState = rememberLazyListState(),
     gestureSettings: GestureSettings = GestureSettings.DEFAULT,
+    showBottomBar: (() -> Unit)? = null,
     onGestureAction: (GestureAction) -> Unit = {},
 ) {
     val (momentumMean, momentumStd) = remember(threads) {
@@ -109,19 +111,32 @@ fun BoardScreen(
                     }
                     gestureHint = GestureHint.Hidden
                     when (action) {
-                        GestureAction.ToTop -> coroutineScope.launch {
-                            listState.scrollToItem(0)
+                        GestureAction.ToTop -> {
+                            showBottomBar?.invoke()
+                            coroutineScope.launch {
+                                listState.scrollToItem(0)
+                            }
                         }
 
-                        GestureAction.ToBottom -> coroutineScope.launch {
-                            val totalItems = listState.layoutInfo.totalItemsCount
-                            val fallback = if (threads.isNotEmpty()) threads.size else 0
-                            val targetIndex = when {
-                                totalItems > 0 -> totalItems - 1
-                                fallback > 0 -> fallback
-                                else -> 0
+                        GestureAction.ToBottom -> {
+                            coroutineScope.launch {
+                                showBottomBar?.invoke()
+                                val prevViewportEnd = listState.layoutInfo.viewportEndOffset
+                                repeat(10) {
+                                    withFrameNanos { /* 1 フレーム待ち */ }
+                                    if (listState.layoutInfo.viewportEndOffset != prevViewportEnd) return@repeat
+                                }
+                                coroutineScope.launch {
+                                    val totalItems = listState.layoutInfo.totalItemsCount
+                                    val fallback = if (threads.isNotEmpty()) threads.size else 0
+                                    val targetIndex = when {
+                                        totalItems > 0 -> totalItems - 1
+                                        fallback > 0 -> fallback
+                                        else -> 0
+                                    }
+                                    listState.scrollToItem(targetIndex)
+                                }
                             }
-                            listState.scrollToItem(targetIndex)
                         }
 
                         else -> onGestureAction(action)

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScreen.kt
@@ -110,7 +110,7 @@ fun BoardScreen(
                     gestureHint = GestureHint.Hidden
                     when (action) {
                         GestureAction.ToTop -> coroutineScope.launch {
-                            listState.animateScrollToItem(0)
+                            listState.scrollToItem(0)
                         }
 
                         GestureAction.ToBottom -> coroutineScope.launch {
@@ -121,7 +121,7 @@ fun BoardScreen(
                                 fallback > 0 -> fallback
                                 else -> 0
                             }
-                            listState.animateScrollToItem(targetIndex)
+                            listState.scrollToItem(targetIndex)
                         }
 
                         else -> onGestureAction(action)

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScreen.kt
@@ -121,9 +121,7 @@ fun BoardScreen(
                                 fallback > 0 -> fallback
                                 else -> 0
                             }
-                            if (targetIndex >= 0) {
-                                listState.animateScrollToItem(targetIndex)
-                            }
+                            listState.animateScrollToItem(targetIndex)
                         }
 
                         else -> onGestureAction(action)

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardUiState.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardUiState.kt
@@ -1,6 +1,7 @@
 package com.websarva.wings.android.slevo.ui.board
 
 import com.websarva.wings.android.slevo.data.model.BoardInfo
+import com.websarva.wings.android.slevo.data.model.GestureSettings
 import com.websarva.wings.android.slevo.data.model.ThreadInfo
 import com.websarva.wings.android.slevo.data.repository.ConfirmationData
 import com.websarva.wings.android.slevo.ui.common.BaseUiState
@@ -28,6 +29,7 @@ data class BoardUiState(
     val postResultMessage: String? = null,
     val resetScroll: Boolean = false,
     val loadProgress: Float = 0f,
+    val gestureSettings: GestureSettings = GestureSettings.DEFAULT,
     override val isLoading: Boolean = false,
 ) : BaseUiState<BoardUiState> {
     override fun copyState(

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardViewModel.kt
@@ -15,6 +15,7 @@ import com.websarva.wings.android.slevo.data.repository.PostHistoryRepository
 import com.websarva.wings.android.slevo.data.repository.PostResult
 import com.websarva.wings.android.slevo.data.repository.ThreadCreateRepository
 import com.websarva.wings.android.slevo.data.repository.ThreadHistoryRepository
+import com.websarva.wings.android.slevo.data.repository.SettingsRepository
 import com.websarva.wings.android.slevo.data.model.NgType
 import com.websarva.wings.android.slevo.ui.common.BaseViewModel
 import com.websarva.wings.android.slevo.ui.common.bookmark.SingleBookmarkViewModel
@@ -39,6 +40,7 @@ class BoardViewModel @AssistedInject constructor(
     private val postHistoryRepository: PostHistoryRepository,
     private val singleBookmarkViewModelFactory: SingleBookmarkViewModelFactory,
     private val ngRepository: NgRepository,
+    private val settingsRepository: SettingsRepository,
     @Assisted("viewModelKey") val viewModelKey: String
 ) : BaseViewModel<BoardUiState>() {
 
@@ -52,6 +54,14 @@ class BoardViewModel @AssistedInject constructor(
     override val _uiState = MutableStateFlow(BoardUiState())
     private var singleBookmarkViewModel: SingleBookmarkViewModel? = null
     private var threadTitleNg: List<Pair<Long?, Regex>> = emptyList()
+
+    init {
+        viewModelScope.launch {
+            settingsRepository.observeGestureSettings().collect { settings ->
+                _uiState.update { it.copy(gestureSettings = settings) }
+            }
+        }
+    }
 
     fun initializeBoard(boardInfo: BoardInfo) {
         if (initializedUrl == boardInfo.url) return

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/common/GestureHintOverlay.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/common/GestureHintOverlay.kt
@@ -1,0 +1,73 @@
+package com.websarva.wings.android.slevo.ui.common
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.websarva.wings.android.slevo.R
+import com.websarva.wings.android.slevo.ui.util.GestureHint
+
+@Composable
+fun GestureHintOverlay(
+    state: GestureHint,
+    modifier: Modifier = Modifier,
+) {
+    when (state) {
+        is GestureHint.Hidden -> Unit
+        is GestureHint.Direction -> Box(
+            modifier = modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center,
+        ) {
+            Surface(
+                tonalElevation = 6.dp,
+                shape = MaterialTheme.shapes.medium,
+            ) {
+                Column(
+                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Text(
+                        text = stringResource(id = state.direction.labelRes),
+                        style = MaterialTheme.typography.titleMedium,
+                        textAlign = TextAlign.Center,
+                    )
+                    val message = state.action?.let { action ->
+                        stringResource(id = action.labelRes)
+                    } ?: stringResource(id = R.string.gesture_action_unassigned_message)
+                    Text(
+                        text = message,
+                        style = MaterialTheme.typography.bodyMedium,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.padding(top = 4.dp),
+                    )
+                }
+            }
+        }
+
+        GestureHint.Invalid -> Box(
+            modifier = modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center,
+        ) {
+            Surface(
+                tonalElevation = 6.dp,
+                shape = MaterialTheme.shapes.medium,
+            ) {
+                Text(
+                    text = stringResource(id = R.string.gesture_invalid_message),
+                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp),
+                    style = MaterialTheme.typography.bodyMedium,
+                    textAlign = TextAlign.Center,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/common/GestureHintOverlay.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/common/GestureHintOverlay.kt
@@ -15,22 +15,27 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.websarva.wings.android.slevo.R
 import com.websarva.wings.android.slevo.ui.util.GestureHint
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.ui.tooling.preview.Preview
+import com.websarva.wings.android.slevo.data.model.GestureDirection
+import com.websarva.wings.android.slevo.data.model.GestureAction
 
 @Composable
 fun GestureHintOverlay(
     state: GestureHint,
     modifier: Modifier = Modifier,
 ) {
+    // Surface の共通サイズを定義（幅を固定、最小高さを確保）
+    // （具体的な Surface は下の OverlaySurface で共通化）
+
     when (state) {
         is GestureHint.Hidden -> Unit
         is GestureHint.Direction -> Box(
             modifier = modifier.fillMaxSize(),
             contentAlignment = Alignment.Center,
         ) {
-            Surface(
-                tonalElevation = 6.dp,
-                shape = MaterialTheme.shapes.medium,
-            ) {
+            OverlaySurface {
                 Column(
                     modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp),
                     horizontalAlignment = Alignment.CenterHorizontally,
@@ -57,10 +62,7 @@ fun GestureHintOverlay(
             modifier = modifier.fillMaxSize(),
             contentAlignment = Alignment.Center,
         ) {
-            Surface(
-                tonalElevation = 6.dp,
-                shape = MaterialTheme.shapes.medium,
-            ) {
+            OverlaySurface {
                 Text(
                     text = stringResource(id = R.string.gesture_invalid_message),
                     modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp),
@@ -70,4 +72,44 @@ fun GestureHintOverlay(
             }
         }
     }
+}
+
+/**
+ * 共通のオーバーレイ Surface を生成するヘルパー。
+ * 幅を固定し最小高さを確保、半透明の背景色を適用します。
+ */
+@Composable
+private fun OverlaySurface(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    Surface(
+        modifier = modifier.width(240.dp).heightIn(min = 72.dp),
+        tonalElevation = 6.dp,
+        shape = MaterialTheme.shapes.medium,
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.9f),
+    ) {
+        content()
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun GestureHintOverlay_DirectionPreview() {
+    GestureHintOverlay(
+        state = GestureHint.Direction(
+            direction = GestureDirection.Right,
+            action = GestureAction.ToTop,
+        ),
+        modifier = Modifier,
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun GestureHintOverlay_InvalidPreview() {
+    GestureHintOverlay(
+        state = GestureHint.Invalid,
+        modifier = Modifier,
+    )
 }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/common/GestureHintOverlay.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/common/GestureHintOverlay.kt
@@ -3,23 +3,26 @@ package com.websarva.wings.android.slevo.ui.common
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.websarva.wings.android.slevo.R
-import com.websarva.wings.android.slevo.ui.util.GestureHint
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.heightIn
-import androidx.compose.ui.tooling.preview.Preview
-import com.websarva.wings.android.slevo.data.model.GestureDirection
 import com.websarva.wings.android.slevo.data.model.GestureAction
+import com.websarva.wings.android.slevo.data.model.GestureDirection
+import com.websarva.wings.android.slevo.ui.util.GestureHint
 
 @Composable
 fun GestureHintOverlay(
@@ -40,10 +43,11 @@ fun GestureHintOverlay(
                     modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp),
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
-                    Text(
-                        text = stringResource(id = state.direction.labelRes),
-                        style = MaterialTheme.typography.titleMedium,
-                        textAlign = TextAlign.Center,
+                    Icon(
+                        painter = painterResource(id = state.direction.iconRes),
+                        contentDescription = stringResource(id = state.direction.labelRes),
+                        modifier = Modifier.size(48.dp),
+                        tint = MaterialTheme.colorScheme.onSurface,
                     )
                     val message = state.action?.let { action ->
                         stringResource(id = action.labelRes)
@@ -52,7 +56,7 @@ fun GestureHintOverlay(
                         text = message,
                         style = MaterialTheme.typography.bodyMedium,
                         textAlign = TextAlign.Center,
-                        modifier = Modifier.padding(top = 4.dp),
+                        modifier = Modifier.padding(top = 8.dp),
                     )
                 }
             }
@@ -64,12 +68,14 @@ fun GestureHintOverlay(
         ) {
             OverlaySurface {
                 Text(
+                    modifier = Modifier
+                        .padding(horizontal = 24.dp, vertical = 16.dp),
                     text = stringResource(id = R.string.gesture_invalid_message),
-                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp),
                     style = MaterialTheme.typography.bodyMedium,
                     textAlign = TextAlign.Center,
                 )
             }
+
         }
     }
 }
@@ -84,12 +90,18 @@ private fun OverlaySurface(
     content: @Composable () -> Unit,
 ) {
     Surface(
-        modifier = modifier.width(240.dp).heightIn(min = 72.dp),
+        modifier = modifier
+            .width(240.dp)
+            .heightIn(min = 120.dp),
         tonalElevation = 6.dp,
         shape = MaterialTheme.shapes.medium,
         color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.9f),
     ) {
-        content()
+        Box(
+            contentAlignment = Alignment.Center,
+        ) {
+            content()
+        }
     }
 }
 

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/RouteScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/RouteScaffold.kt
@@ -13,7 +13,6 @@ import androidx.compose.material3.BottomAppBarScrollBehavior
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -93,6 +92,7 @@ fun <TabInfo : Any, UiState : BaseUiState<UiState>, ViewModel : BaseViewModel<Ui
                 currentPage >= 0 -> currentPage.coerceIn(0, tabs.size - 1)
                 currentTabInfo != null -> tabs.indexOf(currentTabInfo).takeIf { it >= 0 }
                     ?: 0
+
                 else -> 0
             }
         }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/RouteScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/RouteScaffold.kt
@@ -37,8 +37,11 @@ import com.websarva.wings.android.slevo.ui.common.bookmark.DeleteGroupDialog
 import com.websarva.wings.android.slevo.ui.common.bookmark.SingleBookmarkState
 import com.websarva.wings.android.slevo.ui.tabs.TabsBottomSheet
 import com.websarva.wings.android.slevo.ui.tabs.TabsViewModel
+import com.websarva.wings.android.slevo.ui.tabs.UrlOpenDialog
 import com.websarva.wings.android.slevo.ui.thread.state.ThreadUiState
 import com.websarva.wings.android.slevo.ui.thread.viewmodel.ThreadViewModel
+import com.websarva.wings.android.slevo.ui.util.parseBoardUrl
+import com.websarva.wings.android.slevo.ui.util.parseThreadUrl
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
@@ -73,6 +76,8 @@ fun <TabInfo : Any, UiState : BaseUiState<UiState>, ViewModel : BaseViewModel<Ui
         modifier: Modifier,
         navController: NavHostController,
         showBottomBar: (() -> Unit)?,
+        openTabListSheet: () -> Unit,
+        openUrlDialog: () -> Unit,
     ) -> Unit,
     bottomBarScrollBehavior: (@Composable (LazyListState) -> BottomAppBarScrollBehavior)? = null,
     optionalSheetContent: @Composable (viewModel: ViewModel, uiState: UiState) -> Unit = { _, _ -> }
@@ -123,6 +128,7 @@ fun <TabInfo : Any, UiState : BaseUiState<UiState>, ViewModel : BaseViewModel<Ui
         val bookmarkSheetState = rememberModalBottomSheetState()
         val tabListSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
         var showTabListSheet by rememberSaveable { mutableStateOf(false) }
+        var showUrlDialog by rememberSaveable { mutableStateOf(false) }
 
         val pagerUserScrollEnabled = when (
             val currentUiState = currentTabInfo?.let { tabInfo ->
@@ -220,6 +226,8 @@ fun <TabInfo : Any, UiState : BaseUiState<UiState>, ViewModel : BaseViewModel<Ui
                     contentModifier,
                     navController,
                     showBottomBar,
+                    { showTabListSheet = true },
+                    { showUrlDialog = true },
                 )
 
                 // 共通のボトムシートとダイアログ
@@ -312,6 +320,42 @@ fun <TabInfo : Any, UiState : BaseUiState<UiState>, ViewModel : BaseViewModel<Ui
                 navController = navController,
                 onDismissRequest = { showTabListSheet = false },
                 initialPage = initialPage,
+            )
+        }
+
+        if (showUrlDialog) {
+            UrlOpenDialog(
+                onDismissRequest = { showUrlDialog = false },
+                onOpen = { url ->
+                    val thread = parseThreadUrl(url)
+                    if (thread != null) {
+                        val (host, board, key) = thread
+                        val boardUrl = "https://$host/$board/"
+                        val route = AppRoute.Thread(
+                            threadKey = key,
+                            boardUrl = boardUrl,
+                            boardName = board,
+                            threadTitle = url
+                        )
+                        navController.navigateToThread(
+                            route = route,
+                            tabsViewModel = tabsViewModel,
+                        )
+                    } else {
+                        parseBoardUrl(url)?.let { (host, board) ->
+                            val boardUrl = "https://$host/$board/"
+                            val route = AppRoute.Board(
+                                boardName = boardUrl,
+                                boardUrl = boardUrl,
+                            )
+                            navController.navigateToBoard(
+                                route = route,
+                                tabsViewModel = tabsViewModel,
+                            )
+                        }
+                    }
+                    showUrlDialog = false
+                }
             )
         }
     } else {

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/RouteScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/RouteScaffold.kt
@@ -66,7 +66,14 @@ fun <TabInfo : Any, UiState : BaseUiState<UiState>, ViewModel : BaseViewModel<Ui
         scrollBehavior: BottomAppBarScrollBehavior?,
         openTabListSheet: () -> Unit,
     ) -> Unit,
-    content: @Composable (viewModel: ViewModel, uiState: UiState, listState: LazyListState, modifier: Modifier, navController: NavHostController) -> Unit,
+    content: @Composable (
+        viewModel: ViewModel,
+        uiState: UiState,
+        listState: LazyListState,
+        modifier: Modifier,
+        navController: NavHostController,
+        showBottomBar: (() -> Unit)?,
+    ) -> Unit,
     bottomBarScrollBehavior: (@Composable (LazyListState) -> BottomAppBarScrollBehavior)? = null,
     optionalSheetContent: @Composable (viewModel: ViewModel, uiState: UiState) -> Unit = { _, _ -> }
 ) {
@@ -176,6 +183,12 @@ fun <TabInfo : Any, UiState : BaseUiState<UiState>, ViewModel : BaseViewModel<Ui
 
             val bottomBehavior = bottomBarScrollBehavior?.invoke(listState)
             val swipeBlockerState = rememberDraggableState { _ -> }
+            val showBottomBar = bottomBehavior?.let { behavior ->
+                {
+                    behavior.state.heightOffset = 0f
+                }
+            }
+
             Scaffold(
                 modifier = Modifier
                     .let { modifier ->
@@ -205,7 +218,8 @@ fun <TabInfo : Any, UiState : BaseUiState<UiState>, ViewModel : BaseViewModel<Ui
                     uiState,
                     listState,
                     contentModifier,
-                    navController
+                    navController,
+                    showBottomBar,
                 )
 
                 // 共通のボトムシートとダイアログ

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/settings/SettingsGestureScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/settings/SettingsGestureScreen.kt
@@ -2,18 +2,20 @@ package com.websarva.wings.android.slevo.ui.settings
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
@@ -26,6 +28,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -84,6 +87,14 @@ fun SettingsGestureScreen(
                 }
                 ListItem(
                     modifier = itemModifier,
+                    leadingContent = {
+                        Icon(
+                            painter = painterResource(id = item.direction.iconRes),
+                            contentDescription = directionLabel,
+                            modifier = Modifier.size(32.dp),
+                            tint = MaterialTheme.colorScheme.onSurface,
+                        )
+                    },
                     headlineContent = { Text(directionLabel) },
                     trailingContent = { Text(actionLabel) }
                 )

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/settings/SettingsGestureScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/settings/SettingsGestureScreen.kt
@@ -1,7 +1,6 @@
 package com.websarva.wings.android.slevo.ui.settings
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -12,6 +11,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -110,14 +111,21 @@ fun SettingsGestureScreen(
             onDismissRequest = { viewModel.dismissGestureDialog() },
             title = { Text(text = stringResource(id = direction.labelRes)) },
             text = {
-                Column(modifier = Modifier.fillMaxWidth()) {
-                    GestureActionSelectionRow(
-                        label = stringResource(id = R.string.gesture_action_unassigned),
-                        selected = currentAction == null,
-                        onClick = { viewModel.assignGestureAction(direction, null) }
-                    )
-                    Spacer(modifier = Modifier.height(4.dp))
-                    actions.forEachIndexed { index, action ->
+                // Use LazyColumn for better performance with many items and limit max height
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = 320.dp)
+                ) {
+                    item {
+                        GestureActionSelectionRow(
+                            label = stringResource(id = R.string.gesture_action_unassigned),
+                            selected = currentAction == null,
+                            onClick = { viewModel.assignGestureAction(direction, null) }
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
+                    }
+                    itemsIndexed(actions) { index, action ->
                         GestureActionSelectionRow(
                             label = stringResource(id = action.labelRes),
                             selected = currentAction == action,

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabsViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabsViewModel.kt
@@ -227,6 +227,40 @@ class TabsViewModel @Inject constructor(
         _threadCurrentPage.value = page
     }
 
+    fun moveBoardPage(offset: Int) {
+        val tabs = _uiState.value.openBoardTabs
+        if (tabs.isEmpty()) return
+        val currentIndex = _boardCurrentPage.value.takeIf { it in tabs.indices } ?: 0
+        val targetIndex = currentIndex + offset
+        if (targetIndex in tabs.indices) {
+            setBoardCurrentPage(targetIndex)
+        }
+    }
+
+    fun moveThreadPage(offset: Int) {
+        val tabs = _uiState.value.openThreadTabs
+        if (tabs.isEmpty()) return
+        val currentIndex = _threadCurrentPage.value.takeIf { it in tabs.indices } ?: 0
+        val targetIndex = currentIndex + offset
+        if (targetIndex in tabs.indices) {
+            setThreadCurrentPage(targetIndex)
+        }
+    }
+
+    fun closeBoardTabByUrl(boardUrl: String) {
+        _uiState.value.openBoardTabs.find { it.boardUrl == boardUrl }?.let { tab ->
+            closeBoardTab(tab)
+        }
+    }
+
+    fun closeThreadTab(threadKey: String, boardUrl: String) {
+        val (host, board) = parseBoardUrl(boardUrl) ?: return
+        val id = ThreadId.of(host, board, threadKey)
+        _uiState.value.openThreadTabs.find { it.id == id }?.let { tab ->
+            closeThreadTab(tab)
+        }
+    }
+
     /**
      * 指定された板ID・URL・板名からBoardInfoを解決する。
      * - boardIdが有効ならそれを優先。

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -183,7 +183,7 @@ fun ThreadScaffold(
                 }
             }
         },
-        content = { viewModel, uiState, listState, modifier, navController ->
+        content = { viewModel, uiState, listState, modifier, navController, showBottomBar ->
             LaunchedEffect(uiState.threadInfo.key, uiState.isLoading) {
                 // スレッドタイトルが空でなく、投稿リストが取得済みの場合にタブ情報を更新
                 if (
@@ -216,6 +216,7 @@ fun ThreadScaffold(
                 listState = listState,
                 navController = navController,
                 tabsViewModel = tabsViewModel,
+                showBottomBar = showBottomBar,
                 onAutoScrollBottom = { viewModel.onAutoScrollReachedBottom() },
                 onBottomRefresh = { viewModel.reloadThread() },
                 onLastRead = { resNum ->

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -28,6 +28,7 @@ import androidx.navigation.NavHostController
 import com.websarva.wings.android.slevo.R
 import com.websarva.wings.android.slevo.data.model.BoardInfo
 import com.websarva.wings.android.slevo.data.model.ThreadId
+import com.websarva.wings.android.slevo.data.model.GestureAction
 import com.websarva.wings.android.slevo.ui.common.PostDialog
 import com.websarva.wings.android.slevo.ui.common.PostingDialog
 import com.websarva.wings.android.slevo.ui.common.SearchBottomBar
@@ -220,7 +221,16 @@ fun ThreadScaffold(
                 onLastRead = { resNum ->
                     routeThreadId?.let { viewModel.updateThreadLastRead(it, resNum) }
                 },
-                onReplyToPost = { viewModel.showReplyDialog(it) }
+                onReplyToPost = { viewModel.showReplyDialog(it) },
+                gestureSettings = uiState.gestureSettings,
+                onGestureAction = { action ->
+                    when (action) {
+                        GestureAction.Refresh -> viewModel.reloadThread()
+                        GestureAction.PostOrCreateThread -> viewModel.showPostDialog()
+                        GestureAction.Search -> viewModel.startSearch()
+                        GestureAction.ToTop, GestureAction.ToBottom -> Unit
+                    }
+                }
             )
         },
         optionalSheetContent = { viewModel, uiState ->

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -183,7 +183,7 @@ fun ThreadScaffold(
                 }
             }
         },
-        content = { viewModel, uiState, listState, modifier, navController, showBottomBar ->
+        content = { viewModel, uiState, listState, modifier, navController, showBottomBar, openTabListSheet, openUrlDialog ->
             LaunchedEffect(uiState.threadInfo.key, uiState.isLoading) {
                 // スレッドタイトルが空でなく、投稿リストが取得済みの場合にタブ情報を更新
                 if (
@@ -229,6 +229,17 @@ fun ThreadScaffold(
                         GestureAction.Refresh -> viewModel.reloadThread()
                         GestureAction.PostOrCreateThread -> viewModel.showPostDialog()
                         GestureAction.Search -> viewModel.startSearch()
+                        GestureAction.OpenTabList -> openTabListSheet()
+                        GestureAction.OpenBookmarkList -> navController.navigate(AppRoute.BookmarkList)
+                        GestureAction.OpenBoardList -> navController.navigate(AppRoute.ServiceList)
+                        GestureAction.OpenHistory -> navController.navigate(AppRoute.HistoryList)
+                        GestureAction.OpenNewTab -> openUrlDialog()
+                        GestureAction.SwitchToNextTab -> tabsViewModel.moveThreadPage(1)
+                        GestureAction.SwitchToPreviousTab -> tabsViewModel.moveThreadPage(-1)
+                        GestureAction.CloseTab ->
+                            if (uiState.threadInfo.key.isNotBlank() && uiState.boardInfo.url.isNotBlank()) {
+                                tabsViewModel.closeThreadTab(uiState.threadInfo.key, uiState.boardInfo.url)
+                            }
                         GestureAction.ToTop, GestureAction.ToBottom -> Unit
                     }
                 }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
@@ -234,7 +234,7 @@ fun ThreadScreen(
                 gestureHint = GestureHint.Hidden
                 when (action) {
                     GestureAction.ToTop -> coroutineScope.launch {
-                        listState.animateScrollToItem(0)
+                        listState.scrollToItem(0)
                     }
 
                     GestureAction.ToBottom -> coroutineScope.launch {
@@ -245,9 +245,7 @@ fun ThreadScreen(
                             fallback > 0 -> fallback
                             else -> 0
                         }
-                        if (targetIndex >= 0) {
-                            listState.animateScrollToItem(targetIndex)
-                        }
+                        listState.scrollToItem(targetIndex)
                     }
 
                     else -> onGestureAction(action)

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/state/ThreadUiState.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/state/ThreadUiState.kt
@@ -2,6 +2,7 @@ package com.websarva.wings.android.slevo.ui.thread.state
 
 import com.websarva.wings.android.slevo.data.model.BoardInfo
 import com.websarva.wings.android.slevo.data.model.DEFAULT_THREAD_LINE_HEIGHT
+import com.websarva.wings.android.slevo.data.model.GestureSettings
 import com.websarva.wings.android.slevo.data.model.ThreadInfo
 import com.websarva.wings.android.slevo.ui.common.BaseUiState
 import com.websarva.wings.android.slevo.ui.common.bookmark.SingleBookmarkState
@@ -44,6 +45,7 @@ data class ThreadUiState(
     val visiblePosts: List<DisplayPost> = emptyList(),
     val replyCounts: List<Int> = emptyList(),
     val firstAfterIndex: Int = -1,
+    val gestureSettings: GestureSettings = GestureSettings.DEFAULT,
 ) : BaseUiState<ThreadUiState> {
     override fun copyState(
         isLoading: Boolean,

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/viewmodel/ThreadViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/viewmodel/ThreadViewModel.kt
@@ -113,6 +113,11 @@ class ThreadViewModel @AssistedInject constructor(
                 _uiState.update { it.copy(showMinimapScrollbar = enabled) }
             }
         }
+        viewModelScope.launch {
+            settingsRepository.observeGestureSettings().collect { settings ->
+                _uiState.update { it.copy(gestureSettings = settings) }
+            }
+        }
     }
 
     internal val _postUiState = MutableStateFlow(PostUiState())

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/util/BottomBarUtils.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/util/BottomBarUtils.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -36,7 +37,7 @@ fun rememberBottomBarShowOnBottomBehavior(
     val barState = rememberBottomAppBarState()
     var atBottomSticky by remember { mutableStateOf(false) }
     // 保持ロック (ミリ秒)。sticky にした時点から最低この時刻までは解除を無視する
-    var stickyLockUntil by remember { mutableStateOf(0L) }
+    var stickyLockUntil by remember { mutableLongStateOf(0L) }
 
     // 末尾アイテムが“可視か”と、そのときのビューポート下端との隙間(px)
     val lastVisibleAndGap by remember {

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/util/GestureHint.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/util/GestureHint.kt
@@ -1,0 +1,15 @@
+package com.websarva.wings.android.slevo.ui.util
+
+import com.websarva.wings.android.slevo.data.model.GestureAction
+import com.websarva.wings.android.slevo.data.model.GestureDirection
+
+sealed interface GestureHint {
+    data object Hidden : GestureHint
+
+    data class Direction(
+        val direction: GestureDirection,
+        val action: GestureAction?,
+    ) : GestureHint
+
+    data object Invalid : GestureHint
+}

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/util/GestureUtils.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/util/GestureUtils.kt
@@ -1,11 +1,11 @@
 package com.websarva.wings.android.slevo.ui.util
 
-import androidx.compose.runtime.composed
+import android.annotation.SuppressLint
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.input.pointer.awaitEachGesture
-import androidx.compose.ui.input.pointer.awaitFirstDown
-import androidx.compose.ui.input.pointer.awaitPointerEvent
 import androidx.compose.ui.input.pointer.changedToUpIgnoreConsumed
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChange
@@ -22,6 +22,7 @@ private enum class HorizontalDirection {
     Left,
 }
 
+@SuppressLint("UnnecessaryComposedModifier")
 fun Modifier.detectDirectionalGesture(
     enabled: Boolean,
     threshold: Dp = 64.dp,
@@ -31,7 +32,7 @@ fun Modifier.detectDirectionalGesture(
         this
     } else {
         val thresholdPx = with(LocalDensity.current) { threshold.toPx() }
-        pointerInput(enabled, thresholdPx) {
+        pointerInput(true, thresholdPx) {
             if (!enabled) return@pointerInput
             awaitEachGesture {
                 val down = awaitFirstDown(requireUnconsumed = false)

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/util/GestureUtils.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/util/GestureUtils.kt
@@ -1,0 +1,113 @@
+package com.websarva.wings.android.slevo.ui.util
+
+import androidx.compose.runtime.composed
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.awaitEachGesture
+import androidx.compose.ui.input.pointer.awaitFirstDown
+import androidx.compose.ui.input.pointer.awaitPointerEvent
+import androidx.compose.ui.input.pointer.changedToUpIgnoreConsumed
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.websarva.wings.android.slevo.data.model.GestureDirection
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.min
+
+private enum class HorizontalDirection {
+    Right,
+    Left,
+}
+
+fun Modifier.detectDirectionalGesture(
+    enabled: Boolean,
+    threshold: Dp = 64.dp,
+    onGesture: (GestureDirection) -> Unit,
+): Modifier = composed {
+    if (!enabled) {
+        this
+    } else {
+        val thresholdPx = with(LocalDensity.current) { threshold.toPx() }
+        pointerInput(enabled, thresholdPx) {
+            if (!enabled) return@pointerInput
+            awaitEachGesture {
+                val down = awaitFirstDown(requireUnconsumed = false)
+                val pointerId = down.id
+                val path = mutableListOf(Offset.Zero)
+                var totalOffset = Offset.Zero
+
+                while (true) {
+                    val event = awaitPointerEvent()
+                    val change = event.changes.firstOrNull { it.id == pointerId } ?: continue
+                    val delta = change.positionChange()
+                    if (delta != Offset.Zero) {
+                        totalOffset += delta
+                        path.add(totalOffset)
+                    }
+                    if (change.changedToUpIgnoreConsumed()) {
+                        detectGestureDirection(path, thresholdPx)?.let(onGesture)
+                        break
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun detectGestureDirection(
+    path: List<Offset>,
+    thresholdPx: Float,
+): GestureDirection? {
+    if (path.size < 2) return null
+    val firstIndex = path.indexOfFirst { offset ->
+        abs(offset.x) >= thresholdPx
+    }
+    if (firstIndex == -1) return null
+    val firstPoint = path[firstIndex]
+    if (abs(firstPoint.x) < abs(firstPoint.y)) return null
+
+    val firstDirection = if (firstPoint.x > 0f) {
+        HorizontalDirection.Right
+    } else {
+        HorizontalDirection.Left
+    }
+
+    if (firstIndex == path.lastIndex) {
+        return when (firstDirection) {
+            HorizontalDirection.Right -> GestureDirection.Right
+            HorizontalDirection.Left -> GestureDirection.Left
+        }
+    }
+
+    var maxX = firstPoint.x
+    var minX = firstPoint.x
+    var maxY = firstPoint.y
+    var minY = firstPoint.y
+
+    for (i in firstIndex + 1 until path.size) {
+        val point = path[i]
+        maxX = max(maxX, point.x)
+        minX = min(minX, point.x)
+        maxY = max(maxY, point.y)
+        minY = min(minY, point.y)
+    }
+
+    return when (firstDirection) {
+        HorizontalDirection.Right -> when {
+            firstPoint.y - minY >= thresholdPx -> GestureDirection.RightUp
+            maxY - firstPoint.y >= thresholdPx -> GestureDirection.RightDown
+            firstPoint.x - minX >= thresholdPx -> GestureDirection.RightLeft
+            else -> GestureDirection.Right
+        }
+
+        HorizontalDirection.Left -> when {
+            firstPoint.y - minY >= thresholdPx -> GestureDirection.LeftUp
+            maxY - firstPoint.y >= thresholdPx -> GestureDirection.LeftDown
+            maxX - firstPoint.x >= thresholdPx -> GestureDirection.LeftRight
+            else -> GestureDirection.Left
+        }
+    }
+}

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/util/GestureUtils.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/util/GestureUtils.kt
@@ -1,14 +1,11 @@
 package com.websarva.wings.android.slevo.ui.util
 
-import androidx.compose.ui.composed
+import android.R.attr.enabled
 import android.annotation.SuppressLint
-import androidx.compose.foundation.gestures.awaitEachGesture
-import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.foundation.gestures.detectDragGestures
-import androidx.compose.ui.input.pointer.changedToUpIgnoreConsumed
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
@@ -18,109 +15,205 @@ import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
 
+// 水平方向の向きを簡潔に表すための列挙型
 private enum class HorizontalDirection {
     Right,
     Left,
 }
 
+// ジェスチャー検出の結果を表すシールドクラス
+// - None: 判定不能（まだ閾値に達していない等）
+// - Invalid: 複数方向の移動が混在して判定不可
+// - Direction: 有効な方向が確定した（GestureDirection を持つ）
+private sealed interface GestureDetectionResult {
+    data object None : GestureDetectionResult
+    data object Invalid : GestureDetectionResult
+    data class Direction(val value: GestureDirection) : GestureDetectionResult
+}
+
 @SuppressLint("UnnecessaryComposedModifier")
 fun Modifier.detectDirectionalGesture(
     enabled: Boolean,
-    threshold: Dp = 64.dp,
+    threshold: Dp = 48.dp,
     onGestureProgress: (GestureDirection?) -> Unit = {},
     onGestureInvalid: () -> Unit = {},
     onGesture: (GestureDirection) -> Unit,
 ): Modifier = composed {
+    // 有効フラグが false の場合は何もしない Modifier を返す
     if (!enabled) {
         this
     } else {
+        // DP 単位の閾値をピクセルに変換
         val thresholdPx = with(LocalDensity.current) { threshold.toPx() }
         pointerInput(true, thresholdPx) {
             if (!enabled) return@pointerInput
+            // path: ドラッグの累積オフセットを記録するリスト
+            // totalOffset: 前回からのドラッグ量を累積した合計オフセット
+            // lastDirection: 前回通知した方向（変化があった時のみ通知する）
+            // isInvalid: すでに不正（複数方向が混在）と判定済みか
             var path = mutableListOf(Offset.Zero)
             var totalOffset = Offset.Zero
             var lastDirection: GestureDirection? = null
+            var isInvalid = false
 
             detectDragGestures(
                 onDragStart = {
+                    // ドラッグ開始時はプログレスをリセットして状態を初期化
                     onGestureProgress(null)
                     path = mutableListOf(Offset.Zero)
                     totalOffset = Offset.Zero
                     lastDirection = null
+                    isInvalid = false
                 },
                 onDrag = { change, dragAmount ->
+                    // 既に不正判定なら以降の移動は消費して無視
+                    if (isInvalid) {
+                        change.consume()
+                        return@detectDragGestures
+                    }
+                    // 合計移動量を更新してパスに追加
                     totalOffset += dragAmount
                     path.add(totalOffset)
-                    val direction = detectGestureDirection(path, thresholdPx)
-                    if (direction != lastDirection) {
-                        lastDirection = direction
-                        onGestureProgress(direction)
+
+                    // 現在のパスを元に方向を判定
+                    when (val result = detectGestureDirection(path, thresholdPx)) {
+                        GestureDetectionResult.None -> Unit // まだ判定できない
+                        GestureDetectionResult.Invalid -> {
+                            // 初めて Invalid になった場合のみ onGestureInvalid を呼ぶ
+                            if (!isInvalid) {
+                                // 既に何か方向が通知されていたら progress をリセット
+                                if (lastDirection != null) {
+                                    onGestureProgress(null)
+                                    lastDirection = null
+                                }
+                                isInvalid = true
+                                onGestureInvalid()
+                            }
+                        }
+
+                        is GestureDetectionResult.Direction -> {
+                            // 新しい方向が検出されたら onGestureProgress を呼ぶ（前回と同じなら何もしない）
+                            val direction = result.value
+                            if (direction != lastDirection) {
+                                lastDirection = direction
+                                onGestureProgress(direction)
+                            }
+                        }
                     }
+                    // イベントを消費（他へ伝搬しない）
                     change.consume()
                 },
                 onDragCancel = {
+                    // キャンセル時は進行中の表示をリセット
                     if (lastDirection != null) {
                         onGestureProgress(null)
                         lastDirection = null
                     } else {
                         onGestureProgress(null)
                     }
-                    onGestureInvalid()
-                },
-                onDragEnd = {
-                    val direction = detectGestureDirection(path, thresholdPx)
-                    if (direction != null) {
-                        onGesture(direction)
-                        if (lastDirection != null) {
-                            onGestureProgress(null)
-                            lastDirection = null
-                        }
-                    } else {
-                        if (lastDirection != null) {
-                            onGestureProgress(null)
-                            lastDirection = null
-                        } else {
-                            onGestureProgress(null)
-                        }
+                    // まだ isInvalid が false（未通知）の場合は無効通知を送る
+                    if (!isInvalid) {
                         onGestureInvalid()
                     }
+                    isInvalid = false
+                },
+                onDragEnd = {
+                    // ドラッグ終了時に最終判定を行い、確定したら onGesture を呼ぶ
+                    val result = detectGestureDirection(path, thresholdPx)
+                    when (result) {
+                        is GestureDetectionResult.Direction -> {
+                            // 有効な方向として確定
+                            onGesture(result.value)
+                            if (lastDirection != null) {
+                                onGestureProgress(null)
+                                lastDirection = null
+                            }
+                        }
+
+                        GestureDetectionResult.Invalid -> {
+                            // 不正終了（混在など）は invalid を通知
+                            if (lastDirection != null) {
+                                onGestureProgress(null)
+                                lastDirection = null
+                            } else {
+                                onGestureProgress(null)
+                            }
+                            if (!isInvalid) {
+                                onGestureInvalid()
+                            }
+                        }
+
+                        GestureDetectionResult.None -> {
+                            // 判定不能（短い移動など）は progress をリセットして invalid 通知
+                            if (lastDirection != null) {
+                                onGestureProgress(null)
+                                lastDirection = null
+                            } else {
+                                onGestureProgress(null)
+                            }
+                            if (!isInvalid) {
+                                onGestureInvalid()
+                            }
+                        }
+                    }
+                    isInvalid = false
                 }
             )
         }
     }
 }
 
+// path: ドラッグ時に記録した累積オフセットのリスト
+// thresholdPx: 判定に使用する閾値（ピクセル）
+// アルゴリズム概要:
+// 1) path の中から最初に水平移動が閾値を越えた点を見つける（firstPoint）
+// 2) firstPoint から初期の水平方向に伸びた経路のうち、方向が確定的に切り替わった地点
+//    （switchPoint）を特定する
+// 3) switchPoint 以降の点の最大/最小 X/Y を算出し、最初の水平方向（右/左）に対して
+//    上/下/戻り/前進 のうちどれが閾値を越えたかを判定する
+// 4) 複数の方向が閾値を越えていた場合は Invalid、1 つだけなら対応する GestureDirection を返す
 private fun detectGestureDirection(
     path: List<Offset>,
     thresholdPx: Float,
-): GestureDirection? {
-    if (path.size < 2) return null
+): GestureDetectionResult {
+    // 最低でも開始点と 1 点は必要
+    if (path.size < 2) return GestureDetectionResult.None
+
+    // 最初に水平成分が閾値を越えたインデックスを探す
     val firstIndex = path.indexOfFirst { offset ->
         abs(offset.x) >= thresholdPx
     }
-    if (firstIndex == -1) return null
-    val firstPoint = path[firstIndex]
-    if (abs(firstPoint.x) < abs(firstPoint.y)) return null
+    if (firstIndex == -1) return GestureDetectionResult.None
 
+    val firstPoint = path[firstIndex]
+    // その点が主に水平移動であることを確認（水平成分が垂直成分より大きい）
+    if (abs(firstPoint.x) < abs(firstPoint.y)) return GestureDetectionResult.None
+
+    // 最初の水平方向を決定（x が正なら右、負なら左）
     val firstDirection = if (firstPoint.x > 0f) {
         HorizontalDirection.Right
     } else {
         HorizontalDirection.Left
     }
 
+    // もし firstPoint が path の最後の要素なら、その時点で横方向のみ確定
     if (firstIndex == path.lastIndex) {
         return when (firstDirection) {
-            HorizontalDirection.Right -> GestureDirection.Right
-            HorizontalDirection.Left -> GestureDirection.Left
+            HorizontalDirection.Right -> GestureDetectionResult.Direction(GestureDirection.Right)
+            HorizontalDirection.Left -> GestureDetectionResult.Direction(GestureDirection.Left)
         }
     }
 
-    var maxX = firstPoint.x
-    var minX = firstPoint.x
-    var maxY = firstPoint.y
-    var minY = firstPoint.y
+    val switchIndex = findDirectionSwitchIndex(path, firstIndex, firstDirection, thresholdPx)
+    val switchPoint = path[switchIndex]
 
-    for (i in firstIndex + 1 until path.size) {
+    // 以降の点を走査して X/Y の最大・最小を求める
+    var maxX = switchPoint.x
+    var minX = switchPoint.x
+    var maxY = switchPoint.y
+    var minY = switchPoint.y
+
+    for (i in switchIndex + 1 until path.size) {
         val point = path[i]
         maxX = max(maxX, point.x)
         minX = min(minX, point.x)
@@ -128,19 +221,129 @@ private fun detectGestureDirection(
         minY = min(minY, point.y)
     }
 
+    // 最初の方向（右/左）ごとの判定
     return when (firstDirection) {
-        HorizontalDirection.Right -> when {
-            firstPoint.y - minY >= thresholdPx -> GestureDirection.RightUp
-            maxY - firstPoint.y >= thresholdPx -> GestureDirection.RightDown
-            firstPoint.x - minX >= thresholdPx -> GestureDirection.RightLeft
-            else -> GestureDirection.Right
+        HorizontalDirection.Right -> {
+            // 右に最初に動いた場合の追加変化を判定
+            // movedUp: 最初の y から上方向へ閾値以上移動したか
+            // movedDown: 最初の y から下方向へ閾値以上移動したか
+            // movedBack: 最初の x から戻る方向（左）へ閾値以上移動したか
+            // movedForward: 最初の x からさらに進む方向（右）へ閾値以上移動したか
+            val movedUp = switchPoint.y - minY >= thresholdPx
+            val movedDown = maxY - switchPoint.y >= thresholdPx
+            val movedBack = switchPoint.x - minX >= thresholdPx
+            val movedForward = maxX - switchPoint.x >= thresholdPx
+
+            // 複数のフラグが true なら混在していると判断
+            val movementCount = listOf(movedUp, movedDown, movedBack, movedForward).count { it }
+            if (movementCount > 1) {
+                GestureDetectionResult.Invalid
+            } else when {
+                movedUp -> GestureDetectionResult.Direction(GestureDirection.RightUp)
+                movedDown -> GestureDetectionResult.Direction(GestureDirection.RightDown)
+                movedBack -> GestureDetectionResult.Direction(GestureDirection.RightLeft)
+                else -> GestureDetectionResult.Direction(GestureDirection.Right)
+            }
         }
 
-        HorizontalDirection.Left -> when {
-            firstPoint.y - minY >= thresholdPx -> GestureDirection.LeftUp
-            maxY - firstPoint.y >= thresholdPx -> GestureDirection.LeftDown
-            maxX - firstPoint.x >= thresholdPx -> GestureDirection.LeftRight
-            else -> GestureDirection.Left
+        HorizontalDirection.Left -> {
+            // 左に最初に動いた場合の追加変化を判定
+            val movedUp = switchPoint.y - minY >= thresholdPx
+            val movedDown = maxY - switchPoint.y >= thresholdPx
+            val movedBack = maxX - switchPoint.x >= thresholdPx
+            val movedForward = switchPoint.x - minX >= thresholdPx
+
+            val movementCount = listOf(movedUp, movedDown, movedBack, movedForward).count { it }
+            if (movementCount > 1) {
+                GestureDetectionResult.Invalid
+            } else when {
+                movedUp -> GestureDetectionResult.Direction(GestureDirection.LeftUp)
+                movedDown -> GestureDetectionResult.Direction(GestureDirection.LeftDown)
+                movedBack -> GestureDetectionResult.Direction(GestureDirection.LeftRight)
+                else -> GestureDetectionResult.Direction(GestureDirection.Left)
+            }
+        }
+    }
+}
+
+private fun findDirectionSwitchIndex(
+    path: List<Offset>,
+    firstIndex: Int,
+    firstDirection: HorizontalDirection,
+    thresholdPx: Float,
+): Int {
+    var switchIndex = firstIndex
+    var switchPoint = path[firstIndex]
+
+    return when (firstDirection) {
+        HorizontalDirection.Right -> {
+            var furthestX = switchPoint.x
+            var minY = switchPoint.y
+            var maxY = switchPoint.y
+            var minX = switchPoint.x
+
+            for (i in firstIndex + 1 until path.size) {
+                val point = path[i]
+
+                if (point.x > furthestX) {
+                    furthestX = point.x
+                    switchIndex = i
+                    switchPoint = point
+                    minY = point.y
+                    maxY = point.y
+                    minX = point.x
+                    continue
+                }
+
+                minY = min(minY, point.y)
+                maxY = max(maxY, point.y)
+                minX = min(minX, point.x)
+
+                val movedUp = switchPoint.y - minY >= thresholdPx
+                val movedDown = maxY - switchPoint.y >= thresholdPx
+                val movedBack = switchPoint.x - minX >= thresholdPx
+
+                if (movedUp || movedDown || movedBack) {
+                    return switchIndex
+                }
+            }
+
+            switchIndex
+        }
+
+        HorizontalDirection.Left -> {
+            var furthestX = switchPoint.x
+            var minY = switchPoint.y
+            var maxY = switchPoint.y
+            var maxX = switchPoint.x
+
+            for (i in firstIndex + 1 until path.size) {
+                val point = path[i]
+
+                if (point.x < furthestX) {
+                    furthestX = point.x
+                    switchIndex = i
+                    switchPoint = point
+                    minY = point.y
+                    maxY = point.y
+                    maxX = point.x
+                    continue
+                }
+
+                minY = min(minY, point.y)
+                maxY = max(maxY, point.y)
+                maxX = max(maxX, point.x)
+
+                val movedUp = switchPoint.y - minY >= thresholdPx
+                val movedDown = maxY - switchPoint.y >= thresholdPx
+                val movedBack = maxX - switchPoint.x >= thresholdPx
+
+                if (movedUp || movedDown || movedBack) {
+                    return switchIndex
+                }
+            }
+
+            switchIndex
         }
     }
 }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/util/GestureUtils.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/util/GestureUtils.kt
@@ -1,6 +1,5 @@
 package com.websarva.wings.android.slevo.ui.util
 
-import android.R.attr.enabled
 import android.annotation.SuppressLint
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.ui.Modifier

--- a/app/src/main/res/drawable/ic_gesture_left.xml
+++ b/app/src/main/res/drawable/ic_gesture_left.xml
@@ -1,0 +1,25 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <group
+        android:scaleX="-1"
+        android:pivotX="12"
+        android:pivotY="12">
+        <path
+            android:fillColor="#00000000"
+            android:pathData="M3,12 H21"
+            android:strokeWidth="2"
+            android:strokeColor="#FF000000"
+            android:strokeLineCap="round"
+            android:strokeLineJoin="round" />
+        <path
+            android:fillColor="#00000000"
+            android:pathData="M21,12 L17,8 M 21,12 L17,16"
+            android:strokeWidth="2"
+            android:strokeColor="#FF000000"
+            android:strokeLineCap="round"
+            android:strokeLineJoin="round" />
+    </group>
+</vector>

--- a/app/src/main/res/drawable/ic_gesture_left_then_down.xml
+++ b/app/src/main/res/drawable/ic_gesture_left_then_down.xml
@@ -1,0 +1,32 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <group
+        android:scaleX="-1"
+        android:pivotX="12"
+        android:pivotY="12">
+        <path
+            android:fillColor="#00000000"
+            android:pathData="M3,4 H17"
+            android:strokeWidth="2"
+            android:strokeColor="#FF000000"
+            android:strokeLineCap="round"
+            android:strokeLineJoin="round" />
+        <path
+            android:fillColor="#00000000"
+            android:pathData="M17,4 V18"
+            android:strokeWidth="2"
+            android:strokeColor="#FF000000"
+            android:strokeLineCap="round"
+            android:strokeLineJoin="round" />
+        <path
+            android:fillColor="#00000000"
+            android:pathData="M17,20 L13,16 M 17,20 L21,16"
+            android:strokeWidth="2"
+            android:strokeColor="#FF000000"
+            android:strokeLineCap="round"
+            android:strokeLineJoin="round" />
+    </group>
+</vector>

--- a/app/src/main/res/drawable/ic_gesture_left_then_right.xml
+++ b/app/src/main/res/drawable/ic_gesture_left_then_right.xml
@@ -1,0 +1,38 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <group
+        android:pivotX="2"
+        android:pivotY="12"
+        android:rotation="-15"> <!-- ここで角度を指定 -->
+        <path
+            android:fillColor="#00000000"
+            android:pathData="M2,12 H22"
+            android:strokeWidth="2"
+            android:strokeColor="#FF000000"
+            android:strokeLineCap="round"
+            android:strokeLineJoin="round" />
+    </group>
+
+    <group
+        android:pivotX="2"
+        android:pivotY="12"
+        android:rotation="15"> <!-- ここで角度を指定 -->
+        <path
+            android:fillColor="#00000000"
+            android:pathData="M2,12 H22"
+            android:strokeWidth="2"
+            android:strokeColor="#FF000000"
+            android:strokeLineCap="round"
+            android:strokeLineJoin="round" />
+        <path
+            android:fillColor="#00000000"
+            android:pathData="M22,12 L18,8 M 22,12 L18,16"
+            android:strokeWidth="2"
+            android:strokeColor="#FF000000"
+            android:strokeLineCap="round"
+            android:strokeLineJoin="round" />
+    </group>
+</vector>

--- a/app/src/main/res/drawable/ic_gesture_left_then_up.xml
+++ b/app/src/main/res/drawable/ic_gesture_left_then_up.xml
@@ -1,0 +1,33 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <group
+        android:scaleX="-1"
+        android:scaleY="-1"
+        android:pivotX="12"
+        android:pivotY="12">
+        <path
+            android:fillColor="#00000000"
+            android:pathData="M3,4 H17"
+            android:strokeWidth="2"
+            android:strokeColor="#FF000000"
+            android:strokeLineCap="round"
+            android:strokeLineJoin="round" />
+        <path
+            android:fillColor="#00000000"
+            android:pathData="M17,4 V18"
+            android:strokeWidth="2"
+            android:strokeColor="#FF000000"
+            android:strokeLineCap="round"
+            android:strokeLineJoin="round" />
+        <path
+            android:fillColor="#00000000"
+            android:pathData="M17,20 L13,16 M 17,20 L21,16"
+            android:strokeWidth="2"
+            android:strokeColor="#FF000000"
+            android:strokeLineCap="round"
+            android:strokeLineJoin="round" />
+    </group>
+</vector>

--- a/app/src/main/res/drawable/ic_gesture_right.xml
+++ b/app/src/main/res/drawable/ic_gesture_right.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M3,12 H21"
+        android:strokeWidth="2"
+        android:strokeColor="#FF000000"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M21,12 L17,8 M 21,12 L17,16"
+        android:strokeWidth="2"
+        android:strokeColor="#FF000000"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+</vector>

--- a/app/src/main/res/drawable/ic_gesture_right_then_down.xml
+++ b/app/src/main/res/drawable/ic_gesture_right_then_down.xml
@@ -1,0 +1,27 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M3,4 H17"
+        android:strokeWidth="2"
+        android:strokeColor="#FF000000"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M17,4 V18"
+        android:strokeWidth="2"
+        android:strokeColor="#FF000000"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M17,20 L13,16 M 17,20 L21,16"
+        android:strokeWidth="2"
+        android:strokeColor="#FF000000"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+</vector>

--- a/app/src/main/res/drawable/ic_gesture_right_then_left.xml
+++ b/app/src/main/res/drawable/ic_gesture_right_then_left.xml
@@ -1,0 +1,43 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <group
+        android:scaleX="-1"
+        android:pivotX="12"
+        android:pivotY="12">
+        <group
+            android:pivotX="2"
+            android:pivotY="12"
+            android:rotation="-15"> <!-- ここで角度を指定 -->
+            <path
+                android:fillColor="#00000000"
+                android:pathData="M2,12 H22"
+                android:strokeWidth="2"
+                android:strokeColor="#FF000000"
+                android:strokeLineCap="round"
+                android:strokeLineJoin="round" />
+        </group>
+
+        <group
+            android:pivotX="2"
+            android:pivotY="12"
+            android:rotation="15"> <!-- ここで角度を指定 -->
+            <path
+                android:fillColor="#00000000"
+                android:pathData="M2,12 H22"
+                android:strokeWidth="2"
+                android:strokeColor="#FF000000"
+                android:strokeLineCap="round"
+                android:strokeLineJoin="round" />
+            <path
+                android:fillColor="#00000000"
+                android:pathData="M22,12 L18,8 M 22,12 L18,16"
+                android:strokeWidth="2"
+                android:strokeColor="#FF000000"
+                android:strokeLineCap="round"
+                android:strokeLineJoin="round" />
+        </group>
+    </group>
+</vector>

--- a/app/src/main/res/drawable/ic_gesture_right_then_up.xml
+++ b/app/src/main/res/drawable/ic_gesture_right_then_up.xml
@@ -1,0 +1,32 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <group
+        android:scaleY="-1"
+        android:pivotX="12"
+        android:pivotY="12">
+        <path
+            android:fillColor="#00000000"
+            android:pathData="M3,4 H17"
+            android:strokeWidth="2"
+            android:strokeColor="#FF000000"
+            android:strokeLineCap="round"
+            android:strokeLineJoin="round" />
+        <path
+            android:fillColor="#00000000"
+            android:pathData="M17,4 V18"
+            android:strokeWidth="2"
+            android:strokeColor="#FF000000"
+            android:strokeLineCap="round"
+            android:strokeLineJoin="round" />
+        <path
+            android:fillColor="#00000000"
+            android:pathData="M17,20 L13,16 M 17,20 L21,16"
+            android:strokeWidth="2"
+            android:strokeColor="#FF000000"
+            android:strokeLineCap="round"
+            android:strokeLineJoin="round" />
+    </group>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,9 +95,11 @@
     <string name="enable_gesture_feature">ジェスチャー機能を有効にする</string>
     <string name="gesture_list_title">ジェスチャーの割り当て</string>
     <string name="gesture_action_unassigned">未設定</string>
+    <string name="gesture_action_unassigned_message">アクションが未定義です</string>
     <string name="gesture_action_to_top">先頭へ</string>
     <string name="gesture_action_to_bottom">末尾へ</string>
     <string name="gesture_action_post_or_create_thread">書き込み/スレッド作成</string>
+    <string name="gesture_invalid_message">ジェスチャーが無効です</string>
     <string name="gesture_direction_right">右</string>
     <string name="gesture_direction_right_up">右→上</string>
     <string name="gesture_direction_right_left">右→左</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,11 +95,11 @@
     <string name="enable_gesture_feature">ジェスチャー機能を有効にする</string>
     <string name="gesture_list_title">ジェスチャーの割り当て</string>
     <string name="gesture_action_unassigned">未設定</string>
-    <string name="gesture_action_unassigned_message">アクションが未定義です</string>
-    <string name="gesture_action_to_top">先頭へ</string>
-    <string name="gesture_action_to_bottom">末尾へ</string>
+    <string name="gesture_action_unassigned_message">アクションなし</string>
+    <string name="gesture_action_to_top">最上部までスクロール</string>
+    <string name="gesture_action_to_bottom">最下部までスクロール</string>
     <string name="gesture_action_post_or_create_thread">書き込み/スレッド作成</string>
-    <string name="gesture_invalid_message">ジェスチャーが無効です</string>
+    <string name="gesture_invalid_message">無効なジェスチャーです</string>
     <string name="gesture_direction_right">右</string>
     <string name="gesture_direction_right_up">右→上</string>
     <string name="gesture_direction_right_left">右→左</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -99,6 +99,14 @@
     <string name="gesture_action_to_top">最上部までスクロール</string>
     <string name="gesture_action_to_bottom">最下部までスクロール</string>
     <string name="gesture_action_post_or_create_thread">書き込み/スレッド作成</string>
+    <string name="gesture_action_open_tab_list">タブ一覧を表示</string>
+    <string name="gesture_action_open_bookmark_list">ブックマーク一覧を開く</string>
+    <string name="gesture_action_open_board_list">板一覧に移動</string>
+    <string name="gesture_action_open_history">履歴を開く</string>
+    <string name="gesture_action_open_new_tab">新しいタブを開く</string>
+    <string name="gesture_action_switch_to_next_tab">右のタブに切り替え</string>
+    <string name="gesture_action_switch_to_previous_tab">左のタブに切り替え</string>
+    <string name="gesture_action_close_tab">現在のタブを閉じる</string>
     <string name="gesture_invalid_message">無効なジェスチャーです</string>
     <string name="gesture_direction_right">右</string>
     <string name="gesture_direction_right_up">右→上</string>


### PR DESCRIPTION
## Summary
- enable directional gesture detection on board and thread content areas and trigger configured actions such as scrolling, refresh, search, and posting
- observe gesture settings in both BoardViewModel and ThreadViewModel so UI reacts to preference changes
- introduce a reusable gesture detection utility to translate swipe paths into configured gesture directions

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: KSP error, see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68dcef1922148332a67331bed0cc036b