### PR TITLE
fix: keep bottom bar visible on gesture jump

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
@@ -191,7 +191,7 @@ fun BoardScaffold(
                 }
             }
         },
-        content = { viewModel, uiState, listState, modifier, navController ->
+        content = { viewModel, uiState, listState, modifier, navController, showBottomBar ->
             LaunchedEffect(uiState.resetScroll) {
                 if (uiState.resetScroll) {
                     listState.scrollToItem(0)
@@ -220,6 +220,7 @@ fun BoardScaffold(
                 onRefresh = { viewModel.refreshBoardData() },
                 listState = listState,
                 gestureSettings = uiState.gestureSettings,
+                showBottomBar = showBottomBar,
                 onGestureAction = { action ->
                     when (action) {
                         GestureAction.Refresh -> viewModel.refreshBoardData()

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScreen.kt
@@ -58,6 +58,7 @@ fun BoardScreen(
     onRefresh: () -> Unit,
     listState: LazyListState = rememberLazyListState(),
     gestureSettings: GestureSettings = GestureSettings.DEFAULT,
+    showBottomBar: (() -> Unit)? = null,
     onGestureAction: (GestureAction) -> Unit = {},
 ) {
     val (momentumMean, momentumStd) = remember(threads) {
@@ -113,15 +114,18 @@ fun BoardScreen(
                             listState.scrollToItem(0)
                         }
 
-                        GestureAction.ToBottom -> coroutineScope.launch {
-                            val totalItems = listState.layoutInfo.totalItemsCount
-                            val fallback = if (threads.isNotEmpty()) threads.size else 0
-                            val targetIndex = when {
-                                totalItems > 0 -> totalItems - 1
-                                fallback > 0 -> fallback
-                                else -> 0
+                        GestureAction.ToBottom -> {
+                            showBottomBar?.invoke()
+                            coroutineScope.launch {
+                                val totalItems = listState.layoutInfo.totalItemsCount
+                                val fallback = if (threads.isNotEmpty()) threads.size else 0
+                                val targetIndex = when {
+                                    totalItems > 0 -> totalItems - 1
+                                    fallback > 0 -> fallback
+                                    else -> 0
+                                }
+                                listState.scrollToItem(targetIndex)
                             }
-                            listState.scrollToItem(targetIndex)
                         }
 
                         else -> onGestureAction(action)

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/RouteScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/RouteScaffold.kt
@@ -66,7 +66,14 @@ fun <TabInfo : Any, UiState : BaseUiState<UiState>, ViewModel : BaseViewModel<Ui
         scrollBehavior: BottomAppBarScrollBehavior?,
         openTabListSheet: () -> Unit,
     ) -> Unit,
-    content: @Composable (viewModel: ViewModel, uiState: UiState, listState: LazyListState, modifier: Modifier, navController: NavHostController) -> Unit,
+    content: @Composable (
+        viewModel: ViewModel,
+        uiState: UiState,
+        listState: LazyListState,
+        modifier: Modifier,
+        navController: NavHostController,
+        showBottomBar: (() -> Unit)?,
+    ) -> Unit,
     bottomBarScrollBehavior: (@Composable (LazyListState) -> BottomAppBarScrollBehavior)? = null,
     optionalSheetContent: @Composable (viewModel: ViewModel, uiState: UiState) -> Unit = { _, _ -> }
 ) {
@@ -176,6 +183,12 @@ fun <TabInfo : Any, UiState : BaseUiState<UiState>, ViewModel : BaseViewModel<Ui
 
             val bottomBehavior = bottomBarScrollBehavior?.invoke(listState)
             val swipeBlockerState = rememberDraggableState { _ -> }
+            val showBottomBar = bottomBehavior?.let { behavior ->
+                {
+                    behavior.state.heightOffset = 0f
+                }
+            }
+
             Scaffold(
                 modifier = Modifier
                     .let { modifier ->
@@ -205,7 +218,8 @@ fun <TabInfo : Any, UiState : BaseUiState<UiState>, ViewModel : BaseViewModel<Ui
                     uiState,
                     listState,
                     contentModifier,
-                    navController
+                    navController,
+                    showBottomBar,
                 )
 
                 // 共通のボトムシートとダイアログ

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -183,7 +183,7 @@ fun ThreadScaffold(
                 }
             }
         },
-        content = { viewModel, uiState, listState, modifier, navController ->
+        content = { viewModel, uiState, listState, modifier, navController, showBottomBar ->
             LaunchedEffect(uiState.threadInfo.key, uiState.isLoading) {
                 // スレッドタイトルが空でなく、投稿リストが取得済みの場合にタブ情報を更新
                 if (
@@ -216,6 +216,7 @@ fun ThreadScaffold(
                 listState = listState,
                 navController = navController,
                 tabsViewModel = tabsViewModel,
+                showBottomBar = showBottomBar,
                 onAutoScrollBottom = { viewModel.onAutoScrollReachedBottom() },
                 onBottomRefresh = { viewModel.reloadThread() },
                 onLastRead = { resNum ->

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
@@ -79,6 +79,7 @@ fun ThreadScreen(
     listState: LazyListState = rememberLazyListState(),
     navController: NavHostController,
     tabsViewModel: TabsViewModel? = null,
+    showBottomBar: (() -> Unit)? = null,
     onAutoScrollBottom: () -> Unit = {},
     onBottomRefresh: () -> Unit = {},
     onLastRead: (Int) -> Unit = {},
@@ -237,15 +238,18 @@ fun ThreadScreen(
                         listState.scrollToItem(0)
                     }
 
-                    GestureAction.ToBottom -> coroutineScope.launch {
-                        val totalItems = listState.layoutInfo.totalItemsCount
-                        val fallback = if (visiblePosts.isNotEmpty()) visiblePosts.size else 0
-                        val targetIndex = when {
-                            totalItems > 0 -> totalItems - 1
-                            fallback > 0 -> fallback
-                            else -> 0
+                    GestureAction.ToBottom -> {
+                        showBottomBar?.invoke()
+                        coroutineScope.launch {
+                            val totalItems = listState.layoutInfo.totalItemsCount
+                            val fallback = if (visiblePosts.isNotEmpty()) visiblePosts.size else 0
+                            val targetIndex = when {
+                                totalItems > 0 -> totalItems - 1
+                                fallback > 0 -> fallback
+                                else -> 0
+                            }
+                            listState.scrollToItem(targetIndex)
                         }
-                        listState.scrollToItem(targetIndex)
                     }
 
                     else -> onGestureAction(action)

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
@@ -234,21 +234,32 @@ fun ThreadScreen(
                 }
                 gestureHint = GestureHint.Hidden
                 when (action) {
-                    GestureAction.ToTop -> coroutineScope.launch {
-                        listState.scrollToItem(0)
+                    GestureAction.ToTop -> {
+                        showBottomBar?.invoke()
+                        coroutineScope.launch {
+                            listState.scrollToItem(0)
+                        }
                     }
 
                     GestureAction.ToBottom -> {
-                        showBottomBar?.invoke()
                         coroutineScope.launch {
-                            val totalItems = listState.layoutInfo.totalItemsCount
-                            val fallback = if (visiblePosts.isNotEmpty()) visiblePosts.size else 0
-                            val targetIndex = when {
-                                totalItems > 0 -> totalItems - 1
-                                fallback > 0 -> fallback
-                                else -> 0
+                            showBottomBar?.invoke()
+                            val prevViewportEnd = listState.layoutInfo.viewportEndOffset
+                            repeat(10) {
+                                withFrameNanos { /* 1 フレーム待ち */ }
+                                if (listState.layoutInfo.viewportEndOffset != prevViewportEnd) return@repeat
                             }
-                            listState.scrollToItem(targetIndex)
+                            coroutineScope.launch {
+                                val totalItems = listState.layoutInfo.totalItemsCount
+                                val fallback =
+                                    if (visiblePosts.isNotEmpty()) visiblePosts.size else 0
+                                val targetIndex = when {
+                                    totalItems > 0 -> totalItems - 1
+                                    fallback > 0 -> fallback
+                                    else -> 0
+                                }
+                                listState.scrollToItem(targetIndex)
+                            }
                         }
                     }
 


### PR DESCRIPTION
## Summary
- ensure board and thread screens request the bottom bar to show when a ToBottom gesture fires
- expose a showBottomBar callback from RouteScaffold so content can control the bar

## Testing
- ./gradlew :app:compileDebugKotlin --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e11579a5248332adef4f696b03b084