### PR TITLE
Fix bottom bar visibility after jump-to-bottom gesture

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
@@ -191,7 +191,7 @@ fun BoardScaffold(
                 }
             }
         },
-        content = { viewModel, uiState, listState, modifier, navController ->
+        content = { viewModel, uiState, listState, modifier, navController, bottomBarScrollBehavior ->
             LaunchedEffect(uiState.resetScroll) {
                 if (uiState.resetScroll) {
                     listState.scrollToItem(0)
@@ -227,7 +227,8 @@ fun BoardScaffold(
                         GestureAction.Search -> viewModel.setSearchMode(true)
                         GestureAction.ToTop, GestureAction.ToBottom -> Unit
                     }
-                }
+                },
+                bottomBarScrollBehavior = bottomBarScrollBehavior
             )
             if (uiState.showInfoDialog) {
                 BoardInfoDialog(

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.BottomAppBarScrollBehavior
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -59,6 +60,7 @@ fun BoardScreen(
     listState: LazyListState = rememberLazyListState(),
     gestureSettings: GestureSettings = GestureSettings.DEFAULT,
     onGestureAction: (GestureAction) -> Unit = {},
+    bottomBarScrollBehavior: BottomAppBarScrollBehavior? = null,
 ) {
     val (momentumMean, momentumStd) = remember(threads) {
         val values = threads.filter {
@@ -114,6 +116,7 @@ fun BoardScreen(
                         }
 
                         GestureAction.ToBottom -> coroutineScope.launch {
+                            bottomBarScrollBehavior?.state?.heightOffset = 0f
                             val totalItems = listState.layoutInfo.totalItemsCount
                             val fallback = if (threads.isNotEmpty()) threads.size else 0
                             val targetIndex = when {

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/RouteScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/RouteScaffold.kt
@@ -66,7 +66,14 @@ fun <TabInfo : Any, UiState : BaseUiState<UiState>, ViewModel : BaseViewModel<Ui
         scrollBehavior: BottomAppBarScrollBehavior?,
         openTabListSheet: () -> Unit,
     ) -> Unit,
-    content: @Composable (viewModel: ViewModel, uiState: UiState, listState: LazyListState, modifier: Modifier, navController: NavHostController) -> Unit,
+    content: @Composable (
+        viewModel: ViewModel,
+        uiState: UiState,
+        listState: LazyListState,
+        modifier: Modifier,
+        navController: NavHostController,
+        bottomBarScrollBehavior: BottomAppBarScrollBehavior?,
+    ) -> Unit,
     bottomBarScrollBehavior: (@Composable (LazyListState) -> BottomAppBarScrollBehavior)? = null,
     optionalSheetContent: @Composable (viewModel: ViewModel, uiState: UiState) -> Unit = { _, _ -> }
 ) {
@@ -205,7 +212,8 @@ fun <TabInfo : Any, UiState : BaseUiState<UiState>, ViewModel : BaseViewModel<Ui
                     uiState,
                     listState,
                     contentModifier,
-                    navController
+                    navController,
+                    bottomBehavior
                 )
 
                 // 共通のボトムシートとダイアログ

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -183,7 +183,7 @@ fun ThreadScaffold(
                 }
             }
         },
-        content = { viewModel, uiState, listState, modifier, navController ->
+        content = { viewModel, uiState, listState, modifier, navController, bottomBarScrollBehavior ->
             LaunchedEffect(uiState.threadInfo.key, uiState.isLoading) {
                 // スレッドタイトルが空でなく、投稿リストが取得済みの場合にタブ情報を更新
                 if (
@@ -230,7 +230,8 @@ fun ThreadScaffold(
                         GestureAction.Search -> viewModel.startSearch()
                         GestureAction.ToTop, GestureAction.ToBottom -> Unit
                     }
-                }
+                },
+                bottomBarScrollBehavior = bottomBarScrollBehavior
             )
         },
         optionalSheetContent = { viewModel, uiState ->

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
@@ -18,7 +18,9 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowUpward
+import androidx.compose.material3.BottomAppBarScrollBehavior
 import androidx.compose.material3.ContainedLoadingIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -71,7 +73,7 @@ import my.nanihadesuka.compose.LazyColumnScrollbar
 import kotlin.math.min
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun ThreadScreen(
     modifier: Modifier = Modifier,
@@ -85,6 +87,7 @@ fun ThreadScreen(
     onReplyToPost: (Int) -> Unit = {},
     gestureSettings: GestureSettings = GestureSettings.DEFAULT,
     onGestureAction: (GestureAction) -> Unit = {},
+    bottomBarScrollBehavior: BottomAppBarScrollBehavior? = null,
 ) {
     // 投稿一覧（nullの場合は空リスト）
     val posts = uiState.posts ?: emptyList()
@@ -238,6 +241,7 @@ fun ThreadScreen(
                     }
 
                     GestureAction.ToBottom -> coroutineScope.launch {
+                        bottomBarScrollBehavior?.state?.heightOffset = 0f
                         val totalItems = listState.layoutInfo.totalItemsCount
                         val fallback = if (visiblePosts.isNotEmpty()) visiblePosts.size else 0
                         val targetIndex = when {
@@ -486,6 +490,7 @@ fun ThreadScreen(
 
 @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
 @Preview(showBackground = true)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun ThreadScreenPreview() {
     val previewPosts = listOf(


### PR DESCRIPTION
## Summary
- pass the bottom bar scroll behavior into thread and board screens so gestures can control it
- ensure the jump-to-bottom gesture forces the bottom bar to show before scrolling
- adjust RouteScaffold to provide the scroll behavior to screen content

## Testing
- ./gradlew :app:assembleDebug --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e11579a5248332adef4f696b03b084