### PR TITLE
Refactor bookmark handling to BaseViewModel

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/bbsroute/BaseViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/bbsroute/BaseViewModel.kt
@@ -2,6 +2,8 @@ package com.websarva.wings.android.slevo.ui.bbsroute
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.websarva.wings.android.slevo.data.model.Groupable
+import com.websarva.wings.android.slevo.ui.common.bookmark.SingleBookmarkViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -9,6 +11,8 @@ import kotlinx.coroutines.launch
 abstract class BaseViewModel<S> : ViewModel() where S : BaseUiState<S> {
     protected abstract val _uiState: MutableStateFlow<S>
     val uiState: StateFlow<S> get() = _uiState
+
+    protected var bookmarkViewModel: SingleBookmarkViewModel? = null
 
     private var isInitialized = false
 
@@ -35,4 +39,30 @@ abstract class BaseViewModel<S> : ViewModel() where S : BaseUiState<S> {
     fun release() {
         onCleared()
     }
+
+    protected fun bookmarkSaveBookmark(groupId: Long) = bookmarkViewModel?.saveBookmark(groupId)
+
+    protected fun bookmarkUnbookmark() = bookmarkViewModel?.unbookmark()
+
+    protected fun bookmarkOpenAddGroupDialog() = bookmarkViewModel?.openAddGroupDialog()
+
+    protected fun bookmarkOpenEditGroupDialog(group: Groupable) = bookmarkViewModel?.openEditGroupDialog(group)
+
+    protected fun bookmarkCloseAddGroupDialog() = bookmarkViewModel?.closeAddGroupDialog()
+
+    protected fun bookmarkSetEnteredGroupName(name: String) = bookmarkViewModel?.setEnteredGroupName(name)
+
+    protected fun bookmarkSetSelectedColor(color: String) = bookmarkViewModel?.setSelectedColor(color)
+
+    protected fun bookmarkConfirmGroup() = bookmarkViewModel?.confirmGroup()
+
+    protected fun bookmarkRequestDeleteGroup() = bookmarkViewModel?.requestDeleteGroup()
+
+    protected fun bookmarkConfirmDeleteGroup() = bookmarkViewModel?.confirmDeleteGroup()
+
+    protected fun bookmarkCloseDeleteGroupDialog() = bookmarkViewModel?.closeDeleteGroupDialog()
+
+    protected fun bookmarkOpenBookmarkSheet() = bookmarkViewModel?.openBookmarkSheet()
+
+    protected fun bookmarkCloseBookmarkSheet() = bookmarkViewModel?.closeBookmarkSheet()
 }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardViewModel.kt
@@ -19,7 +19,6 @@ import com.websarva.wings.android.slevo.data.repository.SettingsRepository
 import com.websarva.wings.android.slevo.data.model.NgType
 import com.websarva.wings.android.slevo.data.datasource.local.entity.history.PostIdentityType
 import com.websarva.wings.android.slevo.ui.bbsroute.BaseViewModel
-import com.websarva.wings.android.slevo.ui.common.bookmark.SingleBookmarkViewModel
 import com.websarva.wings.android.slevo.ui.common.bookmark.SingleBookmarkViewModelFactory
 import com.websarva.wings.android.slevo.ui.util.toHiragana
 import com.websarva.wings.android.slevo.ui.util.parseServiceName
@@ -59,7 +58,6 @@ class BoardViewModel @AssistedInject constructor(
     private var observedCreateIdentityBoardId: Long? = null
 
     override val _uiState = MutableStateFlow(BoardUiState())
-    private var singleBookmarkViewModel: SingleBookmarkViewModel? = null
     private var threadTitleNg: List<Pair<Long?, Regex>> = emptyList()
 
     init {
@@ -73,7 +71,8 @@ class BoardViewModel @AssistedInject constructor(
     fun initializeBoard(boardInfo: BoardInfo) {
         if (initializedUrl == boardInfo.url) return
         initializedUrl = boardInfo.url
-        singleBookmarkViewModel = singleBookmarkViewModelFactory.create(boardInfo, null)
+        val bookmarkVm = singleBookmarkViewModelFactory.create(boardInfo, null)
+        bookmarkViewModel = bookmarkVm
 
         val serviceName = parseServiceName(boardInfo.url)
         _uiState.update { it.copy(boardInfo = boardInfo, serviceName = serviceName) }
@@ -108,7 +107,7 @@ class BoardViewModel @AssistedInject constructor(
         }
 
         viewModelScope.launch {
-            singleBookmarkViewModel?.uiState?.collect { bkState ->
+            bookmarkVm.uiState.collect { bkState ->
                 _uiState.update { it.copy(singleBookmarkState = bkState) }
             }
         }
@@ -193,19 +192,19 @@ class BoardViewModel @AssistedInject constructor(
     }
 
     // --- お気に入り関連の処理はBookmarkStateViewModelに委譲 ---
-    fun saveBookmark(groupId: Long) = singleBookmarkViewModel?.saveBookmark(groupId)
-    fun unbookmarkBoard() = singleBookmarkViewModel?.unbookmark()
-    fun openAddGroupDialog() = singleBookmarkViewModel?.openAddGroupDialog()
-    fun openEditGroupDialog(group: Groupable) = singleBookmarkViewModel?.openEditGroupDialog(group)
-    fun closeAddGroupDialog() = singleBookmarkViewModel?.closeAddGroupDialog()
-    fun setEnteredGroupName(name: String) = singleBookmarkViewModel?.setEnteredGroupName(name)
-    fun setSelectedColor(color: String) = singleBookmarkViewModel?.setSelectedColor(color)
-    fun confirmGroup() = singleBookmarkViewModel?.confirmGroup()
-    fun requestDeleteGroup() = singleBookmarkViewModel?.requestDeleteGroup()
-    fun confirmDeleteGroup() = singleBookmarkViewModel?.confirmDeleteGroup()
-    fun closeDeleteGroupDialog() = singleBookmarkViewModel?.closeDeleteGroupDialog()
-    fun openBookmarkSheet() = singleBookmarkViewModel?.openBookmarkSheet()
-    fun closeBookmarkSheet() = singleBookmarkViewModel?.closeBookmarkSheet()
+    fun saveBookmark(groupId: Long) = bookmarkSaveBookmark(groupId)
+    fun unbookmarkBoard() = bookmarkUnbookmark()
+    fun openAddGroupDialog() = bookmarkOpenAddGroupDialog()
+    fun openEditGroupDialog(group: Groupable) = bookmarkOpenEditGroupDialog(group)
+    fun closeAddGroupDialog() = bookmarkCloseAddGroupDialog()
+    fun setEnteredGroupName(name: String) = bookmarkSetEnteredGroupName(name)
+    fun setSelectedColor(color: String) = bookmarkSetSelectedColor(color)
+    fun confirmGroup() = bookmarkConfirmGroup()
+    fun requestDeleteGroup() = bookmarkRequestDeleteGroup()
+    fun confirmDeleteGroup() = bookmarkConfirmDeleteGroup()
+    fun closeDeleteGroupDialog() = bookmarkCloseDeleteGroupDialog()
+    fun openBookmarkSheet() = bookmarkOpenBookmarkSheet()
+    fun closeBookmarkSheet() = bookmarkCloseBookmarkSheet()
 
     fun setSortKey(sortKey: ThreadSortKey) {
         _uiState.update { it.copy(currentSortKey = sortKey) }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/viewmodel/ThreadViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/viewmodel/ThreadViewModel.kt
@@ -21,7 +21,6 @@ import com.websarva.wings.android.slevo.data.repository.TabsRepository
 import com.websarva.wings.android.slevo.data.repository.ThreadHistoryRepository
 import com.websarva.wings.android.slevo.data.repository.ThreadReadStateRepository
 import com.websarva.wings.android.slevo.ui.bbsroute.BaseViewModel
-import com.websarva.wings.android.slevo.ui.common.bookmark.SingleBookmarkViewModel
 import com.websarva.wings.android.slevo.ui.common.bookmark.SingleBookmarkViewModelFactory
 import com.websarva.wings.android.slevo.ui.util.toHiragana
 import com.websarva.wings.android.slevo.ui.tabs.ThreadTabInfo
@@ -73,7 +72,6 @@ class ThreadViewModel @AssistedInject constructor(
 ) : BaseViewModel<ThreadUiState>() {
 
     override val _uiState = MutableStateFlow(ThreadUiState())
-    private var singleBookmarkViewModel: SingleBookmarkViewModel? = null
     private var ngList: List<NgEntity> = emptyList()
     private var compiledNg: List<Triple<Long?, Regex, NgType>> = emptyList()
     private var initializedKey: String? = null
@@ -203,11 +201,12 @@ class ThreadViewModel @AssistedInject constructor(
         }
 
         // Factoryを使ってBookmarkStateViewModelを生成
-        singleBookmarkViewModel = singleBookmarkViewModelFactory.create(boardInfo, threadInfo)
+        val bookmarkVm = singleBookmarkViewModelFactory.create(boardInfo, threadInfo)
+        bookmarkViewModel = bookmarkVm
 
         // 状態をマージ
         viewModelScope.launch {
-            singleBookmarkViewModel?.uiState?.collect { favState ->
+            bookmarkVm.uiState.collect { favState ->
                 _uiState.update { it.copy(singleBookmarkState = favState) }
             }
         }
@@ -642,19 +641,19 @@ class ThreadViewModel @AssistedInject constructor(
 
 
     // --- お気に入り関連の処理はBookmarkStateViewModelに委譲 ---
-    fun saveBookmark(groupId: Long) = singleBookmarkViewModel?.saveBookmark(groupId)
-    fun unbookmarkBoard() = singleBookmarkViewModel?.unbookmark()
-    fun openAddGroupDialog() = singleBookmarkViewModel?.openAddGroupDialog()
-    fun openEditGroupDialog(group: Groupable) = singleBookmarkViewModel?.openEditGroupDialog(group)
-    fun closeAddGroupDialog() = singleBookmarkViewModel?.closeAddGroupDialog()
-    fun setEnteredGroupName(name: String) = singleBookmarkViewModel?.setEnteredGroupName(name)
-    fun setSelectedColor(color: String) = singleBookmarkViewModel?.setSelectedColor(color)
-    fun confirmGroup() = singleBookmarkViewModel?.confirmGroup()
-    fun requestDeleteGroup() = singleBookmarkViewModel?.requestDeleteGroup()
-    fun confirmDeleteGroup() = singleBookmarkViewModel?.confirmDeleteGroup()
-    fun closeDeleteGroupDialog() = singleBookmarkViewModel?.closeDeleteGroupDialog()
-    fun openBookmarkSheet() = singleBookmarkViewModel?.openBookmarkSheet()
-    fun closeBookmarkSheet() = singleBookmarkViewModel?.closeBookmarkSheet()
+    fun saveBookmark(groupId: Long) = bookmarkSaveBookmark(groupId)
+    fun unbookmarkBoard() = bookmarkUnbookmark()
+    fun openAddGroupDialog() = bookmarkOpenAddGroupDialog()
+    fun openEditGroupDialog(group: Groupable) = bookmarkOpenEditGroupDialog(group)
+    fun closeAddGroupDialog() = bookmarkCloseAddGroupDialog()
+    fun setEnteredGroupName(name: String) = bookmarkSetEnteredGroupName(name)
+    fun setSelectedColor(color: String) = bookmarkSetSelectedColor(color)
+    fun confirmGroup() = bookmarkConfirmGroup()
+    fun requestDeleteGroup() = bookmarkRequestDeleteGroup()
+    fun confirmDeleteGroup() = bookmarkConfirmDeleteGroup()
+    fun closeDeleteGroupDialog() = bookmarkCloseDeleteGroupDialog()
+    fun openBookmarkSheet() = bookmarkOpenBookmarkSheet()
+    fun closeBookmarkSheet() = bookmarkCloseBookmarkSheet()
 
     fun openThreadInfoSheet() {
         _uiState.update { it.copy(showThreadInfoSheet = true) }


### PR DESCRIPTION
## Summary
- centralize the SingleBookmarkViewModel reference and bookmark helper methods in BaseViewModel
- update BoardViewModel and ThreadViewModel to reuse the shared bookmark helpers and remove duplicate code

## Testing
- ./gradlew --no-daemon --console=plain :app:assembleDebug

------
https://chatgpt.com/codex/tasks/task_e_68f6f2ee2fc88332a9e26ab87761f62c