### PR TITLE
Add copilot-setup-steps.yml for Android build setup

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -7,10 +7,6 @@ jobs:
   copilot-setup-steps:
     runs-on: ubuntu-latest
 
-    env:
-      ANDROID_SDK_ROOT: $HOME/Android/sdk
-      ANDROID_HOME: $HOME/Android/sdk
-
     steps:
       - name: Check out
         uses: actions/checkout@v4
@@ -21,40 +17,14 @@ jobs:
           distribution: temurin
           java-version: '17'
 
-      - name: Install OS prerequisites
-        run: |
-          set -euxo pipefail
-          sudo apt-get update
-          sudo apt-get install -y wget unzip zip tar ca-certificates
-
-      - name: Install Android commandline-tools (fixed layout)
-        run: |
-          set -euxo pipefail
-          mkdir -p "$ANDROID_SDK_ROOT/cmdline-tools"
-          # 公式の推奨レイアウト: SDK直下に展開→フォルダをlatestへリネーム
-          wget -q https://dl.google.com/android/repository/commandlinetools-linux-13114758_latest.zip -O /tmp/tools.zip
-          unzip -q /tmp/tools.zip -d "$ANDROID_SDK_ROOT/cmdline-tools"
-          mv "$ANDROID_SDK_ROOT/cmdline-tools/cmdline-tools" "$ANDROID_SDK_ROOT/cmdline-tools/latest"
-          rm -f /tmp/tools.zip
-
-      - name: Add Android tools to PATH
-        run: |
-          echo "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin" >> "$GITHUB_PATH"
-          echo "$ANDROID_SDK_ROOT/platform-tools" >> "$GITHUB_PATH"
-
-      - name: Sanity check sdkmanager
-        run: |
-          set -euxo pipefail
-          "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" --sdk_root="$ANDROID_SDK_ROOT" --version
-          ls -la "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin"
-          ls -la "$ANDROID_SDK_ROOT/cmdline-tools/latest/lib"
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
 
       - name: Accept licenses & Install SDK packages
         run: |
           set -euxo pipefail
-          yes | "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" --sdk_root="$ANDROID_SDK_ROOT" --licenses
-          "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" --sdk_root="$ANDROID_SDK_ROOT" --install \
-            "platform-tools" "platforms;android-35" "build-tools;35.0.1"
+          sdkmanager --licenses
+          sdkmanager --install "platform-tools" "platforms;android-35" "build-tools;35.0.1"
 
       - name: Cache Gradle
         uses: actions/cache@v4
@@ -66,24 +36,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Gradle warmup
+      - name: Build (assemble + test)
         run: |
           set -euxo pipefail
           chmod +x ./gradlew
-          ./gradlew --no-daemon --version
-
-      - name: Build (assemble + test)
-        id: copilot-build
-        continue-on-error: true
-        run: |
-          set -euxo pipefail
           ./gradlew --no-daemon clean assembleDebug test
-
-      - name: Upload build logs on failure
-        if: steps.copilot-build.outcome == 'failure'
-        uses: actions/upload-artifact@v4
-        with:
-          name: gradle-logs
-          path: |
-            **/build/reports/**
-            **/*.log


### PR DESCRIPTION
This workflow sets up a temporary Linux development environment for building Android projects using Gradle.