### PR TITLE
fix: handle navigation when all tabs are closed

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
@@ -64,12 +64,6 @@ fun BoardScaffold(
     val context = LocalContext.current
     val currentPage by tabsViewModel.boardCurrentPage.collectAsState()
 
-    LaunchedEffect(tabsUiState.boardLoaded, tabsUiState.openBoardTabs) {
-        if (tabsUiState.boardLoaded && tabsUiState.openBoardTabs.isEmpty()) {
-            navController.navigateUp()
-        }
-    }
-
     LaunchedEffect(boardRoute) {
         val info = tabsViewModel.resolveBoardInfo(
             boardId = boardRoute.boardId,
@@ -95,6 +89,8 @@ fun BoardScaffold(
         route = boardRoute,
         tabsViewModel = tabsViewModel,
         navController = navController,
+        isTabsLoaded = tabsUiState.boardLoaded,
+        onEmptyTabs = { navController.navigateUp() },
         openTabs = tabsUiState.openBoardTabs,
         currentRoutePredicate = { it.boardUrl == boardRoute.boardUrl },
         getViewModel = { tab -> tabsViewModel.getOrCreateBoardViewModel(tab.boardUrl) },

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/RouteScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/RouteScaffold.kt
@@ -54,6 +54,8 @@ fun <TabInfo : Any, UiState : BaseUiState<UiState>, ViewModel : BaseViewModel<Ui
     route: AppRoute,
     tabsViewModel: TabsViewModel,
     navController: NavHostController,
+    isTabsLoaded: Boolean,
+    onEmptyTabs: () -> Unit,
     openTabs: List<TabInfo>,
     currentRoutePredicate: (TabInfo) -> Boolean,
     getViewModel: (TabInfo) -> ViewModel,
@@ -89,12 +91,24 @@ fun <TabInfo : Any, UiState : BaseUiState<UiState>, ViewModel : BaseViewModel<Ui
     // - 各タブごとにViewModelとリストのスクロール位置を保持/復元する
     // - 共通のボトムシートやダイアログを表示する
 
+    LaunchedEffect(isTabsLoaded, openTabs) {
+        if (isTabsLoaded && openTabs.isEmpty()) {
+            onEmptyTabs()
+        }
+    }
+
     var cachedTabs by remember { mutableStateOf(openTabs) }
     // openTabsが空の場合に前回のタブ一覧をキャッシュしておくための処理
     if (openTabs.isNotEmpty()) {
         cachedTabs = openTabs
     }
-    val tabs = openTabs.ifEmpty { cachedTabs }
+    val tabs = if (openTabs.isNotEmpty()) {
+        openTabs
+    } else if (!isTabsLoaded) {
+        cachedTabs
+    } else {
+        emptyList()
+    }
     Timber.d("tabs: $tabs")
     val currentTabInfo = tabs.find(currentRoutePredicate)
 

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -73,12 +73,6 @@ fun ThreadScaffold(
     val context = LocalContext.current
     val currentPage by tabsViewModel.threadCurrentPage.collectAsState()
 
-    LaunchedEffect(tabsUiState.threadLoaded, tabsUiState.openThreadTabs) {
-        if (tabsUiState.threadLoaded && tabsUiState.openThreadTabs.isEmpty()) {
-            navController.navigateUp()
-        }
-    }
-
     val routeThreadId = parseBoardUrl(threadRoute.boardUrl)?.let { (host, board) ->
         ThreadId.of(host, board, threadRoute.threadKey)
     }
@@ -115,6 +109,8 @@ fun ThreadScaffold(
         route = threadRoute,
         tabsViewModel = tabsViewModel,
         navController = navController,
+        isTabsLoaded = tabsUiState.threadLoaded,
+        onEmptyTabs = { navController.navigateUp() },
         openTabs = tabsUiState.openThreadTabs,
         currentRoutePredicate = { routeThreadId != null && it.id == routeThreadId },
         getViewModel = { tab -> tabsViewModel.getOrCreateThreadViewModel(tab.id.value) },


### PR DESCRIPTION
## Summary
- update RouteScaffold to accept tab load state and trigger navigation when no tabs remain
- pass the new parameters from BoardScaffold and ThreadScaffold after removing their redundant effects

## Testing
- not run (environment limitation)


------
https://chatgpt.com/codex/tasks/task_e_68ed190b566c83329a45ce9a32f79cac