### PR TITLE
feat: show gesture hints during directional gestures

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/common/GestureHintOverlay.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/common/GestureHintOverlay.kt
@@ -1,0 +1,73 @@
+package com.websarva.wings.android.slevo.ui.common
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.websarva.wings.android.slevo.R
+import com.websarva.wings.android.slevo.ui.util.GestureHint
+
+@Composable
+fun GestureHintOverlay(
+    state: GestureHint,
+    modifier: Modifier = Modifier,
+) {
+    when (state) {
+        is GestureHint.Hidden -> Unit
+        is GestureHint.Direction -> Box(
+            modifier = modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center,
+        ) {
+            Surface(
+                tonalElevation = 6.dp,
+                shape = MaterialTheme.shapes.medium,
+            ) {
+                Column(
+                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Text(
+                        text = stringResource(id = state.direction.labelRes),
+                        style = MaterialTheme.typography.titleMedium,
+                        textAlign = TextAlign.Center,
+                    )
+                    val message = state.action?.let { action ->
+                        stringResource(id = action.labelRes)
+                    } ?: stringResource(id = R.string.gesture_action_unassigned_message)
+                    Text(
+                        text = message,
+                        style = MaterialTheme.typography.bodyMedium,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.padding(top = 4.dp),
+                    )
+                }
+            }
+        }
+
+        GestureHint.Invalid -> Box(
+            modifier = modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center,
+        ) {
+            Surface(
+                tonalElevation = 6.dp,
+                shape = MaterialTheme.shapes.medium,
+            ) {
+                Text(
+                    text = stringResource(id = R.string.gesture_invalid_message),
+                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp),
+                    style = MaterialTheme.typography.bodyMedium,
+                    textAlign = TextAlign.Center,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/util/GestureHint.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/util/GestureHint.kt
@@ -1,0 +1,15 @@
+package com.websarva.wings.android.slevo.ui.util
+
+import com.websarva.wings.android.slevo.data.model.GestureAction
+import com.websarva.wings.android.slevo.data.model.GestureDirection
+
+sealed interface GestureHint {
+    data object Hidden : GestureHint
+
+    data class Direction(
+        val direction: GestureDirection,
+        val action: GestureAction?,
+    ) : GestureHint
+
+    data object Invalid : GestureHint
+}

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/util/GestureUtils.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/util/GestureUtils.kt
@@ -1,14 +1,10 @@
 package com.websarva.wings.android.slevo.ui.util
 
-import androidx.compose.runtime.composed
+import androidx.compose.ui.composed
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.input.pointer.awaitEachGesture
-import androidx.compose.ui.input.pointer.awaitFirstDown
-import androidx.compose.ui.input.pointer.awaitPointerEvent
-import androidx.compose.ui.input.pointer.changedToUpIgnoreConsumed
+import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -25,6 +21,8 @@ private enum class HorizontalDirection {
 fun Modifier.detectDirectionalGesture(
     enabled: Boolean,
     threshold: Dp = 64.dp,
+    onGestureProgress: (GestureDirection?) -> Unit = {},
+    onGestureInvalid: () -> Unit = {},
     onGesture: (GestureDirection) -> Unit,
 ): Modifier = composed {
     if (!enabled) {
@@ -33,26 +31,55 @@ fun Modifier.detectDirectionalGesture(
         val thresholdPx = with(LocalDensity.current) { threshold.toPx() }
         pointerInput(enabled, thresholdPx) {
             if (!enabled) return@pointerInput
-            awaitEachGesture {
-                val down = awaitFirstDown(requireUnconsumed = false)
-                val pointerId = down.id
-                val path = mutableListOf(Offset.Zero)
-                var totalOffset = Offset.Zero
+            var path = mutableListOf(Offset.Zero)
+            var totalOffset = Offset.Zero
+            var lastDirection: GestureDirection? = null
 
-                while (true) {
-                    val event = awaitPointerEvent()
-                    val change = event.changes.firstOrNull { it.id == pointerId } ?: continue
-                    val delta = change.positionChange()
-                    if (delta != Offset.Zero) {
-                        totalOffset += delta
-                        path.add(totalOffset)
+            detectDragGestures(
+                onDragStart = {
+                    onGestureProgress(null)
+                    path = mutableListOf(Offset.Zero)
+                    totalOffset = Offset.Zero
+                    lastDirection = null
+                },
+                onDrag = { change, dragAmount ->
+                    totalOffset += dragAmount
+                    path.add(totalOffset)
+                    val direction = detectGestureDirection(path, thresholdPx)
+                    if (direction != lastDirection) {
+                        lastDirection = direction
+                        onGestureProgress(direction)
                     }
-                    if (change.changedToUpIgnoreConsumed()) {
-                        detectGestureDirection(path, thresholdPx)?.let(onGesture)
-                        break
+                    change.consume()
+                },
+                onDragCancel = {
+                    if (lastDirection != null) {
+                        onGestureProgress(null)
+                        lastDirection = null
+                    } else {
+                        onGestureProgress(null)
+                    }
+                    onGestureInvalid()
+                },
+                onDragEnd = {
+                    val direction = detectGestureDirection(path, thresholdPx)
+                    if (direction != null) {
+                        onGesture(direction)
+                        if (lastDirection != null) {
+                            onGestureProgress(null)
+                            lastDirection = null
+                        }
+                    } else {
+                        if (lastDirection != null) {
+                            onGestureProgress(null)
+                            lastDirection = null
+                        } else {
+                            onGestureProgress(null)
+                        }
+                        onGestureInvalid()
                     }
                 }
-            }
+            )
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,9 +95,11 @@
     <string name="enable_gesture_feature">ジェスチャー機能を有効にする</string>
     <string name="gesture_list_title">ジェスチャーの割り当て</string>
     <string name="gesture_action_unassigned">未設定</string>
+    <string name="gesture_action_unassigned_message">アクションが未定義です</string>
     <string name="gesture_action_to_top">先頭へ</string>
     <string name="gesture_action_to_bottom">末尾へ</string>
     <string name="gesture_action_post_or_create_thread">書き込み/スレッド作成</string>
+    <string name="gesture_invalid_message">ジェスチャーが無効です</string>
     <string name="gesture_direction_right">右</string>
     <string name="gesture_direction_right_up">右→上</string>
     <string name="gesture_direction_right_left">右→左</string>


### PR DESCRIPTION
## Summary
- show gesture direction and action hints while gestures are in progress on board and thread screens
- present overlay messaging for unassigned or invalid gestures with reusable composable
- refactor gesture detection to report progress updates for hint display

## Testing
- ./gradlew :app:compileDebugKotlin

------
https://chatgpt.com/codex/tasks/task_e_68dded19e1d483329e5889e60bbf96d8