### PR TITLE
refactor: centralize bottom bar modifiers

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardScaffold.kt
@@ -1,8 +1,6 @@
 package com.websarva.wings.android.slevo.ui.board
 
 import android.widget.Toast
-import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Sort
 import androidx.compose.material.icons.filled.Create
@@ -15,7 +13,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -37,7 +34,6 @@ import com.websarva.wings.android.slevo.ui.navigation.navigateToThread
 import com.websarva.wings.android.slevo.ui.tabs.BoardTabInfo
 import com.websarva.wings.android.slevo.ui.tabs.TabsViewModel
 import com.websarva.wings.android.slevo.ui.thread.dialog.ResponseWebViewDialog
-import com.websarva.wings.android.slevo.ui.util.isThreeButtonNavigation
 import com.websarva.wings.android.slevo.ui.util.parseBoardUrl
 import com.websarva.wings.android.slevo.ui.util.parseServiceName
 import com.websarva.wings.android.slevo.ui.util.rememberBottomBarShowOnBottomBehavior
@@ -109,14 +105,6 @@ fun BoardScaffold(
         animateToPageFlow = tabsViewModel.boardPageAnimation,
         bottomBarScrollBehavior = { listState -> rememberBottomBarShowOnBottomBehavior(listState) },
         bottomBar = { viewModel, uiState, barScrollBehavior, openTabListSheet ->
-            val isThreeButtonBar = remember { isThreeButtonNavigation(context) }
-            val searchModifier = if (isThreeButtonBar) {
-                Modifier
-                    .navigationBarsPadding()
-                    .imePadding()
-            } else {
-                Modifier.imePadding()
-            }
             val actions = listOf(
                 TabToolBarAction(
                     icon = Icons.AutoMirrored.Filled.Sort,
@@ -144,18 +132,18 @@ fun BoardScaffold(
                 isSearchMode = uiState.isSearchActive,
                 onCloseSearch = { viewModel.setSearchMode(false) },
                 animationLabel = "BoardBottomBarAnimation",
-                searchContent = { closeSearch ->
+                searchContent = { modifier, closeSearch ->
                     SearchBottomBar(
-                        modifier = searchModifier,
+                        modifier = modifier,
                         searchQuery = uiState.searchQuery,
                         onQueryChange = { viewModel.setSearchQuery(it) },
                         onCloseSearch = closeSearch,
                         placeholderResId = R.string.search_in_board,
                     )
                 },
-                defaultContent = {
+                defaultContent = { modifier ->
                     TabToolBar(
-                        modifier = Modifier.navigationBarsPadding(),
+                        modifier = modifier,
                         title = uiState.boardInfo.name,
                         bookmarkState = uiState.singleBookmarkState,
                         onBookmarkClick = { viewModel.openBookmarkSheet() },

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/BbsRouteBottomBar.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/navigation/BbsRouteBottomBar.kt
@@ -8,9 +8,15 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import com.websarva.wings.android.slevo.ui.util.isThreeButtonNavigation
 
 @OptIn(ExperimentalAnimationApi::class)
 @Composable
@@ -18,11 +24,23 @@ fun BbsRouteBottomBar(
     isSearchMode: Boolean,
     onCloseSearch: () -> Unit,
     animationLabel: String,
-    searchContent: @Composable (closeSearch: () -> Unit) -> Unit,
-    defaultContent: @Composable () -> Unit,
+    searchContent: @Composable (modifier: Modifier, closeSearch: () -> Unit) -> Unit,
+    defaultContent: @Composable (modifier: Modifier) -> Unit,
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
     val focusManager = LocalFocusManager.current
+    val context = LocalContext.current
+    val isThreeButtonBar = remember { isThreeButtonNavigation(context) }
+
+    val searchModifier = if (isThreeButtonBar) {
+        Modifier
+            .navigationBarsPadding()
+            .imePadding()
+    } else {
+        Modifier.imePadding()
+    }
+
+    val defaultModifier = Modifier.navigationBarsPadding()
 
     val closeSearch: () -> Unit = {
         keyboardController?.hide()
@@ -43,9 +61,9 @@ fun BbsRouteBottomBar(
         label = animationLabel,
     ) { searchMode ->
         if (searchMode) {
-            searchContent(closeSearch)
+            searchContent(searchModifier, closeSearch)
         } else {
-            defaultContent()
+            defaultContent(defaultModifier)
         }
     }
 }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScaffold.kt
@@ -1,14 +1,11 @@
 package com.websarva.wings.android.slevo.ui.thread.screen
 
 import android.widget.Toast
-import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -45,7 +42,6 @@ import com.websarva.wings.android.slevo.ui.thread.viewmodel.updatePostMail
 import com.websarva.wings.android.slevo.ui.thread.viewmodel.updatePostMessage
 import com.websarva.wings.android.slevo.ui.thread.viewmodel.updatePostName
 import com.websarva.wings.android.slevo.ui.thread.viewmodel.uploadImage
-import com.websarva.wings.android.slevo.ui.util.isThreeButtonNavigation
 import com.websarva.wings.android.slevo.ui.util.parseBoardUrl
 import com.websarva.wings.android.slevo.ui.util.rememberBottomBarShowOnBottomBehavior
 import java.net.URLEncoder
@@ -129,20 +125,11 @@ fun ThreadScaffold(
         animateToPageFlow = tabsViewModel.threadPageAnimation,
         bottomBarScrollBehavior = { listState -> rememberBottomBarShowOnBottomBehavior(listState) },
         bottomBar = { viewModel, uiState, barScrollBehavior, openTabListSheet ->
-            val context = LocalContext.current
-            val isThreeButtonBar = remember { isThreeButtonNavigation(context) }
-            val modifier = if (isThreeButtonBar) {
-                Modifier
-                    .navigationBarsPadding()
-                    .imePadding()
-            } else {
-                Modifier.imePadding()
-            }
             BbsRouteBottomBar(
                 isSearchMode = uiState.isSearchMode,
                 onCloseSearch = { viewModel.closeSearch() },
                 animationLabel = "BottomBarAnimation",
-                searchContent = { closeSearch ->
+                searchContent = { modifier, closeSearch ->
                     SearchBottomBar(
                         modifier = modifier,
                         searchQuery = uiState.searchQuery,
@@ -151,9 +138,9 @@ fun ThreadScaffold(
                         placeholderResId = R.string.search_in_thread,
                     )
                 },
-                defaultContent = {
+                defaultContent = { modifier ->
                     ThreadToolBar(
-                        modifier = Modifier.navigationBarsPadding(),
+                        modifier = modifier,
                         uiState = uiState,
                         isTreeSort = uiState.sortType == ThreadSortType.TREE,
                         onSortClick = { viewModel.toggleSortType() },


### PR DESCRIPTION
## Summary
- centralize bottom bar modifier handling in `BbsRouteBottomBar`
- update `BoardScaffold` and `ThreadScaffold` to use the shared modifier logic

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eddc001e708332bd8f3bc50964b3b0