### PR TITLE
Refactor BaseUiState to expose shared route properties

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/bbsroute/BaseUiState.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/bbsroute/BaseUiState.kt
@@ -1,10 +1,22 @@
 package com.websarva.wings.android.slevo.ui.bbsroute
 
+import com.websarva.wings.android.slevo.data.model.BoardInfo
+import com.websarva.wings.android.slevo.data.model.GestureSettings
+import com.websarva.wings.android.slevo.ui.common.bookmark.SingleBookmarkState
+
 interface BaseUiState<T> where T : BaseUiState<T> {
+    val boardInfo: BoardInfo
+    val singleBookmarkState: SingleBookmarkState
+    val loadProgress: Float
+    val gestureSettings: GestureSettings
     val isLoading: Boolean
 
     // 共通プロパティを更新して、自身の具象型の新しいインスタンスを返すメソッド
     fun copyState(
+        boardInfo: BoardInfo = this.boardInfo,
+        singleBookmarkState: SingleBookmarkState = this.singleBookmarkState,
+        loadProgress: Float = this.loadProgress,
+        gestureSettings: GestureSettings = this.gestureSettings,
         isLoading: Boolean = this.isLoading,
     ): T
 }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/bbsroute/BbsRouteScaffold.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/bbsroute/BbsRouteScaffold.kt
@@ -32,7 +32,6 @@ import com.websarva.wings.android.slevo.ui.board.BoardViewModel
 import com.websarva.wings.android.slevo.ui.common.bookmark.AddGroupDialog
 import com.websarva.wings.android.slevo.ui.common.bookmark.BookmarkBottomSheet
 import com.websarva.wings.android.slevo.ui.common.bookmark.DeleteGroupDialog
-import com.websarva.wings.android.slevo.ui.common.bookmark.SingleBookmarkState
 import com.websarva.wings.android.slevo.ui.navigation.AppRoute
 import com.websarva.wings.android.slevo.ui.navigation.navigateToBoard
 import com.websarva.wings.android.slevo.ui.navigation.navigateToThread
@@ -178,10 +177,7 @@ fun <TabInfo : Any, UiState : BaseUiState<UiState>, ViewModel : BaseViewModel<Ui
             val tab = tabs[page]
             val viewModel = getViewModel(tab)
             val uiState by viewModel.uiState.collectAsState()
-            // Board / Thread 用のブックマーク状態を統一的に取得
-            val bookmarkState = (uiState as? BoardUiState)?.singleBookmarkState
-                ?: (uiState as? ThreadUiState)?.singleBookmarkState
-                ?: SingleBookmarkState()
+            val bookmarkState = uiState.singleBookmarkState
 
 
             // 各タブごとにLazyListStateを復元する。キーに基づいてrememberするため

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardUiState.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/board/BoardUiState.kt
@@ -9,8 +9,8 @@ import com.websarva.wings.android.slevo.ui.common.bookmark.SingleBookmarkState
 
 data class BoardUiState(
     val threads: List<ThreadInfo>? = null,
-    val boardInfo: BoardInfo = BoardInfo(0, "", ""),
-    val singleBookmarkState: SingleBookmarkState = SingleBookmarkState(),
+    override val boardInfo: BoardInfo = BoardInfo(0, "", ""),
+    override val singleBookmarkState: SingleBookmarkState = SingleBookmarkState(),
     val showSortSheet: Boolean = false,
     val serviceName: String = "",
     val showInfoDialog: Boolean = false,
@@ -30,14 +30,22 @@ data class BoardUiState(
     val errorHtmlContent: String = "",
     val postResultMessage: String? = null,
     val resetScroll: Boolean = false,
-    val loadProgress: Float = 0f,
-    val gestureSettings: GestureSettings = GestureSettings.DEFAULT,
+    override val loadProgress: Float = 0f,
+    override val gestureSettings: GestureSettings = GestureSettings.DEFAULT,
     override val isLoading: Boolean = false,
 ) : BaseUiState<BoardUiState> {
     override fun copyState(
+        boardInfo: BoardInfo,
+        singleBookmarkState: SingleBookmarkState,
+        loadProgress: Float,
+        gestureSettings: GestureSettings,
         isLoading: Boolean,
     ): BoardUiState {
         return this.copy(
+            boardInfo = boardInfo,
+            singleBookmarkState = singleBookmarkState,
+            loadProgress = loadProgress,
+            gestureSettings = gestureSettings,
             isLoading = isLoading,
         )
     }

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/state/ThreadUiState.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/state/ThreadUiState.kt
@@ -15,9 +15,9 @@ enum class ThreadSortType {
 data class ThreadUiState(
     val threadInfo: ThreadInfo = ThreadInfo(),
     val posts: List<ReplyInfo>? = null,
-    val loadProgress: Float = 0f,
-    val boardInfo: BoardInfo = BoardInfo(0, "", ""),
-    val singleBookmarkState: SingleBookmarkState = SingleBookmarkState(),
+    override val loadProgress: Float = 0f,
+    override val boardInfo: BoardInfo = BoardInfo(0, "", ""),
+    override val singleBookmarkState: SingleBookmarkState = SingleBookmarkState(),
     override val isLoading: Boolean = false,
     val showThreadInfoSheet: Boolean = false,
     val showMoreSheet: Boolean = false,
@@ -45,12 +45,20 @@ data class ThreadUiState(
     val visiblePosts: List<DisplayPost> = emptyList(),
     val replyCounts: List<Int> = emptyList(),
     val firstAfterIndex: Int = -1,
-    val gestureSettings: GestureSettings = GestureSettings.DEFAULT,
+    override val gestureSettings: GestureSettings = GestureSettings.DEFAULT,
 ) : BaseUiState<ThreadUiState> {
     override fun copyState(
+        boardInfo: BoardInfo,
+        singleBookmarkState: SingleBookmarkState,
+        loadProgress: Float,
+        gestureSettings: GestureSettings,
         isLoading: Boolean,
     ): ThreadUiState {
         return this.copy(
+            boardInfo = boardInfo,
+            singleBookmarkState = singleBookmarkState,
+            loadProgress = loadProgress,
+            gestureSettings = gestureSettings,
             isLoading = isLoading,
         )
     }


### PR DESCRIPTION
## Summary
- promote board, bookmark, progress, and gesture properties to BaseUiState and extend copyState
- update BoardUiState and ThreadUiState implementations to override the new base members
- simplify BbsRouteScaffold bookmark lookup by relying on the shared BaseUiState API

## Testing
- ./gradlew :app:testDebugUnitTest --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68fc3730a1e883328f4a425cf649ef02