### PR TITLE
Refactor identity history handling for thread and board view models

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/bbsroute/BaseViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/bbsroute/BaseViewModel.kt
@@ -2,8 +2,11 @@ package com.websarva.wings.android.slevo.ui.bbsroute
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.websarva.wings.android.slevo.data.datasource.local.entity.history.PostIdentityType
 import com.websarva.wings.android.slevo.data.model.Groupable
+import com.websarva.wings.android.slevo.data.repository.PostHistoryRepository
 import com.websarva.wings.android.slevo.ui.common.bookmark.SingleBookmarkViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -13,6 +16,8 @@ abstract class BaseViewModel<S> : ViewModel() where S : BaseUiState<S> {
     val uiState: StateFlow<S> get() = _uiState
 
     protected var bookmarkViewModel: SingleBookmarkViewModel? = null
+
+    private val identityHistoryObservers = mutableMapOf<String, IdentityHistoryObserver>()
 
     private var isInitialized = false
 
@@ -74,4 +79,121 @@ abstract class BaseViewModel<S> : ViewModel() where S : BaseUiState<S> {
     protected fun bookmarkOpenBookmarkSheet() = bookmarkViewModel?.openBookmarkSheet()
 
     protected fun bookmarkCloseBookmarkSheet() = bookmarkViewModel?.closeBookmarkSheet()
+
+    protected fun prepareIdentityHistory(
+        key: String,
+        boardId: Long,
+        repository: PostHistoryRepository,
+        onLastIdentity: ((String, String) -> Unit)? = null,
+        onNameSuggestions: (List<String>) -> Unit,
+        onMailSuggestions: (List<String>) -> Unit,
+        nameQueryProvider: () -> String,
+        mailQueryProvider: () -> String,
+    ) {
+        val observer = identityHistoryObservers.getOrPut(key) {
+            IdentityHistoryObserver(
+                onLastIdentity = onLastIdentity,
+                onNameSuggestions = onNameSuggestions,
+                onMailSuggestions = onMailSuggestions,
+                nameQueryProvider = nameQueryProvider,
+                mailQueryProvider = mailQueryProvider,
+            )
+        }.apply {
+            this.onLastIdentity = onLastIdentity
+            this.onNameSuggestions = onNameSuggestions
+            this.onMailSuggestions = onMailSuggestions
+            this.nameQueryProvider = nameQueryProvider
+            this.mailQueryProvider = mailQueryProvider
+        }
+
+        if (observer.boardId == boardId) {
+            refreshIdentityHistorySuggestions(key)
+            return
+        }
+
+        observer.boardId = boardId
+        observer.nameJob?.cancel()
+        observer.mailJob?.cancel()
+        observer.latestNames = emptyList()
+        observer.latestMails = emptyList()
+        refreshIdentityHistorySuggestions(key)
+
+        if (boardId == 0L) {
+            return
+        }
+
+        viewModelScope.launch {
+            repository.getLastIdentity(boardId)?.let { identity ->
+                observer.onLastIdentity?.invoke(identity.name, identity.email)
+            }
+        }
+
+        observer.nameJob = viewModelScope.launch {
+            repository.observeIdentityHistories(boardId, PostIdentityType.NAME).collect { histories ->
+                observer.latestNames = histories
+                refreshIdentityHistorySuggestions(key, PostIdentityType.NAME)
+            }
+        }
+        observer.mailJob = viewModelScope.launch {
+            repository.observeIdentityHistories(boardId, PostIdentityType.EMAIL).collect { histories ->
+                observer.latestMails = histories
+                refreshIdentityHistorySuggestions(key, PostIdentityType.EMAIL)
+            }
+        }
+    }
+
+    protected fun refreshIdentityHistorySuggestions(
+        key: String,
+        type: PostIdentityType? = null,
+    ) {
+        val observer = identityHistoryObservers[key] ?: return
+        if (type == null || type == PostIdentityType.NAME) {
+            val suggestions = filterIdentityHistories(observer.latestNames, observer.nameQueryProvider())
+            observer.onNameSuggestions.invoke(suggestions)
+        }
+        if (type == null || type == PostIdentityType.EMAIL) {
+            val suggestions = filterIdentityHistories(observer.latestMails, observer.mailQueryProvider())
+            observer.onMailSuggestions.invoke(suggestions)
+        }
+    }
+
+    protected fun deleteIdentityHistory(
+        key: String,
+        repository: PostHistoryRepository,
+        type: PostIdentityType,
+        value: String,
+    ) {
+        val observer = identityHistoryObservers[key] ?: return
+        val normalized = value.trim()
+        if (normalized.isEmpty()) return
+        when (type) {
+            PostIdentityType.NAME -> {
+                observer.latestNames = observer.latestNames.filterNot { it == normalized }
+            }
+
+            PostIdentityType.EMAIL -> {
+                observer.latestMails = observer.latestMails.filterNot { it == normalized }
+            }
+        }
+        refreshIdentityHistorySuggestions(key, type)
+        val boardId = observer.boardId
+        if (boardId == 0L) return
+        viewModelScope.launch {
+            repository.deleteIdentity(boardId, type, normalized)
+        }
+    }
+
+    private class IdentityHistoryObserver(
+        var onLastIdentity: ((String, String) -> Unit)?,
+        var onNameSuggestions: (List<String>) -> Unit,
+        var onMailSuggestions: (List<String>) -> Unit,
+        var nameQueryProvider: () -> String,
+        var mailQueryProvider: () -> String,
+    ) {
+        var boardId: Long = -1L
+        var nameJob: Job? = null
+        var mailJob: Job? = null
+        var latestNames: List<String> = emptyList()
+        var latestMails: List<String> = emptyList()
+    }
 }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/viewmodel/ThreadViewModelPost.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/viewmodel/ThreadViewModelPost.kt
@@ -42,12 +42,12 @@ fun ThreadViewModel.hideConfirmationScreen() {
 
 fun ThreadViewModel.updatePostName(name: String) {
     _postUiState.update { it.copy(postFormState = it.postFormState.copy(name = name)) }
-    refreshNameHistorySuggestions(name)
+    refreshPostIdentityHistory(PostIdentityType.NAME)
 }
 
 fun ThreadViewModel.updatePostMail(mail: String) {
     _postUiState.update { it.copy(postFormState = it.postFormState.copy(mail = mail)) }
-    refreshMailHistorySuggestions(mail)
+    refreshPostIdentityHistory(PostIdentityType.EMAIL)
 }
 
 fun ThreadViewModel.updatePostMessage(message: String) {
@@ -156,19 +156,19 @@ fun ThreadViewModel.clearPostResultMessage() {
 
 fun ThreadViewModel.selectPostNameHistory(name: String) {
     _postUiState.update { it.copy(postFormState = it.postFormState.copy(name = name)) }
-    refreshNameHistorySuggestions(name)
+    refreshPostIdentityHistory(PostIdentityType.NAME)
 }
 
 fun ThreadViewModel.selectPostMailHistory(mail: String) {
     _postUiState.update { it.copy(postFormState = it.postFormState.copy(mail = mail)) }
-    refreshMailHistorySuggestions(mail)
+    refreshPostIdentityHistory(PostIdentityType.EMAIL)
 }
 
 fun ThreadViewModel.deletePostNameHistory(name: String) {
-    deletePostIdentityHistory(PostIdentityType.NAME, name)
+    deletePostIdentity(PostIdentityType.NAME, name)
 }
 
 fun ThreadViewModel.deletePostMailHistory(mail: String) {
-    deletePostIdentityHistory(PostIdentityType.EMAIL, mail)
+    deletePostIdentity(PostIdentityType.EMAIL, mail)
 }
 


### PR DESCRIPTION
## Summary
- add shared identity history preparation helpers to BaseViewModel and use them from the thread/board view models
- simplify ThreadViewModel and BoardViewModel by delegating identity history refresh/deletion to the shared helpers
- keep UI state updates intact while removing duplicate jobs and cached history fields

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Kotlin incremental cache cleanup error, falls back to non-daemon compile)*

------
https://chatgpt.com/codex/tasks/task_e_68fad9b8f10c8332998b5669fa256318