### PR TITLE
Group gesture settings by swipe direction

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -117,6 +117,8 @@
     <string name="gesture_direction_left_up">左から上へ</string>
     <string name="gesture_direction_left_right">左から右へ</string>
     <string name="gesture_direction_left_down">左から下へ</string>
+    <string name="gesture_group_right">右からのジェスチャー</string>
+    <string name="gesture_group_left">左からのジェスチャー</string>
 
     <string name="about_this_app">このアプリについて</string>
     <string name="version_name_label">バージョン: %1$s</string>


### PR DESCRIPTION
## Summary
- separate gesture assignment options into right and left groups wrapped with `SettingsCard`
- add string resources for the new gesture group headers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3b14be4888332bc9f05fa20afb9e4