### PR TITLE
feat: show gesture icons in overlay and settings

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/data/model/GestureSettings.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/model/GestureSettings.kt
@@ -1,5 +1,6 @@
 package com.websarva.wings.android.slevo.data.model
 
+import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import com.websarva.wings.android.slevo.R
 
@@ -18,15 +19,42 @@ data class GestureSettings(
     }
 }
 
-enum class GestureDirection(@StringRes val labelRes: Int) {
-    Right(R.string.gesture_direction_right),
-    RightUp(R.string.gesture_direction_right_up),
-    RightLeft(R.string.gesture_direction_right_left),
-    RightDown(R.string.gesture_direction_right_down),
-    Left(R.string.gesture_direction_left),
-    LeftUp(R.string.gesture_direction_left_up),
-    LeftRight(R.string.gesture_direction_left_right),
-    LeftDown(R.string.gesture_direction_left_down),
+enum class GestureDirection(
+    @StringRes val labelRes: Int,
+    @DrawableRes val iconRes: Int,
+) {
+    Right(
+        labelRes = R.string.gesture_direction_right,
+        iconRes = R.drawable.ic_gesture_right,
+    ),
+    RightUp(
+        labelRes = R.string.gesture_direction_right_up,
+        iconRes = R.drawable.ic_gesture_right_then_up,
+    ),
+    RightLeft(
+        labelRes = R.string.gesture_direction_right_left,
+        iconRes = R.drawable.ic_gesture_right_then_left,
+    ),
+    RightDown(
+        labelRes = R.string.gesture_direction_right_down,
+        iconRes = R.drawable.ic_gesture_right_then_down,
+    ),
+    Left(
+        labelRes = R.string.gesture_direction_left,
+        iconRes = R.drawable.ic_gesture_left,
+    ),
+    LeftUp(
+        labelRes = R.string.gesture_direction_left_up,
+        iconRes = R.drawable.ic_gesture_left_then_up,
+    ),
+    LeftRight(
+        labelRes = R.string.gesture_direction_left_right,
+        iconRes = R.drawable.ic_gesture_left_then_right,
+    ),
+    LeftDown(
+        labelRes = R.string.gesture_direction_left_down,
+        iconRes = R.drawable.ic_gesture_left_then_down,
+    ),
 }
 
 enum class GestureAction(@StringRes val labelRes: Int) {

--- a/app/src/main/java/com/websarva/wings/android/slevo/data/model/GestureSettings.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/model/GestureSettings.kt
@@ -14,7 +14,7 @@ data class GestureSettings(
     companion object {
         val DEFAULT = GestureSettings(
             isEnabled = false,
-            assignments = GestureDirection.values().associateWith { null }
+            assignments = GestureDirection.entries.associateWith { null }
         )
     }
 }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/common/GestureHintOverlay.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/common/GestureHintOverlay.kt
@@ -7,22 +7,22 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.websarva.wings.android.slevo.R
-import com.websarva.wings.android.slevo.ui.util.GestureHint
-import androidx.compose.ui.tooling.preview.Preview
-import com.websarva.wings.android.slevo.data.model.GestureDirection
 import com.websarva.wings.android.slevo.data.model.GestureAction
+import com.websarva.wings.android.slevo.data.model.GestureDirection
+import com.websarva.wings.android.slevo.ui.util.GestureHint
 
 @Composable
 fun GestureHintOverlay(
@@ -68,12 +68,14 @@ fun GestureHintOverlay(
         ) {
             OverlaySurface {
                 Text(
+                    modifier = Modifier
+                        .padding(horizontal = 24.dp, vertical = 16.dp),
                     text = stringResource(id = R.string.gesture_invalid_message),
-                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp),
                     style = MaterialTheme.typography.bodyMedium,
                     textAlign = TextAlign.Center,
                 )
             }
+
         }
     }
 }
