### PR TITLE
Refactor identity history filtering into BaseViewModel

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/bbsroute/BaseViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/bbsroute/BaseViewModel.kt
@@ -12,6 +12,15 @@ abstract class BaseViewModel<S> : ViewModel() where S : BaseUiState<S> {
 
     private var isInitialized = false
 
+    protected fun filterIdentityHistories(source: List<String>, query: String): List<String> {
+        val normalized = query.trim()
+        return if (normalized.isEmpty()) {
+            source
+        } else {
+            source.filter { it.contains(normalized, ignoreCase = true) }
+        }
+    }
+
     /**
      * ViewModelの初期化を行う標準メソッド。
      * UI側からはこのメソッドを呼び出すように統一する。

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardViewModel.kt
@@ -438,15 +438,6 @@ class BoardViewModel @AssistedInject constructor(
         _uiState.update { it.copy(createMailHistory = filtered) }
     }
 
-    private fun filterIdentityHistories(source: List<String>, query: String): List<String> {
-        val normalized = query.trim()
-        return if (normalized.isEmpty()) {
-            source
-        } else {
-            source.filter { it.contains(normalized, ignoreCase = true) }
-        }
-    }
-
     fun hideConfirmationScreen() {
         _uiState.update { it.copy(isConfirmationScreen = false) }
     }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/viewmodel/ThreadViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/viewmodel/ThreadViewModel.kt
@@ -825,16 +825,6 @@ class ThreadViewModel @AssistedInject constructor(
         }
     }
 
-    private fun filterIdentityHistories(source: List<String>, query: String): List<String> {
-        val normalized = query.trim()
-        return if (normalized.isEmpty()) {
-            source
-        } else {
-            source.filter { it.contains(normalized, ignoreCase = true) }
-        }
-    }
-
-
     fun updateThreadTabInfo(threadId: ThreadId, title: String, resCount: Int) {
         viewModelScope.launch {
             val current = tabsRepository.observeOpenThreadTabs().first()


### PR DESCRIPTION
## Summary
- add a reusable identity history filter helper to BaseViewModel
- reuse the BaseViewModel helper in ThreadViewModel and BoardViewModel

## Testing
- ./gradlew --console=plain :app:testDebugUnitTest

------
https://chatgpt.com/codex/tasks/task_e_68f6f2ee60548332a58817be690c7def