### PR TITLE
Add gesture actions for navigation and tab management

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/data/model/GestureSettings.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/data/model/GestureSettings.kt
@@ -63,4 +63,12 @@ enum class GestureAction(@StringRes val labelRes: Int) {
     Refresh(R.string.refresh),
     PostOrCreateThread(R.string.gesture_action_post_or_create_thread),
     Search(R.string.search),
+    OpenTabList(R.string.gesture_action_open_tab_list),
+    OpenBookmarkList(R.string.gesture_action_open_bookmark_list),
+    OpenBoardList(R.string.gesture_action_open_board_list),
+    OpenHistory(R.string.gesture_action_open_history),
+    OpenNewTab(R.string.gesture_action_open_new_tab),
+    SwitchToNextTab(R.string.gesture_action_switch_to_next_tab),
+    SwitchToPreviousTab(R.string.gesture_action_switch_to_previous_tab),
+    CloseTab(R.string.gesture_action_close_tab),
 }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
@@ -191,7 +191,7 @@ fun BoardScaffold(
                 }
             }
         },
-        content = { viewModel, uiState, listState, modifier, navController, showBottomBar ->
+        content = { viewModel, uiState, listState, modifier, navController, showBottomBar, openTabListSheet, openUrlDialog ->
             LaunchedEffect(uiState.resetScroll) {
                 if (uiState.resetScroll) {
                     listState.scrollToItem(0)
@@ -226,6 +226,17 @@ fun BoardScaffold(
                         GestureAction.Refresh -> viewModel.refreshBoardData()
                         GestureAction.PostOrCreateThread -> viewModel.showCreateDialog()
                         GestureAction.Search -> viewModel.setSearchMode(true)
+                        GestureAction.OpenTabList -> openTabListSheet()
+                        GestureAction.OpenBookmarkList -> navController.navigate(AppRoute.BookmarkList)
+                        GestureAction.OpenBoardList -> navController.navigate(AppRoute.ServiceList)
+                        GestureAction.OpenHistory -> navController.navigate(AppRoute.HistoryList)
+                        GestureAction.OpenNewTab -> openUrlDialog()
+                        GestureAction.SwitchToNextTab -> tabsViewModel.moveBoardPage(1)
+                        GestureAction.SwitchToPreviousTab -> tabsViewModel.moveBoardPage(-1)
+                        GestureAction.CloseTab ->
+                            if (uiState.boardInfo.url.isNotBlank()) {
+                                tabsViewModel.closeBoardTabByUrl(uiState.boardInfo.url)
+                            }
                         GestureAction.ToTop, GestureAction.ToBottom -> Unit
                     }
                 }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/RouteScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/RouteScaffold.kt
@@ -37,8 +37,11 @@ import com.websarva.wings.android.slevo.ui.common.bookmark.DeleteGroupDialog
 import com.websarva.wings.android.slevo.ui.common.bookmark.SingleBookmarkState
 import com.websarva.wings.android.slevo.ui.tabs.TabsBottomSheet
 import com.websarva.wings.android.slevo.ui.tabs.TabsViewModel
+import com.websarva.wings.android.slevo.ui.tabs.UrlOpenDialog
 import com.websarva.wings.android.slevo.ui.thread.state.ThreadUiState
 import com.websarva.wings.android.slevo.ui.thread.viewmodel.ThreadViewModel
+import com.websarva.wings.android.slevo.ui.util.parseBoardUrl
+import com.websarva.wings.android.slevo.ui.util.parseThreadUrl
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
@@ -73,6 +76,8 @@ fun <TabInfo : Any, UiState : BaseUiState<UiState>, ViewModel : BaseViewModel<Ui
         modifier: Modifier,
         navController: NavHostController,
         showBottomBar: (() -> Unit)?,
+        openTabListSheet: () -> Unit,
+        openUrlDialog: () -> Unit,
     ) -> Unit,
     bottomBarScrollBehavior: (@Composable (LazyListState) -> BottomAppBarScrollBehavior)? = null,
     optionalSheetContent: @Composable (viewModel: ViewModel, uiState: UiState) -> Unit = { _, _ -> }
@@ -123,6 +128,7 @@ fun <TabInfo : Any, UiState : BaseUiState<UiState>, ViewModel : BaseViewModel<Ui
         val bookmarkSheetState = rememberModalBottomSheetState()
         val tabListSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
         var showTabListSheet by rememberSaveable { mutableStateOf(false) }
+        var showUrlDialog by rememberSaveable { mutableStateOf(false) }
 
         val pagerUserScrollEnabled = when (
             val currentUiState = currentTabInfo?.let { tabInfo ->
@@ -220,6 +226,8 @@ fun <TabInfo : Any, UiState : BaseUiState<UiState>, ViewModel : BaseViewModel<Ui
                     contentModifier,
                     navController,
                     showBottomBar,
+                    { showTabListSheet = true },
+                    { showUrlDialog = true },
                 )
 
                 // 共通のボトムシートとダイアログ
@@ -312,6 +320,42 @@ fun <TabInfo : Any, UiState : BaseUiState<UiState>, ViewModel : BaseViewModel<Ui
                 navController = navController,
                 onDismissRequest = { showTabListSheet = false },
                 initialPage = initialPage,
+            )
+        }
+
+        if (showUrlDialog) {
+            UrlOpenDialog(
+                onDismissRequest = { showUrlDialog = false },
+                onOpen = { url ->
+                    val thread = parseThreadUrl(url)
+                    if (thread != null) {
+                        val (host, board, key) = thread
+                        val boardUrl = "https://$host/$board/"
+                        val route = AppRoute.Thread(
+                            threadKey = key,
+                            boardUrl = boardUrl,
+                            boardName = board,
+                            threadTitle = url
+                        )
+                        navController.navigateToThread(
+                            route = route,
+                            tabsViewModel = tabsViewModel,
+                        )
+                    } else {
+                        parseBoardUrl(url)?.let { (host, board) ->
+                            val boardUrl = "https://$host/$board/"
+                            val route = AppRoute.Board(
+                                boardName = boardUrl,
+                                boardUrl = boardUrl,
+                            )
+                            navController.navigateToBoard(
+                                route = route,
+                                tabsViewModel = tabsViewModel,
+                            )
+                        }
+                    }
+                    showUrlDialog = false
+                }
             )
         }
     } else {

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/settings/SettingsGestureScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/settings/SettingsGestureScreen.kt
@@ -1,7 +1,6 @@
 package com.websarva.wings.android.slevo.ui.settings
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -12,6 +11,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -110,14 +111,21 @@ fun SettingsGestureScreen(
             onDismissRequest = { viewModel.dismissGestureDialog() },
             title = { Text(text = stringResource(id = direction.labelRes)) },
             text = {
-                Column(modifier = Modifier.fillMaxWidth()) {
-                    GestureActionSelectionRow(
-                        label = stringResource(id = R.string.gesture_action_unassigned),
-                        selected = currentAction == null,
-                        onClick = { viewModel.assignGestureAction(direction, null) }
-                    )
-                    Spacer(modifier = Modifier.height(4.dp))
-                    actions.forEachIndexed { index, action ->
+                // Use LazyColumn for better performance with many items and limit max height
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = 320.dp)
+                ) {
+                    item {
+                        GestureActionSelectionRow(
+                            label = stringResource(id = R.string.gesture_action_unassigned),
+                            selected = currentAction == null,
+                            onClick = { viewModel.assignGestureAction(direction, null) }
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
+                    }
+                    itemsIndexed(actions) { index, action ->
                         GestureActionSelectionRow(
                             label = stringResource(id = action.labelRes),
                             selected = currentAction == action,

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabsViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/tabs/TabsViewModel.kt
@@ -227,6 +227,40 @@ class TabsViewModel @Inject constructor(
         _threadCurrentPage.value = page
     }
 
+    fun moveBoardPage(offset: Int) {
+        val tabs = _uiState.value.openBoardTabs
+        if (tabs.isEmpty()) return
+        val currentIndex = _boardCurrentPage.value.takeIf { it in tabs.indices } ?: 0
+        val targetIndex = currentIndex + offset
+        if (targetIndex in tabs.indices) {
+            setBoardCurrentPage(targetIndex)
+        }
+    }
+
+    fun moveThreadPage(offset: Int) {
+        val tabs = _uiState.value.openThreadTabs
+        if (tabs.isEmpty()) return
+        val currentIndex = _threadCurrentPage.value.takeIf { it in tabs.indices } ?: 0
+        val targetIndex = currentIndex + offset
+        if (targetIndex in tabs.indices) {
+            setThreadCurrentPage(targetIndex)
+        }
+    }
+
+    fun closeBoardTabByUrl(boardUrl: String) {
+        _uiState.value.openBoardTabs.find { it.boardUrl == boardUrl }?.let { tab ->
+            closeBoardTab(tab)
+        }
+    }
+
+    fun closeThreadTab(threadKey: String, boardUrl: String) {
+        val (host, board) = parseBoardUrl(boardUrl) ?: return
+        val id = ThreadId.of(host, board, threadKey)
+        _uiState.value.openThreadTabs.find { it.id == id }?.let { tab ->
+            closeThreadTab(tab)
+        }
+    }
+
     /**
      * 指定された板ID・URL・板名からBoardInfoを解決する。
      * - boardIdが有効ならそれを優先。

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -183,7 +183,7 @@ fun ThreadScaffold(
                 }
             }
         },
-        content = { viewModel, uiState, listState, modifier, navController, showBottomBar ->
+        content = { viewModel, uiState, listState, modifier, navController, showBottomBar, openTabListSheet, openUrlDialog ->
             LaunchedEffect(uiState.threadInfo.key, uiState.isLoading) {
                 // スレッドタイトルが空でなく、投稿リストが取得済みの場合にタブ情報を更新
                 if (
@@ -229,6 +229,17 @@ fun ThreadScaffold(
                         GestureAction.Refresh -> viewModel.reloadThread()
                         GestureAction.PostOrCreateThread -> viewModel.showPostDialog()
                         GestureAction.Search -> viewModel.startSearch()
+                        GestureAction.OpenTabList -> openTabListSheet()
+                        GestureAction.OpenBookmarkList -> navController.navigate(AppRoute.BookmarkList)
+                        GestureAction.OpenBoardList -> navController.navigate(AppRoute.ServiceList)
+                        GestureAction.OpenHistory -> navController.navigate(AppRoute.HistoryList)
+                        GestureAction.OpenNewTab -> openUrlDialog()
+                        GestureAction.SwitchToNextTab -> tabsViewModel.moveThreadPage(1)
+                        GestureAction.SwitchToPreviousTab -> tabsViewModel.moveThreadPage(-1)
+                        GestureAction.CloseTab ->
+                            if (uiState.threadInfo.key.isNotBlank() && uiState.boardInfo.url.isNotBlank()) {
+                                tabsViewModel.closeThreadTab(uiState.threadInfo.key, uiState.boardInfo.url)
+                            }
                         GestureAction.ToTop, GestureAction.ToBottom -> Unit
                     }
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -99,6 +99,14 @@
     <string name="gesture_action_to_top">最上部までスクロール</string>
     <string name="gesture_action_to_bottom">最下部までスクロール</string>
     <string name="gesture_action_post_or_create_thread">書き込み/スレッド作成</string>
+    <string name="gesture_action_open_tab_list">タブ一覧を表示</string>
+    <string name="gesture_action_open_bookmark_list">ブックマーク一覧を開く</string>
+    <string name="gesture_action_open_board_list">板一覧に移動</string>
+    <string name="gesture_action_open_history">履歴を開く</string>
+    <string name="gesture_action_open_new_tab">新しいタブを開く</string>
+    <string name="gesture_action_switch_to_next_tab">右のタブに切り替え</string>
+    <string name="gesture_action_switch_to_previous_tab">左のタブに切り替え</string>
+    <string name="gesture_action_close_tab">現在のタブを閉じる</string>
     <string name="gesture_invalid_message">無効なジェスチャーです</string>
     <string name="gesture_direction_right">右</string>
     <string name="gesture_direction_right_up">右→上</string>


### PR DESCRIPTION
## Summary
- add gesture options for opening tab list, bookmarks, board list, history, new tab, and tab navigation
- wire board and thread screens to execute the new gesture actions, including tab switching and closing
- enhance the shared route scaffold and tabs view model to support showing the URL dialog and adjacent tab selection

## Testing
- ./gradlew --no-daemon --console=plain :app:assembleDebug

------
https://chatgpt.com/codex/tasks/task_e_68e324ece74c8332a03331058391c17a