@@ -88,12 +90,18 @@ private fun OverlaySurface(
     content: @Composable () -> Unit,
 ) {
     Surface(
-        modifier = modifier.width(240.dp).heightIn(min = 72.dp),
+        modifier = modifier
+            .width(240.dp)
+            .heightIn(min = 120.dp),
         tonalElevation = 6.dp,
         shape = MaterialTheme.shapes.medium,
         color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.9f),
     ) {
-        content()
+        Box(
+            contentAlignment = Alignment.Center,
+        ) {
+            content()
+        }
     }
 }
 

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/common/GestureHintOverlay.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/common/GestureHintOverlay.kt
@@ -3,20 +3,23 @@ package com.websarva.wings.android.slevo.ui.common
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.websarva.wings.android.slevo.R
 import com.websarva.wings.android.slevo.ui.util.GestureHint
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.ui.tooling.preview.Preview
 import com.websarva.wings.android.slevo.data.model.GestureDirection
 import com.websarva.wings.android.slevo.data.model.GestureAction
@@ -40,10 +43,11 @@ fun GestureHintOverlay(
                     modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp),
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
-                    Text(
-                        text = stringResource(id = state.direction.labelRes),
-                        style = MaterialTheme.typography.titleMedium,
-                        textAlign = TextAlign.Center,
+                    Icon(
+                        painter = painterResource(id = state.direction.iconRes),
+                        contentDescription = stringResource(id = state.direction.labelRes),
+                        modifier = Modifier.size(48.dp),
+                        tint = MaterialTheme.colorScheme.onSurface,
                     )
                     val message = state.action?.let { action ->
                         stringResource(id = action.labelRes)
@@ -52,7 +56,7 @@ fun GestureHintOverlay(
                         text = message,
                         style = MaterialTheme.typography.bodyMedium,
                         textAlign = TextAlign.Center,
-                        modifier = Modifier.padding(top = 4.dp),
+                        modifier = Modifier.padding(top = 8.dp),
                     )
                 }
             }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/settings/SettingsGestureScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/settings/SettingsGestureScreen.kt
@@ -2,18 +2,20 @@ package com.websarva.wings.android.slevo.ui.settings
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
@@ -26,6 +28,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -84,6 +87,14 @@ fun SettingsGestureScreen(
                 }
                 ListItem(
                     modifier = itemModifier,
+                    leadingContent = {
+                        Icon(
+                            painter = painterResource(id = item.direction.iconRes),
+                            contentDescription = directionLabel,
+                            modifier = Modifier.size(32.dp),
+                            tint = MaterialTheme.colorScheme.onSurface,
+                        )
+                    },
                     headlineContent = { Text(directionLabel) },
                     trailingContent = { Text(actionLabel) }
                 )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,11 +95,11 @@
     <string name="enable_gesture_feature">ジェスチャー機能を有効にする</string>
     <string name="gesture_list_title">ジェスチャーの割り当て</string>
     <string name="gesture_action_unassigned">未設定</string>
-    <string name="gesture_action_unassigned_message">アクションが未定義です</string>
-    <string name="gesture_action_to_top">先頭へ</string>
-    <string name="gesture_action_to_bottom">末尾へ</string>
+    <string name="gesture_action_unassigned_message">アクションなし</string>
+    <string name="gesture_action_to_top">最上部までスクロール</string>
+    <string name="gesture_action_to_bottom">最下部までスクロール</string>
     <string name="gesture_action_post_or_create_thread">書き込み/スレッド作成</string>
-    <string name="gesture_invalid_message">ジェスチャーが無効です</string>
+    <string name="gesture_invalid_message">無効なジェスチャーです</string>
     <string name="gesture_direction_right">右</string>
     <string name="gesture_direction_right_up">右→上</string>
     <string name="gesture_direction_right_left">右→左</string>


### PR DESCRIPTION
## Summary
- add drawable references to gesture directions so icons are available throughout the app
- update the in-thread gesture hint overlay to present the direction with an icon instead of text
- show the same direction icon alongside each entry in the gesture settings list for visual clarity

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e310c56fec8332ba71b16b9082f4f3