### PR TITLE
feat: animate tab transitions for gesture navigation

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
@@ -115,6 +115,7 @@ fun BoardScaffold(
         },
         currentPage = currentPage,
         onPageChange = { tabsViewModel.setBoardCurrentPage(it) },
+        animateToPageFlow = tabsViewModel.boardPageAnimation,
         bottomBarScrollBehavior = { listState -> rememberBottomBarShowOnBottomBehavior(listState) },
         bottomBar = { viewModel, uiState, barScrollBehavior, openTabListSheet ->
             val keyboardController = LocalSoftwareKeyboardController.current
@@ -231,8 +232,8 @@ fun BoardScaffold(
                         GestureAction.OpenBoardList -> navController.navigate(AppRoute.ServiceList)
                         GestureAction.OpenHistory -> navController.navigate(AppRoute.HistoryList)
                         GestureAction.OpenNewTab -> openUrlDialog()
-                        GestureAction.SwitchToNextTab -> tabsViewModel.moveBoardPage(1)
-                        GestureAction.SwitchToPreviousTab -> tabsViewModel.moveBoardPage(-1)
+                        GestureAction.SwitchToNextTab -> tabsViewModel.animateBoardPage(1)
+                        GestureAction.SwitchToPreviousTab -> tabsViewModel.animateBoardPage(-1)
                         GestureAction.CloseTab ->
                             if (uiState.boardInfo.url.isNotBlank()) {
                                 tabsViewModel.closeBoardTabByUrl(uiState.boardInfo.url)

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -130,6 +130,7 @@ fun ThreadScaffold(
         },
         currentPage = currentPage,
         onPageChange = { tabsViewModel.setThreadCurrentPage(it) },
+        animateToPageFlow = tabsViewModel.threadPageAnimation,
         bottomBarScrollBehavior = { listState -> rememberBottomBarShowOnBottomBehavior(listState) },
         bottomBar = { viewModel, uiState, barScrollBehavior, openTabListSheet ->
             val context = LocalContext.current
@@ -234,8 +235,8 @@ fun ThreadScaffold(
                         GestureAction.OpenBoardList -> navController.navigate(AppRoute.ServiceList)
                         GestureAction.OpenHistory -> navController.navigate(AppRoute.HistoryList)
                         GestureAction.OpenNewTab -> openUrlDialog()
-                        GestureAction.SwitchToNextTab -> tabsViewModel.moveThreadPage(1)
-                        GestureAction.SwitchToPreviousTab -> tabsViewModel.moveThreadPage(-1)
+                        GestureAction.SwitchToNextTab -> tabsViewModel.animateThreadPage(1)
+                        GestureAction.SwitchToPreviousTab -> tabsViewModel.animateThreadPage(-1)
                         GestureAction.CloseTab ->
                             if (uiState.threadInfo.key.isNotBlank() && uiState.boardInfo.url.isNotBlank()) {
                                 tabsViewModel.closeThreadTab(uiState.threadInfo.key, uiState.boardInfo.url)


### PR DESCRIPTION
## Summary
- emit pager animation events from TabsViewModel when swipe gestures switch tabs
- have RouteScaffold react to animation events to smoothly scroll between pages
- update board and thread scaffolds to request animated transitions for gesture-driven tab changes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e346fbfc788332b0272166764c0ce2