### PR TITLE
Adjust thread new arrival indicators

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/screen/ThreadScreen.kt
@@ -393,6 +393,11 @@ fun ThreadScreen(
                         )
                     )
             }
+            if (firstAfterIndex == visiblePosts.size && firstAfterIndex != -1) {
+                item(key = "new_arrival_footer") {
+                    NewArrivalBar()
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/viewmodel/ThreadViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/slevo/ui/thread/viewmodel/ThreadViewModel.kt
@@ -353,7 +353,6 @@ class ThreadViewModel @AssistedInject constructor(
 
     private fun updateDisplayPosts() {
         val posts = uiState.value.posts ?: return
-        val firstNewResNo = uiState.value.firstNewResNo
         val prevResCount = uiState.value.prevResCount
         val order = if (uiState.value.sortType == ThreadSortType.TREE) {
             uiState.value.treeOrder
@@ -365,7 +364,6 @@ class ThreadViewModel @AssistedInject constructor(
             order = order,
             sortType = uiState.value.sortType,
             treeDepthMap = uiState.value.treeDepthMap,
-            firstNewResNo = firstNewResNo,
             prevResCount = prevResCount
         )
 
@@ -382,7 +380,17 @@ class ThreadViewModel @AssistedInject constructor(
         }
         val visiblePosts = filteredPosts.filterNot { it.num in uiState.value.ngPostNumbers }
         val replyCounts = visiblePosts.map { p -> uiState.value.replySourceMap[p.num]?.size ?: 0 }
-        val firstAfterIndex = visiblePosts.indexOfFirst { it.isAfter }
+        val hasNewPosts = posts.size > prevResCount
+        val firstAfterIndex = if (hasNewPosts) {
+            val firstVisibleNew = visiblePosts.indexOfFirst { it.isAfter }
+            if (firstVisibleNew != -1) {
+                firstVisibleNew
+            } else {
+                visiblePosts.count { it.num <= prevResCount }
+            }
+        } else {
+            -1
+        }
 
         _uiState.update {
             it.copy(

--- a/app/src/test/java/com/websarva/wings/android/slevo/ui/thread/viewmodel/ThreadDisplayTransformersTest.kt
+++ b/app/src/test/java/com/websarva/wings/android/slevo/ui/thread/viewmodel/ThreadDisplayTransformersTest.kt
@@ -4,7 +4,6 @@ import com.websarva.wings.android.slevo.ui.thread.state.DisplayPost
 import com.websarva.wings.android.slevo.ui.thread.state.ReplyInfo
 import com.websarva.wings.android.slevo.ui.thread.state.ThreadSortType
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ThreadDisplayTransformersTest {
@@ -54,7 +53,7 @@ class ThreadDisplayTransformersTest {
     }
 
     @Test
-    fun buildOrderedPosts_handlesTreeAfterGrouping() {
+    fun buildOrderedPosts_appendsTreeSortedNewPosts() {
         val posts = listOf(
             reply(content = "root", id = "id1"),
             reply(content = ">>1 child", id = "id2"),
@@ -68,7 +67,6 @@ class ThreadDisplayTransformersTest {
             order = order,
             sortType = ThreadSortType.TREE,
             treeDepthMap = depthMap,
-            firstNewResNo = 4,
             prevResCount = 3
         )
 
@@ -76,11 +74,10 @@ class ThreadDisplayTransformersTest {
             DisplayPost(1, posts[0], dimmed = false, isAfter = false, depth = 0),
             DisplayPost(2, posts[1], dimmed = false, isAfter = false, depth = 1),
             DisplayPost(3, posts[2], dimmed = false, isAfter = false, depth = 2),
-            DisplayPost(1, posts[0], dimmed = true, isAfter = true, depth = 0),
             DisplayPost(4, posts[3], dimmed = false, isAfter = true, depth = 1)
         )
         assertEquals(expected, result)
-        assertTrue(result.drop(3).all { it.isAfter })
+        assertEquals(listOf(false, false, false, true), result.map { it.isAfter })
     }
 
     @Test
@@ -96,7 +93,6 @@ class ThreadDisplayTransformersTest {
             order = listOf(1, 2, 3),
             sortType = ThreadSortType.NUMBER,
             treeDepthMap = emptyMap(),
-            firstNewResNo = 3,
             prevResCount = 2
         )
 


### PR DESCRIPTION
## Summary
- anchor the new arrival boundary by prevResCount and append tree-sorted new posts after existing items
- simplify ordered post assembly and expose the boundary in the UI even when new items are filtered
- update the display transformer unit test expectations

## Testing
- ⚠️ `./gradlew --no-daemon --console=plain :app:testDebugUnitTest --tests "com.websarva.wings.android.slevo.ui.thread.viewmodel.ThreadDisplayTransformersTest"` *(stalled in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_6906d9bd05f483329e4ac97975730bd9