### PR TITLE
fix: show navigate up button on history list

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/history/HistoryListScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/history/HistoryListScaffold.kt
@@ -20,7 +20,7 @@ import com.websarva.wings.android.slevo.R
 import com.websarva.wings.android.slevo.data.model.threadKey
 import com.websarva.wings.android.slevo.ui.navigation.AppRoute
 import com.websarva.wings.android.slevo.ui.navigation.navigateToThread
-import com.websarva.wings.android.slevo.ui.topbar.HomeTopAppBarScreen
+import com.websarva.wings.android.slevo.ui.topbar.SlevoTopAppBar
 import com.websarva.wings.android.slevo.ui.tabs.TabsViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -38,8 +38,9 @@ fun HistoryListScaffold(
 
     Scaffold(
         topBar = {
-            HomeTopAppBarScreen(
+            SlevoTopAppBar(
                 title = stringResource(R.string.history),
+                onNavigateUp = { navController.popBackStack() },
                 scrollBehavior = scrollBehavior
             )
         },

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/settings/SettingsScreen.kt
@@ -13,7 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.websarva.wings.android.slevo.R
-import com.websarva.wings.android.slevo.ui.topbar.HomeTopAppBarScreen
+import com.websarva.wings.android.slevo.ui.topbar.SlevoTopAppBar
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -23,12 +23,14 @@ fun SettingsScreen(
     onThreadClick: () -> Unit,
     onNgClick: () -> Unit,
     onCookieClick: () -> Unit,
+    onNavigateUp: (() -> Unit)? = null,
 ) {
     Scaffold(
         topBar = {
-            HomeTopAppBarScreen(
+            SlevoTopAppBar(
                 title = "設定",
                 modifier = Modifier,
+                onNavigateUp = onNavigateUp,
                 scrollBehavior = null
             )
         }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/topbar/TopAppBarScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/topbar/TopAppBarScreen.kt
@@ -2,7 +2,6 @@ package com.websarva.wings.android.slevo.ui.topbar
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBackIos
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -17,24 +16,10 @@ import androidx.compose.ui.tooling.preview.Preview
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun HomeTopAppBarScreen(
-    title: String,
-    modifier: Modifier = Modifier,
-    scrollBehavior: TopAppBarScrollBehavior? = null
-) {
-    CenterAlignedTopAppBar(
-        title = { Text(title) },
-        modifier = modifier,
-        scrollBehavior = scrollBehavior,
-    )
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
 fun SlevoTopAppBar(
     modifier: Modifier = Modifier,
     title: String,
-    onNavigateUp: () -> Unit, // 戻る処理のためのコールバック
+    onNavigateUp: (() -> Unit)? = null, // 戻る処理のためのコールバック
     scrollBehavior: TopAppBarScrollBehavior? = null
 ) {
     TopAppBar(
@@ -45,12 +30,14 @@ fun SlevoTopAppBar(
                 style = MaterialTheme.typography.titleLarge
             )
         },
-        navigationIcon = { // 左端にボタンを追加
-            IconButton(onClick = onNavigateUp) {
-                Icon(
-                    imageVector = Icons.AutoMirrored.Filled.ArrowBackIos,
-                    contentDescription = "Back"
-                )
+        navigationIcon = {
+            if (onNavigateUp != null) { // 左端にボタンを追加
+                IconButton(onClick = onNavigateUp) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBackIos,
+                        contentDescription = "Back"
+                    )
+                }
             }
         },
         modifier = modifier,
@@ -63,8 +50,9 @@ fun SlevoTopAppBar(
 @Preview(showBackground = true)
 @Composable
 fun CenterAlignedTopAppBarScreenPreview() {
-    HomeTopAppBarScreen(
-        title = "お気に入り"
+    SlevoTopAppBar(
+        title = "お気に入り",
+        onNavigateUp = null
     )
 }
 


### PR DESCRIPTION
## Summary
- replace HomeTopAppBarScreen usages with SlevoTopAppBar
- remove the HomeTopAppBarScreen implementation and allow SlevoTopAppBar to omit a navigation icon
- show the navigation icon on the history list scaffold

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e50a9738e8833292aaf8e426d2ec0f