### PR TITLE
Fix thread new arrival ordering

### DIFF
--- a/app/src/test/java/com/websarva/wings/android/slevo/ui/thread/viewmodel/ThreadDisplayTransformersTest.kt
+++ b/app/src/test/java/com/websarva/wings/android/slevo/ui/thread/viewmodel/ThreadDisplayTransformersTest.kt
@@ -108,6 +108,26 @@ class ThreadDisplayTransformersTest {
     }
 
     @Test
+    fun buildOrderedPosts_usesFirstNewWhenPrevCountZero() {
+        val posts = listOf(
+            reply(content = "first", id = "id1"),
+            reply(content = "second", id = "id2"),
+            reply(content = "third", id = "id3")
+        )
+
+        val ordered = buildOrderedPosts(
+            posts = posts,
+            order = listOf(1, 2, 3),
+            sortType = ThreadSortType.NUMBER,
+            treeDepthMap = emptyMap(),
+            firstNewResNo = 2,
+            prevResCount = 0
+        )
+
+        assertEquals(listOf(false, true, true), ordered.map { it.isAfter })
+    }
+
+    @Test
     fun parseDateToUnix_parsesWithFallback() {
         val timestamp = parseDateToUnix("2024/01/02 03:04:05.123")
         val expected = DATE_FORMAT.parse("2024/01/02 03:04:05")!!.time


### PR DESCRIPTION
## Summary
- keep previously loaded tree order intact and append new replies when reloading a thread
- place the new arrival bar between prevResCount and prevResCount + 1 and align highlighting logic
- cover the new behaviour with a display transformer unit test

## Testing
- ./gradlew :app:testDebugUnitTest --tests com.websarva.wings.android.slevo.ui.thread.viewmodel.ThreadDisplayTransformersTest

------
https://chatgpt.com/codex/tasks/task_e_6906d9bd05f483329e4ac97975730bd9